### PR TITLE
Integrate `useDisclosure` hook for modal interaction management

### DIFF
--- a/src/features/milestones-create/ui/milestone-create-form.tsx
+++ b/src/features/milestones-create/ui/milestone-create-form.tsx
@@ -13,7 +13,11 @@ interface IFormInput {
   endDate: string;
 }
 
-export const MilestoneCreateForm = () => {
+interface MilestoneCreateFormProps {
+  onClose?: () => void;
+}
+
+export const MilestoneCreateForm = ({onClose}: MilestoneCreateFormProps) => {
   const { register, handleSubmit } = useForm<IFormInput>();
   const onSubmit = async (data: IFormInput) => {
     const formData = new FormData();
@@ -84,7 +88,7 @@ export const MilestoneCreateForm = () => {
               type="button"
               variant="ghost"
               className="mt-2 w-full"
-              onClick={() => alert('취소 클릭')}
+              onClick={onClose}
             >
               취소
             </DSButton>

--- a/src/features/suites-create/ui/suite-create-form.tsx
+++ b/src/features/suites-create/ui/suite-create-form.tsx
@@ -10,7 +10,11 @@ interface IFormInput {
   description?: string;
 }
 
-export const SuiteCreateForm = ({ onClose }: { onClose?: () => void }) => {
+interface SuiteCreateFormProps {
+  onClose?: () => void;
+}
+
+export const SuiteCreateForm = ({ onClose }: SuiteCreateFormProps) => {
   const {
     register,
     handleSubmit,
@@ -96,10 +100,7 @@ export const SuiteCreateForm = ({ onClose }: { onClose?: () => void }) => {
               variant="ghost"
               className="w-full"
               disabled={isSubmitting}
-              onClick={() => {
-                if (onClose) onClose();
-                else alert('취소 클릭');
-              }}
+              onClick={onClose}
             >
               취소
             </DSButton>

--- a/src/shared/hooks/use-disclosure/use-disclosure.ts
+++ b/src/shared/hooks/use-disclosure/use-disclosure.ts
@@ -2,10 +2,7 @@ import React from 'react';
 
 export const useDisclosure = (initialValue = false) => {
   const [isOpen, setIsOpen] = React.useState(initialValue);
-
   const onOpen = React.useCallback(() => setIsOpen(true), []);
   const onClose = React.useCallback(() => setIsOpen(false), []);
-  const onToggle = React.useCallback(() => setIsOpen((prev) => !prev), []);
-
-  return { isOpen, onOpen, onClose, onToggle };
+  return { isOpen, onOpen, onClose };
 };

--- a/src/view/project/cases/test-case-side-view.tsx
+++ b/src/view/project/cases/test-case-side-view.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-
 import { DSButton } from '@/shared';
 import { Calendar, Clock, Copy, Edit2, Flag, Folder, Play, Tag, Trash2, X } from 'lucide-react';
 
-export const TestCaseSideView = () => {
+interface TestCaseSideViewProps {
+  onClose: () => void;
+}
+
+export const TestCaseSideView = ({ onClose }: TestCaseSideViewProps) => {
   return (
     <section className="bg-bg-1 border-bg-4 fixed top-0 right-0 h-full w-[600px] translate-x-0 overflow-y-auto border-l p-4 transition-transform duration-300 ease-in-out">
       <div className="flex flex-col gap-6">
         <header className="flex flex-col gap-2">
           <div className="flex justify-between">
-            <DSButton size="small" variant="ghost" className="px-2">
+            <DSButton size="small" variant="ghost" className="px-2" onClick={onClose}>
               <X className="h-4 w-4" />
             </DSButton>
             <DSButton size="small" variant="ghost" className="flex items-center gap-1 px-2">

--- a/src/view/project/cases/test-cases-view.tsx
+++ b/src/view/project/cases/test-cases-view.tsx
@@ -1,16 +1,17 @@
+'use client';
 import React from 'react';
-
 import { Container, DSButton, MainContainer } from '@/shared';
 import { Aside } from '@/widgets';
 import { ChevronDown, Filter, MoreHorizontal, Plus, Search } from 'lucide-react';
 import { TestCaseSideView } from '@/view/project/cases/test-case-side-view';
+import { useDisclosure } from '@/shared/hooks';
 
 export const TestCasesView = () => {
+  const { isOpen, onClose, onOpen } = useDisclosure();
   return (
     <Container className="bg-bg-1 text-text-1 flex min-h-screen items-center justify-center font-sans">
       {/* Aside */}
       <Aside />
-
       {/* Main Content */}
       <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         {/* Header */}
@@ -20,7 +21,6 @@ export const TestCasesView = () => {
             프로젝트의 모든 테스트 케이스를 조회하고 관리합니다.
           </p>
         </header>
-
         {/* Toolbar (Search, Filter, Actions) */}
         <section className="col-span-6 flex items-center justify-between gap-4">
           {/* Left: Search & Filters */}
@@ -36,21 +36,18 @@ export const TestCasesView = () => {
                 className="typo-body2-normal rounded-2 border-line-2 bg-bg-2 text-text-1 placeholder:text-text-4 focus:border-primary focus:ring-primary w-full border py-2 pr-4 pl-10 focus:ring-1 focus:outline-none"
               />
             </div>
-
             {/* Filter Dropdown Trigger */}
             <DSButton className="typo-body2-heading rounded-2 border-line-2 bg-bg-2 text-text-2 hover:bg-bg-3 flex items-center gap-2 border px-3 py-2 transition-colors">
               <Filter className="h-4 w-4" />
               <span>상태: All</span>
               <ChevronDown className="text-text-3 h-4 w-4" />
             </DSButton>
-
             {/* Sort Dropdown Trigger */}
             <DSButton className="typo-body2-heading rounded-2 border-line-2 bg-bg-2 text-text-2 hover:bg-bg-3 flex items-center gap-2 border px-3 py-2 transition-colors">
               <span>정렬: 최근 수정 순</span>
               <ChevronDown className="text-text-3 h-4 w-4" />
             </DSButton>
           </div>
-
           {/* Right: Advanced Create Button */}
           <button className="typo-body2-heading flex items-center gap-2 rounded-2 bg-primary px-4 py-2 text-text-1 shadow-2 hover:opacity-90 transition-opacity">
             <Plus className="h-4 w-4" />
@@ -74,7 +71,7 @@ export const TestCasesView = () => {
             <div className="typo-caption-heading text-text-3 col-span-3 text-right uppercase">
               최종 수정
             </div>
-            <div className="col-span-1"></div>
+            <div className="col-span-1"/>
           </div>
 
           {/* Inline Create Row */}
@@ -92,7 +89,7 @@ export const TestCasesView = () => {
           </div>
 
           {/* Untested */}
-          <div className="group border-line-2 hover:bg-bg-3 grid cursor-pointer grid-cols-12 items-center gap-4 border-b px-6 py-4 transition-colors">
+          <div className="group border-line-2 hover:bg-bg-3 grid cursor-pointer grid-cols-12 items-center gap-4 border-b px-6 py-4 transition-colors" onClick={onOpen}>
             <div className='col-span-2'>
               <span className="typo-body2-heading text-text-1 group-hover:text-primary transition-colors">
                 TC-1001
@@ -223,7 +220,7 @@ export const TestCasesView = () => {
           </div>
         </section>
       </MainContainer>
-      <TestCaseSideView/>
+      {isOpen && <TestCaseSideView onClose={onClose} />}
     </Container>
   );
 };

--- a/src/view/project/milestones/milestones-view.tsx
+++ b/src/view/project/milestones/milestones-view.tsx
@@ -1,16 +1,17 @@
+'use client';
 import React from 'react';
-
 import { Container, DSButton, MainContainer } from '@/shared';
 import { Aside } from '@/widgets';
 import { Calendar, CheckCircle, ListChecks, PlayCircle } from 'lucide-react';
 import { MilestoneCreateForm } from '@/features';
+import { useDisclosure } from '@/shared/hooks';
 
 export const MilestonesView = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
       {/* Aside */}
       <Aside />
-
       {/* Main Content */}
       <MainContainer className="grid min-h-screen w-full flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 py-8 max-w-[1200px] mx-auto px-10">
         {/* 헤더 영역 */}
@@ -21,9 +22,8 @@ export const MilestonesView = () => {
               스프레드시트 복사 대신, 마일스톤별 테스트 케이스와 실행 결과를 한 화면에서 확인하세요.
             </p>
           </div>
-          <DSButton type='button' variant='solid'>마일스톤 생성하기</DSButton>
+          <DSButton type='button' variant='solid' onClick={onOpen}>마일스톤 생성하기</DSButton>
         </header>
-
         {/* 필터 / 요약 바 */}
         <section
           aria-label="마일스톤 필터"
@@ -53,14 +53,12 @@ export const MilestonesView = () => {
             <span>오늘 실행 12건</span>
           </div>
         </section>
-
         {/* 컬럼 헤더 (엑셀 헤더 느낌으로) */}
         <div className="col-span-6 mt-2 hidden items-center justify-between text-label-normal text-text-3 md:flex">
           <span className="w-[40%]">마일스톤</span>
           <span className="w-[30%]">진행률</span>
           <span className="w-[30%] text-right">테스트 현황</span>
         </div>
-
         {/* 마일스톤 리스트 */}
         <section aria-label="마일스톤 목록" className="col-span-6 flex flex-col gap-3">
           {/* 카드 1 */}
@@ -198,7 +196,7 @@ export const MilestonesView = () => {
             </div>
           </article>
         </section>
-        <MilestoneCreateForm/>
+        {isOpen && <MilestoneCreateForm onClose={onClose}/>}
       </MainContainer>
     </Container>
   );

--- a/src/view/project/suites/test-suites-view.tsx
+++ b/src/view/project/suites/test-suites-view.tsx
@@ -1,16 +1,17 @@
+'use client'
 import React from 'react';
-
 import { SuiteCreateForm } from '@/features/suites-create';
 import { Container, DSButton, MainContainer } from '@/shared';
 import { Aside } from '@/widgets';
 import { AlertCircle, FileText, FolderTree, Layers, PlayCircle, Search } from 'lucide-react';
+import { useDisclosure } from '@/shared/hooks';
 
 export const TestSuitesView = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
       {/* Aside */}
       <Aside />
-
       {/* Main Content */}
       <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         {/* 헤더 영역 */}
@@ -22,7 +23,7 @@ export const TestSuitesView = () => {
               스위트를 반복 실행하세요.
             </p>
           </div>
-          <DSButton type="button" variant="solid">
+          <DSButton type="button" variant="solid" onClick={onOpen}>
             테스트 스위트 생성하기
           </DSButton>
         </header>
@@ -217,7 +218,7 @@ export const TestSuitesView = () => {
             </div>
           </article>
         </section>
-        <SuiteCreateForm />
+        {isOpen && <SuiteCreateForm onClose={onClose} />}
       </MainContainer>
     </Container>
   );


### PR DESCRIPTION
### Description

This pull request introduces the `useDisclosure` hook to manage modal visibility across multiple views, improving interaction control and code maintainability. Specific updates include:

- Introducing `useDisclosure` to handle modal visibility in `TestSuitesView`, `TestCasesView`, and `MilestonesView`.
- Enhancing `TestCaseSideView`, `SuiteCreateForm`, and `MilestoneCreateForm` to use controlled visibility managed by `onClose`.
- Refactoring to remove the unused `onToggle` function for simplicity within `useDisclosure`.
- Adding prop interfaces to promote type safety and reusability of modal components. 

These changes aim to streamline modal control logic while boosting code clarity and reuse.