### PR TITLE
Introduce RunCreateForm component and testRun schema

### DIFF
--- a/src/entities/test-run/index.ts
+++ b/src/entities/test-run/index.ts
@@ -1,0 +1,1 @@
+export * from './model';

--- a/src/entities/test-run/model/index.ts
+++ b/src/entities/test-run/model/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './types';

--- a/src/entities/test-run/model/schema.ts
+++ b/src/entities/test-run/model/schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const TestRunSchema = z.object({
+  id: z.uuidv7({ error: 'uuidv7 test error' }),
+  project_id: z.uuidv7(),
+  milestone_id: z.uuidv7().nullable(),
+  run_name: z.string().optional(),
+  started_at: z.coerce.date().optional(),
+  ended_at: z.coerce.date().nullable().optional(),
+  create_at: z.date(),
+  update_at: z.date(),
+  delete_at: z.date().nullable(),
+});
+
+export const CreateTestRunSchema = TestRunSchema.omit({
+  id: true,
+  create_at: true,
+  update_at: true,
+  delete_at: true,
+});

--- a/src/entities/test-run/model/types.ts
+++ b/src/entities/test-run/model/types.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+import { CreateTestRunSchema, TestRunSchema } from './schema';
+
+export type TestRunDTO = z.infer<typeof TestRunSchema>;
+export type CreateTestRunDTO = z.infer<typeof CreateTestRunSchema>;

--- a/src/features/runs-create/index.ts
+++ b/src/features/runs-create/index.ts
@@ -1,0 +1,2 @@
+export * from './model';
+export * from './ui';

--- a/src/features/runs-create/model/index.ts
+++ b/src/features/runs-create/model/index.ts
@@ -1,0 +1,1 @@
+export { createTestRunMock, createTestRunAction } from './server-action';

--- a/src/features/runs-create/model/server-action.ts
+++ b/src/features/runs-create/model/server-action.ts
@@ -1,0 +1,62 @@
+'use server';
+import { CreateTestRunSchema } from '@/entities/test-run';
+import { getDatabase, testRun } from '@/shared/lib/db';
+import { z } from 'zod';
+
+type MockTestRunData = {
+  project_id: string;
+  milestone_id?: string;
+  run_name?: string;
+  started_at?: string;
+  ended_at?: string;
+};
+
+type MockFlatErrors = {
+  formErrors: string[];
+  fieldErrors: { [key in keyof MockTestRunData]?: string[] };
+};
+
+const createTestRun = async (data: any) => {
+  const db = getDatabase();
+  return await db.insert(testRun).values(data).returning();
+};
+
+export const createTestRunAction = async (formData: any) => {
+  const data = Object.fromEntries(formData.entries());
+  const validation = CreateTestRunSchema.safeParse(data);
+  if (!validation.success) return { success: false, errors: z.flattenError(validation.error) };
+
+  const newTestRun = await createTestRun(validation.data);
+  return { success: true, testRun: newTestRun };
+};
+
+export const createTestRunMock = async (formData: FormData) => {
+  const data = Object.fromEntries(formData.entries());
+  const project_id = typeof data.project_id === 'string' ? data.project_id : '';
+  const run_name = typeof data.run_name === 'string' ? data.run_name : '';
+
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  if (!project_id) {
+    const mockErrors: MockFlatErrors = {
+      formErrors: ['필수 입력 항목이 누락되었습니다.'],
+      fieldErrors: {
+        project_id: ['프로젝트 ID가 필요합니다.'],
+      },
+    };
+    return { success: false, errors: mockErrors };
+  }
+
+  if (run_name.toUpperCase() === 'SERVER_ERROR') {
+    const mockServerError: MockFlatErrors = {
+      formErrors: ['DB 연결 실패: 서버 내부에서 치명적인 오류가 발생했습니다.'],
+      fieldErrors: {},
+    };
+    return { success: false, errors: mockServerError };
+  }
+
+  return {
+    success: true,
+    errors: { id: `uuid-${Date.now()}`, ...data },
+  };
+};

--- a/src/features/runs-create/ui/index.ts
+++ b/src/features/runs-create/ui/index.ts
@@ -1,0 +1,1 @@
+export { RunCreateForm } from './run-create-form';

--- a/src/features/runs-create/ui/run-create-form.tsx
+++ b/src/features/runs-create/ui/run-create-form.tsx
@@ -1,0 +1,50 @@
+'use client';
+import React from 'react';
+
+import { DSButton, FormField } from '@/shared';
+import { useForm } from 'react-hook-form';
+import {createTestRunMock} from "@/features/runs-create";
+
+interface IFormInput {
+  name: string;
+}
+
+export const RunCreateForm = () => {
+  const { register, handleSubmit } = useForm<IFormInput>();
+  const onSubmit = async (data: IFormInput) => {
+    const formData = new FormData();
+    formData.append('name', data.name);
+
+    const result = await createTestRunMock(formData);
+    if (!result.success) {
+      console.error('서버 에러 발생:', JSON.stringify(result.errors, null, 2));
+      return;
+    }
+    alert('생성 클릭\n' + JSON.stringify(data, null, 2));
+  };
+  return (
+    <section
+      id="create-suite"
+      className="bg-bg-2 absolute top-1/2 left-[calc(50%+0.5px)] z-50 box-border flex w-[46.25rem] translate-x-[-50%] translate-y-[-50%] flex-col content-stretch items-center gap-[48px] overflow-clip rounded-[36px] px-32 py-16"
+    >
+      <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4" noValidate>
+        <div>
+          <h2 className="text-primary text-3xl">테스트 스위트를 만들어 볼까요?</h2>
+          <p className="mt-2 text-base text-neutral-400">필요한 테스트들을 한 곳에 모아 관리해요</p>
+        </div>
+        <FormField.Root className='flex flex-col gap-2'>
+          <FormField.Label>name</FormField.Label>
+          <FormField.Control placeholder="테스트 스위트 이름 입력" type='text' {...register('name', {required: true})}/>
+        </FormField.Root>
+        <div className='flex gap-2'>
+          <DSButton type="button" variant="ghost" className="mt-2 w-full" onClick={()=> alert('취소 클릭')}>
+            취소
+          </DSButton>
+          <DSButton type="submit" variant="solid" className="mt-2 w-full">
+            생성
+          </DSButton>
+        </div>
+      </form>
+    </section>
+  );
+};

--- a/src/shared/lib/db/schema/index.ts
+++ b/src/shared/lib/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './project';
 export * from './test-suite';
 export * from './test-case';
+export * from './test-run';
 export * from './milestone';

--- a/src/shared/lib/db/schema/milestone.ts
+++ b/src/shared/lib/db/schema/milestone.ts
@@ -1,5 +1,6 @@
 import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { project } from './project';
+import { relations } from 'drizzle-orm';
 
 export const milestone = pgTable('milestone', {
   id: uuid('id').primaryKey(),
@@ -13,3 +14,10 @@ export const milestone = pgTable('milestone', {
   update_at: timestamp().defaultNow().notNull(),
   delete_at: timestamp(),
 });
+
+export const milestoneRelations = relations(milestone, ({ one }) => ({
+  project: one(project, {
+    fields: [milestone.project_id],
+    references: [project.id],
+  }),
+}));

--- a/src/shared/lib/db/schema/test-run.ts
+++ b/src/shared/lib/db/schema/test-run.ts
@@ -1,0 +1,27 @@
+import { relations } from 'drizzle-orm';
+import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import { milestone } from './milestone';
+import { project } from './project';
+
+export const testRun = pgTable('test_run', {
+  id: uuid('id').primaryKey(),
+  project_id: uuid('project_id').references(() => project.id),
+  milestone_id: uuid('milestone_id').references(() => milestone.id),
+  run_name: varchar('run_name').notNull(),
+  started_at: timestamp('started_at'),
+  ended_at: timestamp('ended_at'),
+  create_at: timestamp().defaultNow().notNull(),
+  update_at: timestamp().defaultNow().notNull(),
+  delete_at: timestamp(),
+});
+
+export const testRunRelations = relations(testRun, ({ one }) => ({
+  project: one(project, {
+    fields: [testRun.project_id],
+    references: [project.id],
+  }),
+  milestone: one(milestone, {
+    fields: [testRun.milestone_id],
+    references: [milestone.id],
+  }),
+}));


### PR DESCRIPTION
---

- Implemented the `RunCreateForm` component for managing test run creation with form validation and submission capabilities using `react-hook-form`.
- Added a new `testRun` table schema in the shared layer, including relationships with `project` and `milestone` entities.
- Developed server-action logic (`createTestRunMock` and `createTestRunAction`) to handle form submissions and mock API responses.
- Updated and organized module exports to align with the project's architecture design.