### PR TITLE
Feat: 마일스톤 및 테스트 스위트 상세 조회를 위한 사이드 뷰(Side View) 컴포넌트 추가

### DIFF
--- a/src/view/project/index.ts
+++ b/src/view/project/index.ts
@@ -3,4 +3,4 @@ export { ProjectDashboardView } from '@/view/project/dashboard';
 export { TestCasesView } from '@/view/project/cases';
 export { TestSuitesView } from '@/view/project/suites';
 export { TestRunsListView } from '@/view/project/runs';
-export { MilestonesView } from '@/view/project/milestones';
+export { MilestonesView, MilestoneDetailView } from '@/view/project/milestones';

--- a/src/view/project/milestones/index.ts
+++ b/src/view/project/milestones/index.ts
@@ -1,2 +1,3 @@
 export { MilestonesView } from '@/view/project/milestones/milestones-view';
 export { MilestoneSideView } from '@/view/project/milestones/milestone-side-view';
+export { MilestoneDetailView } from '@/view/project/milestones/milestone-detail-view';

--- a/src/view/project/milestones/milestone-detail-view.tsx
+++ b/src/view/project/milestones/milestone-detail-view.tsx
@@ -1,0 +1,246 @@
+'use client';
+import React from 'react';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import { MilestoneWithStats } from '@/entities/milestone';
+import { Container, DSButton, MainContainer, cn } from '@/shared';
+import { Aside } from '@/widgets';
+import {
+  ArrowLeft,
+  Calendar,
+  CheckCircle,
+  Edit2,
+  ListChecks,
+  Play,
+  PlayCircle,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+
+const STATUS_CONFIG: Record<string, { label: string; style: string }> = {
+  inProgress: {
+    label: '진행 중',
+    style: 'bg-amber-500/20 text-amber-300',
+  },
+  done: {
+    label: '완료',
+    style: 'bg-green-500/20 text-green-300',
+  },
+  planned: {
+    label: '예정',
+    style: 'bg-slate-500/20 text-slate-300',
+  },
+};
+
+const formatDate = (date: Date | null) => {
+  if (!date) return '-';
+  return date.toISOString().split('T')[0];
+};
+
+// Mock data - 실제로는 API에서 가져옴
+const MOCK_MILESTONE: MilestoneWithStats = {
+  id: '1',
+  projectId: 'project-1',
+  title: 'Sprint 1 - 사용자 인증',
+  description:
+    '사용자 인증 관련 기능을 검증합니다. 로그인, 회원가입, 비밀번호 찾기 등의 기능이 포함됩니다.',
+  startDate: new Date('2025-01-01'),
+  endDate: new Date('2025-01-15'),
+  status: 'inProgress',
+  createdAt: new Date('2024-12-20'),
+  updatedAt: new Date('2025-01-05'),
+  deletedAt: null,
+  totalCases: 24,
+  completedCases: 18,
+  progressRate: 75,
+  runCount: 5,
+};
+
+// Mock test cases
+const MOCK_TEST_CASES = [
+  { id: 'tc-1', code: 'TC-1001', title: '이메일 로그인 성공', status: 'passed' },
+  { id: 'tc-2', code: 'TC-1002', title: '이메일 형식 검증 실패', status: 'passed' },
+  { id: 'tc-3', code: 'TC-1003', title: '비밀번호 불일치 에러', status: 'passed' },
+  { id: 'tc-4', code: 'TC-1004', title: '소셜 로그인 - Google', status: 'failed' },
+  { id: 'tc-5', code: 'TC-1005', title: '소셜 로그인 - Kakao', status: 'passed' },
+  { id: 'tc-6', code: 'TC-1006', title: '회원가입 성공', status: 'not_run' },
+  { id: 'tc-7', code: 'TC-1007', title: '비밀번호 찾기 이메일 발송', status: 'not_run' },
+];
+
+const TEST_STATUS_CONFIG: Record<string, { label: string; style: string }> = {
+  passed: { label: 'Passed', style: 'bg-green-500/20 text-green-300' },
+  failed: { label: 'Failed', style: 'bg-red-500/20 text-red-300' },
+  blocked: { label: 'Blocked', style: 'bg-amber-500/20 text-amber-300' },
+  not_run: { label: 'Not Run', style: 'bg-slate-500/20 text-slate-300' },
+};
+
+export const MilestoneDetailView = () => {
+  const params = useParams();
+  const milestone = MOCK_MILESTONE; // 실제로는 milestoneId로 API 조회
+  const statusInfo = STATUS_CONFIG[milestone.status] || {
+    label: milestone.status,
+    style: 'bg-gray-500/20 text-gray-300',
+  };
+
+  return (
+    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
+      <Aside />
+      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-6 px-10 py-8">
+        {/* 뒤로가기 + 헤더 */}
+        <header className="col-span-6 flex flex-col gap-4">
+          <Link
+            href={`/projects/${params.slug}/milestones`}
+            className="text-text-3 hover:text-text-1 flex w-fit items-center gap-1 text-sm transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            마일스톤 목록으로
+          </Link>
+
+          <div className="flex items-start justify-between">
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-3">
+                <h1 className="typo-title-heading">{milestone.title}</h1>
+                <span className={cn('rounded-full px-3 py-1 text-sm font-medium', statusInfo.style)}>
+                  {statusInfo.label}
+                </span>
+              </div>
+              <div className="text-text-3 flex items-center gap-1.5 text-sm">
+                <Calendar className="h-4 w-4" strokeWidth={1.5} />
+                <span>
+                  {formatDate(milestone.startDate)} ~ {formatDate(milestone.endDate)}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <DSButton variant="ghost" className="flex items-center gap-2">
+                <Edit2 className="h-4 w-4" />
+                수정
+              </DSButton>
+              <DSButton variant="ghost" className="flex items-center gap-2 text-red-400">
+                <Trash2 className="h-4 w-4" />
+                삭제
+              </DSButton>
+            </div>
+          </div>
+        </header>
+
+        {/* 설명 */}
+        <section className="col-span-6">
+          <div className="bg-bg-2 border-line-2 rounded-4 border p-4">
+            <p className="text-text-2">{milestone.description || '설명이 없습니다.'}</p>
+          </div>
+        </section>
+
+        {/* 진행률 + 통계 */}
+        <section className="col-span-6 grid grid-cols-4 gap-4">
+          {/* 진행률 */}
+          <div className="bg-bg-2 border-line-2 rounded-4 col-span-2 border p-4">
+            <div className="mb-3 flex items-center justify-between">
+              <h3 className="text-text-3 font-semibold">진행률</h3>
+              <span className="text-primary text-2xl font-bold">{milestone.progressRate}%</span>
+            </div>
+            <div className="bg-bg-3 h-3 w-full rounded-full">
+              <div
+                className="bg-primary h-full rounded-full transition-all duration-300"
+                style={{ width: `${milestone.progressRate}%` }}
+              />
+            </div>
+            <p className="text-text-3 mt-2 text-sm">
+              {milestone.completedCases} / {milestone.totalCases} 케이스 완료
+            </p>
+          </div>
+
+          {/* 통계 카드들 */}
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <ListChecks className="h-4 w-4" strokeWidth={1.5} />
+              <span>테스트 케이스</span>
+            </div>
+            <span className="text-text-1 text-2xl font-bold">{milestone.totalCases}개</span>
+          </div>
+
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <PlayCircle className="h-4 w-4" strokeWidth={1.5} />
+              <span>테스트 실행</span>
+            </div>
+            <span className="text-text-1 text-2xl font-bold">{milestone.runCount}회</span>
+          </div>
+        </section>
+
+        {/* 테스트 실행 생성 버튼 */}
+        <section className="col-span-6">
+          <DSButton className="flex items-center gap-2">
+            <Play className="h-4 w-4" />
+            마일스톤 기반 테스트 실행 생성
+          </DSButton>
+        </section>
+
+        {/* 테스트 케이스 목록 */}
+        <section className="col-span-6 flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <h2 className="typo-h2-heading">포함된 테스트 케이스</h2>
+            <DSButton variant="ghost" size="small" className="flex items-center gap-1">
+              <Plus className="h-4 w-4" />
+              케이스 추가
+            </DSButton>
+          </div>
+
+          {MOCK_TEST_CASES.length === 0 ? (
+            <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col items-center justify-center gap-4 border-2 border-dashed py-12">
+              <ListChecks className="text-text-3 h-8 w-8" />
+              <div className="text-center">
+                <p className="text-text-1 font-semibold">포함된 테스트 케이스가 없습니다.</p>
+                <p className="text-text-3 text-sm">테스트 케이스를 추가하여 마일스톤 범위를 정의하세요.</p>
+              </div>
+              <DSButton variant="ghost" className="flex items-center gap-1">
+                <Plus className="h-4 w-4" />
+                테스트 케이스 추가
+              </DSButton>
+            </div>
+          ) : (
+            <div className="bg-bg-2 border-line-2 rounded-4 divide-line-2 divide-y border">
+              {MOCK_TEST_CASES.map((testCase) => {
+                const statusConfig = TEST_STATUS_CONFIG[testCase.status] || TEST_STATUS_CONFIG.not_run;
+                return (
+                  <div
+                    key={testCase.id}
+                    className="hover:bg-bg-3 flex items-center justify-between px-4 py-3 transition-colors"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="text-primary font-mono text-sm">{testCase.code}</span>
+                      <span className="text-text-1">{testCase.title}</span>
+                    </div>
+                    <span
+                      className={cn(
+                        'rounded-full px-2 py-0.5 text-xs font-medium',
+                        statusConfig.style
+                      )}
+                    >
+                      {statusConfig.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        {/* 테스트 실행 이력 */}
+        <section className="col-span-6 flex flex-col gap-4">
+          <h2 className="typo-h2-heading">테스트 실행 이력</h2>
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col items-center justify-center gap-4 border-2 border-dashed py-12">
+            <PlayCircle className="text-text-3 h-8 w-8" />
+            <div className="text-center">
+              <p className="text-text-1 font-semibold">테스트 실행 이력이 없습니다.</p>
+              <p className="text-text-3 text-sm">마일스톤 기반 테스트 실행을 생성하세요.</p>
+            </div>
+          </div>
+        </section>
+      </MainContainer>
+    </Container>
+  );
+};

--- a/src/view/project/milestones/milestone-side-view.tsx
+++ b/src/view/project/milestones/milestone-side-view.tsx
@@ -1,0 +1,146 @@
+'use client'
+import React from 'react';
+
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import { MilestoneWithStats } from '@/entities/milestone';
+import { DSButton } from '@/shared';
+import { Calendar, CheckCircle, Edit2, ExternalLink, ListChecks, PlayCircle, Trash2, X } from 'lucide-react';
+import { cn } from '@/shared';
+
+interface MilestoneSideViewProps {
+  milestone: MilestoneWithStats;
+  onClose: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const STATUS_CONFIG: Record<string, { label: string; style: string }> = {
+  inProgress: {
+    label: '진행 중',
+    style: 'bg-amber-500/20 text-amber-300',
+  },
+  done: {
+    label: '완료',
+    style: 'bg-green-500/20 text-green-300',
+  },
+  planned: {
+    label: '예정',
+    style: 'bg-slate-500/20 text-slate-300',
+  },
+};
+
+const formatDate = (date: Date | null) => {
+  if (!date) return '-';
+  return date.toISOString().split('T')[0];
+};
+
+export const MilestoneSideView = ({
+  milestone,
+  onClose,
+  onEdit,
+  onDelete,
+}: MilestoneSideViewProps) => {
+  const params = useParams();
+  const statusInfo = STATUS_CONFIG[milestone.status] || {
+    label: milestone.status,
+    style: 'bg-gray-500/20 text-gray-300',
+  };
+
+  return (
+    <section className="bg-bg-1 border-bg-4 fixed top-0 right-0 h-full w-[600px] translate-x-0 overflow-y-auto border-l p-4 transition-transform duration-300 ease-in-out">
+      <div className="flex flex-col gap-6">
+        {/* 헤더 */}
+        <header className="flex flex-col gap-3">
+          <div className="flex justify-between">
+            <DSButton size="small" variant="ghost" className="px-2" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </DSButton>
+            <DSButton size="small" variant="ghost" className="flex items-center gap-1 px-2" onClick={onEdit}>
+              <Edit2 className="h-4 w-4" />
+              <span>수정</span>
+            </DSButton>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-semibold">{milestone.title}</h2>
+            <span className={cn('rounded-full px-3 py-1 text-sm font-medium', statusInfo.style)}>
+              {statusInfo.label}
+            </span>
+          </div>
+
+          <div className="text-text-3 flex items-center gap-1.5 text-sm">
+            <Calendar className="h-4 w-4" strokeWidth={1.5} />
+            <span>
+              {formatDate(milestone.startDate)} ~ {formatDate(milestone.endDate)}
+            </span>
+          </div>
+        </header>
+
+        {/* 설명 */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-text-3 text-lg font-semibold">설명</h3>
+          <div className="bg-bg-2 border-line-2 rounded-4 border p-4">
+            <p className="text-text-2">{milestone.description || '설명이 없습니다.'}</p>
+          </div>
+        </div>
+
+        {/* 진행률 */}
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-text-3 text-lg font-semibold">진행률</h3>
+            <span className="text-primary text-xl font-bold">{milestone.progressRate}%</span>
+          </div>
+          <div className="bg-bg-3 h-2 w-full rounded-full">
+            <div
+              className="bg-primary h-full rounded-full transition-all duration-300"
+              style={{ width: `${milestone.progressRate}%` }}
+            />
+          </div>
+        </div>
+
+        {/* 통계 */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <ListChecks className="h-4 w-4" strokeWidth={1.5} />
+              <span>테스트 케이스</span>
+            </div>
+            <span className="text-text-1 text-xl font-bold">{milestone.totalCases}개</span>
+          </div>
+
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <CheckCircle className="h-4 w-4" strokeWidth={1.5} />
+              <span>완료</span>
+            </div>
+            <span className="text-green-400 text-xl font-bold">{milestone.completedCases}개</span>
+          </div>
+
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <PlayCircle className="h-4 w-4" strokeWidth={1.5} />
+              <span>실행 횟수</span>
+            </div>
+            <span className="text-text-1 text-xl font-bold">{milestone.runCount}회</span>
+          </div>
+        </div>
+
+        {/* 액션 버튼 */}
+        <div className="mt-auto flex justify-between border-t border-line-2 pt-4">
+          <DSButton variant="ghost" className="flex items-center gap-2 text-red-400" onClick={onDelete}>
+            <Trash2 className="h-4 w-4" />
+            삭제
+          </DSButton>
+          <Link href={`/projects/${params.slug}/milestones/${milestone.id}`}>
+            <DSButton variant="solid" className="flex items-center gap-2">
+              <ExternalLink className="h-4 w-4" />
+              상세 보기
+            </DSButton>
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/view/project/suites/test-suite-side-view.tsx
+++ b/src/view/project/suites/test-suite-side-view.tsx
@@ -1,0 +1,231 @@
+import React from 'react';
+
+import { TestSuiteCard } from '@/entities/test-suite';
+import { DSButton, cn } from '@/shared';
+import {
+  CheckCircle,
+  Edit2,
+  Flag,
+  History,
+  ListChecks,
+  Play,
+  Trash2,
+  X,
+  XCircle,
+  AlertCircle,
+} from 'lucide-react';
+
+interface TestSuiteSideViewProps {
+  suite: TestSuiteCard;
+  onClose: () => void;
+  onRun?: () => void;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+const TAG_TONE_STYLES: Record<string, string> = {
+  neutral: 'bg-slate-500/20 text-slate-300',
+  info: 'bg-blue-500/20 text-blue-300',
+  success: 'bg-green-500/20 text-green-300',
+  warning: 'bg-amber-500/20 text-amber-300',
+  danger: 'bg-red-500/20 text-red-300',
+};
+
+const STATUS_CONFIG: Record<string, { icon: React.ReactNode; color: string }> = {
+  passed: {
+    icon: <CheckCircle className="h-4 w-4" />,
+    color: 'text-green-400',
+  },
+  failed: {
+    icon: <XCircle className="h-4 w-4" />,
+    color: 'text-red-400',
+  },
+  blocked: {
+    icon: <AlertCircle className="h-4 w-4" />,
+    color: 'text-amber-400',
+  },
+  running: {
+    icon: <Play className="h-4 w-4" />,
+    color: 'text-blue-400',
+  },
+  not_run: {
+    icon: <ListChecks className="h-4 w-4" />,
+    color: 'text-slate-400',
+  },
+};
+
+const formatDate = (date: Date) => {
+  return date.toISOString().split('T')[0];
+};
+
+export const TestSuiteSideView = ({
+  suite,
+  onClose,
+  onRun,
+  onEdit,
+  onDelete,
+}: TestSuiteSideViewProps) => {
+  const tagStyle = TAG_TONE_STYLES[suite.tag.tone] || TAG_TONE_STYLES.neutral;
+
+  return (
+    <section className="bg-bg-1 border-bg-4 fixed top-0 right-0 h-full w-[600px] translate-x-0 overflow-y-auto border-l p-4 transition-transform duration-300 ease-in-out">
+      <div className="flex flex-col gap-6">
+        {/* 헤더 */}
+        <header className="flex flex-col gap-3">
+          <div className="flex justify-between">
+            <DSButton size="small" variant="ghost" className="px-2" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </DSButton>
+            <DSButton
+              size="small"
+              variant="ghost"
+              className="flex items-center gap-1 px-2"
+              onClick={onEdit}
+            >
+              <Edit2 className="h-4 w-4" />
+              <span>수정</span>
+            </DSButton>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <h2 className="text-xl font-semibold">{suite.title}</h2>
+            <span className={cn('rounded-full px-3 py-1 text-sm font-medium', tagStyle)}>
+              {suite.tag.label}
+            </span>
+          </div>
+
+          {/* 연결된 마일스톤 */}
+          {suite.linkedMilestone && (
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <Flag className="h-4 w-4" strokeWidth={1.5} />
+              <span>
+                {suite.linkedMilestone.title} ({suite.linkedMilestone.versionLabel})
+              </span>
+            </div>
+          )}
+        </header>
+
+        {/* 설명 */}
+        <div className="flex flex-col gap-2">
+          <h3 className="text-text-3 text-lg font-semibold">설명</h3>
+          <div className="bg-bg-2 border-line-2 rounded-4 border p-4">
+            <p className="text-text-2">{suite.description || '설명이 없습니다.'}</p>
+          </div>
+        </div>
+
+        {/* 통계 */}
+        <div className="grid grid-cols-2 gap-3">
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <ListChecks className="h-4 w-4" strokeWidth={1.5} />
+              <span>테스트 케이스</span>
+            </div>
+            <span className="text-text-1 text-xl font-bold">{suite.caseCount}개</span>
+          </div>
+
+          <div className="bg-bg-2 border-line-2 rounded-4 flex flex-col gap-1 border p-4">
+            <div className="text-text-3 flex items-center gap-1.5 text-sm">
+              <History className="h-4 w-4" strokeWidth={1.5} />
+              <span>실행 이력</span>
+            </div>
+            <span className="text-text-1 text-xl font-bold">{suite.executionHistoryCount}회</span>
+          </div>
+        </div>
+
+        {/* 마지막 실행 결과 */}
+        {suite.lastRun && (
+          <div className="flex flex-col gap-3">
+            <h3 className="text-text-3 text-lg font-semibold">마지막 실행 결과</h3>
+            <div className="bg-bg-2 border-line-2 rounded-4 border p-4">
+              <div className="mb-3 flex items-center justify-between">
+                <span className="text-text-3 text-sm">{formatDate(suite.lastRun.runAt)}</span>
+                <span
+                  className={cn(
+                    'flex items-center gap-1',
+                    STATUS_CONFIG[suite.lastRun.status]?.color
+                  )}
+                >
+                  {STATUS_CONFIG[suite.lastRun.status]?.icon}
+                  <span className="text-sm font-medium capitalize">{suite.lastRun.status}</span>
+                </span>
+              </div>
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <div className="flex flex-col">
+                  <span className="text-lg font-bold text-green-400">
+                    {suite.lastRun.counts.passed}
+                  </span>
+                  <span className="text-text-3 text-xs">Passed</span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-lg font-bold text-red-400">
+                    {suite.lastRun.counts.failed}
+                  </span>
+                  <span className="text-text-3 text-xs">Failed</span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-lg font-bold text-amber-400">
+                    {suite.lastRun.counts.blocked}
+                  </span>
+                  <span className="text-text-3 text-xs">Blocked</span>
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-lg font-bold text-slate-400">
+                    {suite.lastRun.counts.skipped}
+                  </span>
+                  <span className="text-text-3 text-xs">Skipped</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 최근 실행 이력 미니 그래프 */}
+        {suite.recentRuns.length > 0 && (
+          <div className="flex flex-col gap-3">
+            <h3 className="text-text-3 text-lg font-semibold">최근 실행 이력</h3>
+            <div className="flex gap-1">
+              {suite.recentRuns.slice(0, 5).map((run) => {
+                const passRate = run.total > 0 ? (run.passed / run.total) * 100 : 0;
+                return (
+                  <div
+                    key={run.runId}
+                    className="bg-bg-2 border-line-2 flex-1 rounded border p-2 text-center"
+                    title={`${formatDate(run.runAt)} - ${run.passed}/${run.total} passed`}
+                  >
+                    <div
+                      className={cn(
+                        'mx-auto mb-1 h-2 w-2 rounded-full',
+                        run.status === 'passed'
+                          ? 'bg-green-400'
+                          : run.status === 'failed'
+                            ? 'bg-red-400'
+                            : 'bg-amber-400'
+                      )}
+                    />
+                    <span className="text-text-3 text-xs">{Math.round(passRate)}%</span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* 액션 버튼 */}
+        <div className="border-line-2 mt-auto flex gap-2 border-t pt-4">
+          <DSButton className="flex flex-1 items-center justify-center gap-2" onClick={onRun}>
+            <Play className="h-4 w-4" />
+            테스트 실행
+          </DSButton>
+          <DSButton
+            variant="ghost"
+            className="flex items-center gap-2 text-red-400"
+            onClick={onDelete}
+          >
+            <Trash2 className="h-4 w-4" />
+            삭제
+          </DSButton>
+        </div>
+      </div>
+    </section>
+  );
+};


### PR DESCRIPTION
## 변경 요약
- 마일스톤 및 테스트 스위트 목록에서 각 항목 클릭 시 상세 정보를 확인할 수 있는우측 사이드 뷰(Side View) 기능을 구현했습니다.
- 페이지 전환 없이 주요 통계 및 상세 내역을 빠르게 확인할 수 있어 사용자 경험을 개선했습니다.

## 상세 변경 사항
### 마일스톤 사이드 뷰 (MilestoneSideView) 추가
- 마일스톤 진행 상태(진행 중, 완료, 예정) 및 기간 표시
- 테스트 케이스 개수, 완료 개수, 실행 횟수 등 주요 통계 대시보드 제공
- 진행률(Progress Rate) 시각화 바(Progress Bar) 구현
- 상세 페이지 이동 및 수정/삭제 액션 연동

### 테스트 스위트 사이드 뷰 (TestSuiteSideView) 추가
- 테스트 스위트 태그 및 연결된 마일스톤 정보 표시
- 테스트 케이스 수 및 실행 이력 통계 제공
- 마지막 실행 결과 요약: Passed/Failed/Blocked/Skipped 수치 및 마지막 실행일 표시
- 최근 실행 이력 그래프: 최근 5회 실행 결과의 성공률을 미니 그래프 형태로 시각화
- 테스트 바로 실행하기 및 수정/삭제 액션 연동

### 목록 뷰 연동
- MilestonesView 및 TestSuitesView에서 아이템 클릭 시 사이드 뷰가 열리도록 상태 관리 로직 추가
- 사이드 뷰 외부 영역 클릭 또는 닫기 버튼을 통한 인터랙션 구현

## 참고 사항
UI 일관성을 위해 Lucide React 아이콘과 프로젝트 공통 디자인 시스템(DSButton, cn)을 활용했습니다.
반응형 레이아웃을 고려하여 슬라이딩 애니메이션과 오버레이 스타일을 적용했습니다.