### PR TITLE
Feat: 테스트 실행 API 및 엔티티 서버 액션 구현

### DIFF
--- a/src/entities/test-run/model/schema.ts
+++ b/src/entities/test-run/model/schema.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod';
 
+export const TestRunStatusEnum = z.enum(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
+export const TestRunSourceTypeEnum = z.enum(['SUITE', 'MILESTONE', 'ADHOC']);
+
 export const TestRunSchema = z.object({
   id: z.uuidv7({ error: 'uuidv7 test error' }),
   project_id: z.uuidv7(),
   milestone_id: z.uuidv7().nullable(),
   run_name: z.string().optional(),
+  status: TestRunStatusEnum.default('NOT_STARTED'),
+  source_type: TestRunSourceTypeEnum,
   started_at: z.coerce.date().optional(),
   ended_at: z.coerce.date().nullable().optional(),
   create_at: z.date(),

--- a/src/entities/test-run/model/types.ts
+++ b/src/entities/test-run/model/types.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
-import { CreateTestRunSchema, TestRunSchema } from './schema';
+import { CreateTestRunSchema, TestRunSchema, TestRunStatusEnum, TestRunSourceTypeEnum } from './schema';
 
 export type TestRunDTO = z.infer<typeof TestRunSchema>;
 export type CreateTestRunDTO = z.infer<typeof CreateTestRunSchema>;
+export type TestRunStatus = z.infer<typeof TestRunStatusEnum>;
+export type TestRunSourceType = z.infer<typeof TestRunSourceTypeEnum>;

--- a/src/shared/lib/db/schema/test-run.ts
+++ b/src/shared/lib/db/schema/test-run.ts
@@ -3,11 +3,19 @@ import { pgTable, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
 import { milestones } from './milestones';
 import { projects } from './projects';
 
+export const testRunStatus = ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] as const;
+export type TestRunStatus = (typeof testRunStatus)[number];
+
+export const testRunSourceType = ['SUITE', 'MILESTONE', 'ADHOC'] as const;
+export type TestRunSourceType = (typeof testRunSourceType)[number];
+
 export const testRun = pgTable('test_run', {
   id: uuid('id').primaryKey(),
   project_id: uuid('project_id').references(() => projects.id),
   milestone_id: uuid('milestone_id').references(() => milestones.id),
   run_name: varchar('run_name').notNull(),
+  status: varchar('status').$type<TestRunStatus>().default('NOT_STARTED').notNull(),
+  source_type: varchar('source_type').$type<TestRunSourceType>().notNull(),
   started_at: timestamp('started_at'),
   ended_at: timestamp('ended_at'),
   create_at: timestamp().defaultNow().notNull(),


### PR DESCRIPTION
## Summary
- 테스트 실행(Test Run) 스키마에 상태(`status`) 및 소스 타입(`source_type`) 필드 추가
- Milestone 엔티티 CRUD 서버 액션 및 유닛 테스트 구현
- Test Suite 엔티티 CRUD 서버 액션 및 유닛 테스트 구현  
- Test Case 생성 서버 액션 추가
- 엔티티 모델 매퍼 및 스키마 타입 정의 개선

## Changes
### Test Run 엔티티
- `status` 필드 추가 (NOT_STARTED, IN_PROGRESS, COMPLETED)
- `source_type` 필드 추가 (SUITE, MILESTONE, ADHOC)
- 관련 Enum 타입 정의 (`TestRunStatus`, `TestRunSourceType`)

### Milestone 엔티티
- CRUD 서버 액션 구현 (`getMilestones`, `getMilestoneById`, `createMilestone`, `updateMilestone`, `deleteMilestone`)
- 스키마 및 매퍼 수정 (날짜 필드 nullable 처리, DTO/도메인 모델 분리)
- 유닛 테스트 작성 (생성/수정/삭제)

### Test Suite 엔티티
- CRUD 서버 액션 구현
- 유닛 테스트 작성 (생성/조회/수정/삭제)

### Test Case 엔티티
- `createTestCase` 서버 액션 추가

### 기타
- 엔티티 index 파일 업데이트 (test-suite, project export 추가)
- Milestone UI 컴포넌트 날짜 포맷 함수 nullable 처리

## Test plan
- [x] Milestone CRUD 유닛 테스트 통과
- [x] Test Suite CRUD 유닛 테스트 통과
- [ ] 각 API 엔드포인트 통합 테스트
- [ ] UI에서 Milestone/Test Suite 생성/수정/삭제 동작 확인