### PR TITLE
Feat: 대시보드 개선 및 테스트 관리 핵심 기능 구현

### DIFF
--- a/src/features/cases-create/ui/test-case-detail-form.tsx
+++ b/src/features/cases-create/ui/test-case-detail-form.tsx
@@ -47,19 +47,19 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess }: TestCaseDe
   };
 
   const inputClassName =
-    'bg-bg-3 border-line-2 rounded-2 w-full border px-4 py-3 text-text-1 placeholder:text-text-3 focus:border-primary focus:outline-none transition-colors';
+    'bg-bg-3 border-line-2 rounded-2 w-full border px-3 py-2.5 text-sm text-text-1 placeholder:text-text-3 focus:border-primary focus:outline-none transition-colors';
   const textareaClassName =
-    'bg-bg-3 border-line-2 rounded-2 w-full border px-4 py-3 text-text-1 placeholder:text-text-3 focus:border-primary focus:outline-none transition-colors resize-none min-h-[120px]';
+    'bg-bg-3 border-line-2 rounded-2 w-full border px-3 py-2.5 text-sm text-text-1 placeholder:text-text-3 focus:border-primary focus:outline-none transition-colors resize-none min-h-[80px]';
   const labelClassName = 'text-text-2 typo-body2-heading flex items-center gap-2';
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <section className="bg-bg-1 rounded-4 flex w-full max-w-[720px] flex-col overflow-hidden shadow-xl">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <section className="bg-bg-1 rounded-4 flex max-h-[85vh] w-full max-w-[560px] flex-col overflow-hidden shadow-xl">
         {/* Header */}
-        <header className="border-line-2 flex items-center justify-between border-b px-6 py-4">
+        <header className="border-line-2 flex shrink-0 items-center justify-between border-b px-5 py-4">
           <div>
-            <h2 className="text-text-1 text-xl font-bold">테스트 케이스 생성</h2>
-            <p className="text-text-3 mt-1 text-sm">
+            <h2 className="text-text-1 text-lg font-bold">테스트 케이스 생성</h2>
+            <p className="text-text-3 mt-0.5 text-xs">
               테스트 시나리오의 상세 내용을 작성해주세요.
             </p>
           </div>
@@ -69,7 +69,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess }: TestCaseDe
         </header>
 
         {/* Form */}
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-6 p-6" noValidate>
+        <form id="test-case-form" onSubmit={handleSubmit(onSubmit)} className="flex flex-1 flex-col gap-5 overflow-y-auto p-5" noValidate>
           {/* 제목 (필수) */}
           <FormField.Root error={errors.name} className="flex flex-col gap-2">
             <FormField.Label className={labelClassName}>
@@ -123,7 +123,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess }: TestCaseDe
               {...register('pre_condition')}
               placeholder="테스트 실행 전 충족되어야 하는 조건을 작성해주세요."
               className={textareaClassName}
-              rows={3}
+              rows={2}
             />
           </FormField.Root>
 
@@ -137,7 +137,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess }: TestCaseDe
               {...register('steps')}
               placeholder="1. 첫 번째 단계&#10;2. 두 번째 단계&#10;3. 세 번째 단계"
               className={textareaClassName}
-              rows={4}
+              rows={3}
             />
           </FormField.Root>
 
@@ -151,20 +151,20 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess }: TestCaseDe
               {...register('expected_result')}
               placeholder="각 테스트 단계 수행 후 예상되는 결과를 작성해주세요."
               className={textareaClassName}
-              rows={4}
+              rows={3}
             />
           </FormField.Root>
-
-          {/* Actions */}
-          <div className="border-line-2 flex justify-end gap-3 border-t pt-6">
-            <DSButton type="button" variant="ghost" onClick={onClose} disabled={isPending}>
-              취소
-            </DSButton>
-            <DSButton type="submit" variant="solid" disabled={isPending}>
-              {isPending ? '생성 중...' : '테스트 케이스 생성'}
-            </DSButton>
-          </div>
         </form>
+
+        {/* Actions - 스크롤 영역 밖 */}
+        <div className="border-line-2 flex shrink-0 justify-end gap-3 border-t px-5 py-4">
+          <DSButton type="button" variant="ghost" onClick={onClose} disabled={isPending}>
+            취소
+          </DSButton>
+          <DSButton type="submit" form="test-case-form" variant="solid" disabled={isPending}>
+            {isPending ? '생성 중...' : '테스트 케이스 생성'}
+          </DSButton>
+        </div>
       </section>
     </div>
   );

--- a/src/features/suites-create/ui/suite-create-form.tsx
+++ b/src/features/suites-create/ui/suite-create-form.tsx
@@ -39,80 +39,81 @@ export const SuiteCreateForm = ({ projectId, onClose }: SuiteCreateFormProps) =>
   return (
     <section
       id="create-suite"
-      className="bg-bg-2/20 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-[4px]"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
     >
-      <div className="bg-bg-2 shadow-4 w-[600px] overflow-hidden rounded-xl p-8">
-        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-8" noValidate>
-          {/* Header */}
-          <div className="border-line-1 border-b pb-6">
-            <h2 className="text-primary text-3xl">테스트 스위트를 만들어 볼까요?</h2>
-            <p className="mt-2 text-base text-neutral-400">
-              필요한 테스트들을 한 곳에 모아 관리해요
-            </p>
-          </div>
-          {/* Body */}
-          <div className="flex flex-col gap-6">
-            <FormField.Root className="flex flex-col gap-2">
-              <FormField.Label className="text-text-1 font-medium">
-                스위트 이름 <span className="text-system-red">*</span>
-              </FormField.Label>
-              <FormField.Control
-                placeholder="스위트 이름을 입력해 주세요."
-                type="text"
-                disabled={isPending}
-                {...register('title', {
-                  required: '유효한 이름을 입력해주세요.',
-                  minLength: {
-                    value: 5,
-                    message: '스위트 이름은 최소 5자 이상이어야 합니다.',
-                  },
-                  maxLength: {
-                    value: 50,
-                    message: '스위트 이름은 50자를 초과할 수 없습니다.',
-                  },
-                  validate: (value) => !!value.trim() || '공백만으로는 이름을 생성할 수 없습니다.',
-                  pattern: {
-                    value: /^[a-zA-Z0-9가-힣\s._-]+$/,
-                    message: '특수문자는 사용할 수 없습니다. (-, _, ., 공백만 허용)',
-                  },
-                })}
-                className={errors.title ? 'border-system-red focus:border-system-red' : ''}
-              />
-              {/* 에러 메시지 출력 */}
-              {errors.title && (
-                <span className="text-system-red mt-1 text-sm">{errors.title.message}</span>
-              )}
-            </FormField.Root>
-            <FormField.Root className="flex flex-col gap-2">
-              <FormField.Label className="text-text-1 font-medium">설명 (선택)</FormField.Label>
-              <FormField.Control
-                placeholder="이 스위트에 대한 간략한 설명을 입력해주세요."
-                type="text"
-                disabled={isPending}
-                {...register('description')}
-              />
-            </FormField.Root>
-          </div>
-          <div className="border-line-1 flex gap-3 border-t pt-6">
-            <DSButton
-              type="button"
-              variant="ghost"
-              className="w-full"
+      <div className="bg-bg-2 shadow-4 flex max-h-[85vh] w-full max-w-[480px] flex-col overflow-hidden rounded-xl">
+        {/* Header */}
+        <div className="border-line-2 shrink-0 border-b px-6 py-5">
+          <h2 className="text-text-1 text-lg font-bold">테스트 스위트 생성</h2>
+          <p className="text-text-3 mt-1 text-sm">
+            필요한 테스트들을 한 곳에 모아 관리해요
+          </p>
+        </div>
+
+        {/* Body */}
+        <form id="suite-form" onSubmit={handleSubmit(onSubmit)} className="flex flex-1 flex-col gap-5 overflow-y-auto p-6" noValidate>
+          <FormField.Root className="flex flex-col gap-2">
+            <FormField.Label className="text-text-2 text-sm font-medium">
+              스위트 이름 <span className="text-system-red">*</span>
+            </FormField.Label>
+            <FormField.Control
+              placeholder="스위트 이름을 입력해 주세요."
+              type="text"
               disabled={isPending}
-              onClick={onClose}
-            >
-              취소
-            </DSButton>
-            <DSButton
-              type="submit"
-              variant="solid"
-              className="w-full"
+              {...register('title', {
+                required: '유효한 이름을 입력해주세요.',
+                minLength: {
+                  value: 5,
+                  message: '스위트 이름은 최소 5자 이상이어야 합니다.',
+                },
+                maxLength: {
+                  value: 50,
+                  message: '스위트 이름은 50자를 초과할 수 없습니다.',
+                },
+                validate: (value) => !!value.trim() || '공백만으로는 이름을 생성할 수 없습니다.',
+                pattern: {
+                  value: /^[a-zA-Z0-9가-힣\s._-]+$/,
+                  message: '특수문자는 사용할 수 없습니다. (-, _, ., 공백만 허용)',
+                },
+              })}
+              className={errors.title ? 'border-system-red focus:border-system-red' : ''}
+            />
+            {errors.title && (
+              <span className="text-system-red text-sm">{errors.title.message}</span>
+            )}
+          </FormField.Root>
+          <FormField.Root className="flex flex-col gap-2">
+            <FormField.Label className="text-text-2 text-sm font-medium">설명 (선택)</FormField.Label>
+            <FormField.Control
+              placeholder="이 스위트에 대한 간략한 설명을 입력해주세요."
+              type="text"
               disabled={isPending}
-            >
-              {isPending ? '생성 중...' : '생성'}
-            </DSButton>
-          </div>
+              {...register('description')}
+            />
+          </FormField.Root>
         </form>
+
+        {/* Actions */}
+        <div className="border-line-2 flex shrink-0 gap-3 border-t px-6 py-4">
+          <DSButton
+            type="button"
+            variant="ghost"
+            className="w-full"
+            disabled={isPending}
+            onClick={onClose}
+          >
+            취소
+          </DSButton>
+          <DSButton
+            type="submit"
+            form="suite-form"
+            variant="solid"
+            className="w-full"
+            disabled={isPending}
+          >
+            {isPending ? '생성 중...' : '생성'}
+          </DSButton>
+        </div>
       </div>
     </section>
   );

--- a/src/view/project/dashboard/dashboard-view.tsx
+++ b/src/view/project/dashboard/dashboard-view.tsx
@@ -1,204 +1,184 @@
 'use client';
-import React, { useEffect, useState } from 'react';
-
-
+import React from 'react';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useParams } from 'next/navigation';
-
-
 
 import { dashboardQueryOptions } from '@/features';
 import { Container, MainContainer } from '@/shared/lib/primitives';
 import { DSButton } from '@/shared/ui';
 import { Aside } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronRight, Plus, Settings } from 'lucide-react';
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+import { ChevronRight, Clock, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
 
 export const ProjectDashboardView = () => {
   const params = useParams();
-  const [url, setUrl] = useState('');
+  const slug = params.slug as string;
 
-  useEffect(() => {
-    setUrl(window.location.href);
-  }, []);
-
-  console.log(params, params.slug, typeof params, typeof params.slug);
   const {
     data: dashboardData,
     isLoading,
-    isError,
   } = useQuery({
-    ...dashboardQueryOptions.stats(params.slug as string),
-    enabled: !!params.slug,
+    ...dashboardQueryOptions.stats(slug),
+    enabled: !!slug,
   });
 
+  // 로딩 상태
   if (isLoading) {
-    return <div>로딩중...</div>;
+    return (
+      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
+        <Aside />
+        <MainContainer className="flex flex-1 items-center justify-center">
+          <div className="text-text-3">로딩 중...</div>
+        </MainContainer>
+      </Container>
+    );
   }
 
-  if (isError || !dashboardData || !dashboardData.success) {
-    return <div>에러 발생</div>
+  // 에러 상태
+  if (!dashboardData?.success) {
+    return (
+      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
+        <Aside />
+        <MainContainer className="flex flex-1 items-center justify-center">
+          <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
+        </MainContainer>
+      </Container>
+    );
   }
 
   const { project, recentActivities } = dashboardData.data;
-  console.log(dashboardData.data);
 
   return (
-    <Container
-      id="container"
-      className="bg-bg-1 text-text-1 flex min-h-screen items-start justify-start font-sans"
-    >
+    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
       <Aside />
-      <MainContainer className="flex min-h-screen w-full flex-1 flex-col gap-20 px-10 py-20">
-        {/* 섹션 1: 헤더 + 프로젝트 정보/최근 활동 */}
-        <section className="flex w-full max-w-[1200px] flex-col gap-9">
-          {/* 헤더 텍스트 */}
-          <h1 className="text-text-1 text-[32px] leading-[1.4] font-bold tracking-tight">
-            클릭 몇 번이면 뚝딱!
-            <br />
-            테스트 케이스를 자동으로 만들어보세요.
-          </h1>
+      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
+        {/* Header */}
+        <header className="border-line-2 col-span-6 flex flex-col gap-1 border-b pb-6">
+          <h1 className="typo-h1-heading text-text-1">대시보드</h1>
+          <p className="typo-body2-normal text-text-2">
+            클릭 몇 번이면 뚝딱! 테스트 케이스를 자동으로 만들어보세요.
+          </p>
+        </header>
 
-          {/* 프로젝트 정보 + 최근 활동 카드 */}
-          <div className="flex w-full gap-3">
-            {/* 내 프로젝트 정보 카드 */}
-            <div className="bg-bg-2 relative flex w-[350px] flex-col gap-4 overflow-hidden rounded-lg p-4">
-              <span className="text-text-3 text-xs">내 프로젝트 정보</span>
+        {/* 프로젝트 정보 + 최근 활동 카드 */}
+        <section className="col-span-6 grid grid-cols-6 gap-5">
+          {/* 내 프로젝트 정보 카드 */}
+          <div className="rounded-3 border-line-2 bg-bg-2 col-span-2 flex flex-col gap-4 border p-5">
+            <span className="typo-body2-heading text-text-3">내 프로젝트 정보</span>
 
-              <div className="flex flex-col items-center justify-center gap-1 rounded-lg bg-white/5 p-4">
-                <div className="flex items-center gap-1">
-                  <span className="text-primary text-base font-semibold">{url}</span>
-                  {/* 공유 아이콘 placeholder */}
-                  <div className="text-primary size-4">{/* icon placeholder */}</div>
-                </div>
-                <span className="text-text-2 text-xs">{project.created_at} 생성됨</span>
+            <div className="rounded-2 bg-bg-3 flex flex-col items-center justify-center gap-2 p-4">
+              <div className="flex items-center gap-2">
+                <span className="typo-body2-heading text-primary truncate max-w-[200px]">
+                  {project.name}
+                </span>
+                <button className="text-primary hover:text-primary/80 transition-colors">
+                  <Share2 className="h-4 w-4" />
+                </button>
               </div>
-
-              <div className="flex justify-end">
-                <DSButton variant="text" className="text-text-2 flex items-center gap-2">
-                  <Settings className="size-4" />
-                  <span>환경설정</span>
-                </DSButton>
-              </div>
-
-              {/* 배경 데코레이션 placeholder */}
-              <div className="bg-primary/10 absolute top-12 -left-[228px] size-64 rounded-full blur-3xl" />
+              <span className="typo-caption text-text-3">
+                {new Date(project.created_at).toLocaleDateString('ko-KR')} 생성됨
+              </span>
             </div>
 
-            {/* 최근 활동 카드 */}
-            <div className="bg-bg-2 flex flex-1 flex-col gap-4 rounded-lg p-4">
-              <span className="text-text-3 text-xs">최근 활동</span>
+            <div className="flex justify-end">
+              <DSButton variant="text" className="text-text-2 flex items-center gap-2">
+                <Settings className="h-4 w-4" />
+                <span>환경설정</span>
+              </DSButton>
+            </div>
+          </div>
 
-              <ul className="flex flex-col gap-1">
-                {recentActivities.map((item) => (
-                  <li key={item.id} className="flex items-center gap-1">
-                    <span className="text-text-1 text-base">
-                      <span className="mr-2">•</span>
+          {/* 최근 활동 카드 */}
+          <div className="rounded-3 border-line-2 bg-bg-2 col-span-4 flex flex-col gap-4 border p-5">
+            <span className="typo-body2-heading text-text-3">최근 활동</span>
+
+            {recentActivities.length === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-2 py-6">
+                <Clock className="text-text-3 h-8 w-8" />
+                <p className="typo-body2-normal text-text-3">최근 활동이 없습니다.</p>
+              </div>
+            ) : (
+              <ul className="flex flex-col gap-2">
+                {recentActivities.slice(0, 5).map((item) => (
+                  <li key={item.id} className="flex items-center gap-2">
+                    <span className="bg-primary h-1.5 w-1.5 rounded-full" />
+                    <span className="typo-body2-normal text-text-1 flex-1 truncate">
                       {item.title}
                     </span>
-                    <span className="text-text-2 mx-1">•</span>
-                    <span className="text-text-2 text-base font-semibold">{item.created_at}일전</span>
+                    <span className="typo-caption text-text-3">
+                      {item.created_at}일 전
+                    </span>
                   </li>
                 ))}
               </ul>
-            </div>
+            )}
           </div>
         </section>
 
-        {/* 섹션 2: 테스트 케이스 한눈에 보기 */}
-        <section className="flex w-full max-w-[1200px] flex-col gap-9">
-          {/* 섹션 헤더 */}
-          <div className="flex items-center gap-2">
-            <h2 className="text-text-1 text-[32px] leading-[1.4] font-bold tracking-tight">
-              테스트 케이스 한눈에 보기
-            </h2>
-            <ChevronRight className="text-text-1 size-6" />
-          </div>
+        {/* 테스트 케이스 섹션 */}
+        <section className="col-span-6 flex flex-col gap-4">
+          <Link href={`/projects/${slug}/cases`} className="flex items-center gap-2 group">
+            <h2 className="typo-h2-heading text-text-1">테스트 케이스</h2>
+            <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
+          </Link>
 
           {/* 빈 상태 카드 */}
-          <div className="bg-bg-2 relative gap-4 overflow-hidden rounded-2xl px-6 pt-6 pb-12">
-            <div className="flex flex-col items-center justify-center gap-4">
-              {/* 이미지 placeholder */}
-              <Image
-                src="/teacup/tea-cup-not-found.svg"
-                width={383.27}
-                height={488.57}
-                alt="테스트 케이스 없음"
-              />
+          <div className="rounded-3 border-line-2 bg-bg-2 border-2 border-dashed flex flex-col items-center justify-center gap-6 py-16">
+            <Image
+              src="/teacup/tea-cup-not-found.svg"
+              width={200}
+              height={255}
+              alt="테스트 케이스 없음"
+            />
 
-              {/* 텍스트 + CTA */}
-              <div className="flex flex-col items-center gap-4">
-                <div className="flex flex-col items-center gap-4">
-                  <h3 className="text-text-1 text-2xl font-bold">테스트 케이스를 생성해보세요!</h3>
-                  <p className="text-text-1 text-center text-lg">
-                    아직 생성된 테스트 케이스가 없습니다.
-                    <br />
-                    테스트 케이스를 만들면 여기에서 빠르게 확인할 수 있어요.
-                  </p>
-                </div>
-
-                <DSButton
-                  variant="solid"
-                  className="flex h-14 cursor-pointer items-center gap-2 px-5"
-                >
-                  <Plus className="size-6" />
-                  <span className="text-lg font-semibold">테스트 케이스 만들기</span>
-                </DSButton>
-              </div>
+            <div className="flex flex-col items-center gap-2 text-center">
+              <h3 className="typo-h3-heading text-text-1">테스트 케이스를 생성해보세요!</h3>
+              <p className="typo-body2-normal text-text-3">
+                아직 생성된 테스트 케이스가 없습니다.
+                <br />
+                테스트 케이스를 만들면 여기에서 빠르게 확인할 수 있어요.
+              </p>
             </div>
 
-            {/* 배경 데코레이션 placeholder */}
-            <div className="bg-primary/10 absolute right-[25%] bottom-[-200px] size-[500px] rounded-full blur-3xl" />
-          </div>
-        </section>
-
-        {/* 섹션 3: 테스트 스위트 */}
-        <section className="flex w-full max-w-[1200px] flex-col gap-9">
-          {/* 섹션 헤더 */}
-          <div className="flex items-center gap-2">
-            <h2 className="text-text-1 text-[32px] leading-[1.4] font-bold tracking-tight">
-              테스트 스위트
-            </h2>
-            <ChevronRight className="text-text-1 size-6" />
-          </div>
-
-          {/* 빈 상태 카드 */}
-          <div className="bg-bg-2 flex flex-col items-center gap-4 rounded-lg px-0 py-12">
-            <div className="flex flex-col items-center gap-4">
-              <div className="flex flex-col items-center gap-4">
-                <h3 className="text-text-1 text-2xl font-bold">테스트 스위트를 생성해보세요!</h3>
-                <p className="text-text-1 text-center text-lg">
-                  아직 생성된 테스트 스위트가 없습니다.
-                  <br />
-                  테스트 스위트로, 테스트 케이스를 더 쉽게 관리해보세요!
-                </p>
-              </div>
-
-              <DSButton
-                variant="solid"
-                className="flex h-14 cursor-pointer items-center gap-2 px-5"
-              >
-                <Plus className="size-6" />
-                <span className="text-lg font-semibold">테스트 스위트 만들기</span>
+            <Link href={`/projects/${slug}/cases`}>
+              <DSButton variant="solid" className="flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                <span>테스트 케이스 만들기</span>
               </DSButton>
+            </Link>
+          </div>
+        </section>
+
+        {/* 테스트 스위트 섹션 */}
+        <section className="col-span-6 flex flex-col gap-4">
+          <Link href={`/projects/${slug}/suites`} className="flex items-center gap-2 group">
+            <h2 className="typo-h2-heading text-text-1">테스트 스위트</h2>
+            <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
+          </Link>
+
+          {/* 빈 상태 카드 */}
+          <div className="rounded-3 border-line-2 bg-bg-2/50 border-2 border-dashed flex flex-col items-center justify-center gap-4 py-12">
+            <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
+              <FolderOpen className="h-6 w-6" strokeWidth={1.5} />
             </div>
+
+            <div className="flex flex-col items-center gap-1 text-center">
+              <h3 className="typo-h3-heading text-text-1">테스트 스위트를 생성해보세요!</h3>
+              <p className="typo-body2-normal text-text-3">
+                아직 생성된 테스트 스위트가 없습니다.
+                <br />
+                테스트 스위트로, 테스트 케이스를 더 쉽게 관리해보세요!
+              </p>
+            </div>
+
+            <Link href={`/projects/${slug}/suites`}>
+              <DSButton variant="solid" className="flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                <span>테스트 스위트 만들기</span>
+              </DSButton>
+            </Link>
           </div>
         </section>
       </MainContainer>

--- a/src/view/project/dashboard/dashboard-view.tsx
+++ b/src/view/project/dashboard/dashboard-view.tsx
@@ -5,16 +5,22 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
-import { dashboardQueryOptions } from '@/features';
+import { TestCaseDetailForm } from '@/features/cases-create';
+import { dashboardQueryOptions } from '@/features/dashboard';
+import { SuiteCreateForm } from '@/features/suites-create';
 import { Container, MainContainer } from '@/shared/lib/primitives';
+import { useDisclosure } from '@/shared/hooks';
 import { DSButton } from '@/shared/ui';
 import { Aside } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { ChevronRight, Clock, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
 
+type ModalType = 'case' | 'suite';
+
 export const ProjectDashboardView = () => {
   const params = useParams();
   const slug = params.slug as string;
+  const { onClose, onOpen, isActiveType } = useDisclosure<ModalType>();
 
   const {
     data: dashboardData,
@@ -23,6 +29,8 @@ export const ProjectDashboardView = () => {
     ...dashboardQueryOptions.stats(slug),
     enabled: !!slug,
   });
+
+  const projectId = dashboardData?.success ? dashboardData.data.project.id : undefined;
 
   // 로딩 상태
   if (isLoading) {
@@ -142,12 +150,10 @@ export const ProjectDashboardView = () => {
               </p>
             </div>
 
-            <Link href={`/projects/${slug}/cases`}>
-              <DSButton variant="solid" className="flex items-center gap-2">
-                <Plus className="h-4 w-4" />
-                <span>테스트 케이스 만들기</span>
-              </DSButton>
-            </Link>
+            <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('case')}>
+              <Plus className="h-4 w-4" />
+              <span>테스트 케이스 만들기</span>
+            </DSButton>
           </div>
         </section>
 
@@ -173,15 +179,21 @@ export const ProjectDashboardView = () => {
               </p>
             </div>
 
-            <Link href={`/projects/${slug}/suites`}>
-              <DSButton variant="solid" className="flex items-center gap-2">
-                <Plus className="h-4 w-4" />
-                <span>테스트 스위트 만들기</span>
-              </DSButton>
-            </Link>
+            <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('suite')}>
+              <Plus className="h-4 w-4" />
+              <span>테스트 스위트 만들기</span>
+            </DSButton>
           </div>
         </section>
       </MainContainer>
+
+      {/* Modals */}
+      {isActiveType('case') && projectId && (
+        <TestCaseDetailForm projectId={projectId} onClose={onClose} />
+      )}
+      {isActiveType('suite') && projectId && (
+        <SuiteCreateForm projectId={projectId} onClose={onClose} />
+      )}
     </Container>
   );
 };

--- a/src/view/project/dashboard/dashboard-view.tsx
+++ b/src/view/project/dashboard/dashboard-view.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
@@ -13,7 +13,7 @@ import { useDisclosure } from '@/shared/hooks';
 import { DSButton } from '@/shared/ui';
 import { Aside } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
-import { ChevronRight, Clock, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
+import { Check, ChevronRight, Clock, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
 
 type ModalType = 'case' | 'suite';
 
@@ -21,6 +21,7 @@ export const ProjectDashboardView = () => {
   const params = useParams();
   const slug = params.slug as string;
   const { onClose, onOpen, isActiveType } = useDisclosure<ModalType>();
+  const [isCopied, setIsCopied] = useState(false);
 
   const {
     data: dashboardData,
@@ -31,6 +32,16 @@ export const ProjectDashboardView = () => {
   });
 
   const projectId = dashboardData?.success ? dashboardData.data.project.id : undefined;
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch (err) {
+      console.error('링크 복사 실패:', err);
+    }
+  };
 
   // 로딩 상태
   if (isLoading) {
@@ -81,8 +92,12 @@ export const ProjectDashboardView = () => {
                 <span className="typo-body2-heading text-primary truncate max-w-[200px]">
                   {project.name}
                 </span>
-                <button className="text-primary hover:text-primary/80 transition-colors">
-                  <Share2 className="h-4 w-4" />
+                <button
+                  onClick={handleCopyLink}
+                  className="text-primary hover:text-primary/80 transition-colors cursor-pointer"
+                  title="링크 복사"
+                >
+                  {isCopied ? <Check className="h-4 w-4" /> : <Share2 className="h-4 w-4" />}
                 </button>
               </div>
               <span className="typo-caption text-text-3">

--- a/src/view/project/dashboard/dashboard-view.tsx
+++ b/src/view/project/dashboard/dashboard-view.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
 import { TestCaseDetailForm } from '@/features/cases-create';
+import { testCasesQueryOptions } from '@/features/cases-list';
 import { dashboardQueryOptions } from '@/features/dashboard';
 import { SuiteCreateForm } from '@/features/suites-create';
 import { Container, MainContainer } from '@/shared/lib/primitives';
@@ -13,7 +14,7 @@ import { useDisclosure } from '@/shared/hooks';
 import { DSButton } from '@/shared/ui';
 import { Aside } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
-import { Check, ChevronRight, Clock, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
+import { Check, ChevronRight, Clock, FileText, FolderOpen, Plus, Settings, Share2 } from 'lucide-react';
 
 type ModalType = 'case' | 'suite';
 
@@ -32,6 +33,14 @@ export const ProjectDashboardView = () => {
   });
 
   const projectId = dashboardData?.success ? dashboardData.data.project.id : undefined;
+
+  const { data: testCasesData } = useQuery({
+    ...testCasesQueryOptions(projectId!),
+    enabled: !!projectId,
+  });
+
+  const testCases = testCasesData?.success ? testCasesData.data : [];
+  const testSuites = dashboardData?.success ? dashboardData.data.testSuites : [];
 
   const handleCopyLink = async () => {
     try {
@@ -142,63 +151,151 @@ export const ProjectDashboardView = () => {
 
         {/* 테스트 케이스 섹션 */}
         <section className="col-span-6 flex flex-col gap-4">
-          <Link href={`/projects/${slug}/cases`} className="flex items-center gap-2 group">
-            <h2 className="typo-h2-heading text-text-1">테스트 케이스</h2>
-            <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
-          </Link>
-
-          {/* 빈 상태 카드 */}
-          <div className="rounded-3 border-line-2 bg-bg-2 border-2 border-dashed flex flex-col items-center justify-center gap-6 py-16">
-            <Image
-              src="/teacup/tea-cup-not-found.svg"
-              width={200}
-              height={255}
-              alt="테스트 케이스 없음"
-            />
-
-            <div className="flex flex-col items-center gap-2 text-center">
-              <h3 className="typo-h3-heading text-text-1">테스트 케이스를 생성해보세요!</h3>
-              <p className="typo-body2-normal text-text-3">
-                아직 생성된 테스트 케이스가 없습니다.
-                <br />
-                테스트 케이스를 만들면 여기에서 빠르게 확인할 수 있어요.
-              </p>
-            </div>
-
-            <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('case')}>
-              <Plus className="h-4 w-4" />
-              <span>테스트 케이스 만들기</span>
-            </DSButton>
+          <div className="flex items-center justify-between">
+            <Link href={`/projects/${slug}/cases`} className="flex items-center gap-2 group">
+              <h2 className="typo-h2-heading text-text-1">테스트 케이스</h2>
+              <span className="typo-body2-normal text-text-3">({testCases.length})</span>
+              <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
+            </Link>
+            {testCases.length > 0 && (
+              <DSButton variant="ghost" size="small" className="flex items-center gap-1" onClick={() => onOpen('case')}>
+                <Plus className="h-4 w-4" />
+                <span>추가</span>
+              </DSButton>
+            )}
           </div>
+
+          {testCases.length === 0 ? (
+            /* 빈 상태 카드 */
+            <div className="rounded-3 border-line-2 bg-bg-2 border-2 border-dashed flex flex-col items-center justify-center gap-6 py-16">
+              <Image
+                src="/teacup/tea-cup-not-found.svg"
+                width={200}
+                height={255}
+                alt="테스트 케이스 없음"
+              />
+
+              <div className="flex flex-col items-center gap-2 text-center">
+                <h3 className="typo-h3-heading text-text-1">테스트 케이스를 생성해보세요!</h3>
+                <p className="typo-body2-normal text-text-3">
+                  아직 생성된 테스트 케이스가 없습니다.
+                  <br />
+                  테스트 케이스를 만들면 여기에서 빠르게 확인할 수 있어요.
+                </p>
+              </div>
+
+              <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('case')}>
+                <Plus className="h-4 w-4" />
+                <span>테스트 케이스 만들기</span>
+              </DSButton>
+            </div>
+          ) : (
+            /* 테스트 케이스 목록 */
+            <div className="rounded-3 border-line-2 bg-bg-2 border flex flex-col divide-y divide-line-2">
+              {testCases.slice(0, 5).map((testCase) => (
+                <Link
+                  key={testCase.id}
+                  href={`/projects/${slug}/cases`}
+                  className="flex items-center gap-4 px-5 py-4 hover:bg-bg-3 transition-colors"
+                >
+                  <div className="bg-primary/10 text-primary rounded-2 flex h-10 w-10 items-center justify-center shrink-0">
+                    <FileText className="h-5 w-5" />
+                  </div>
+                  <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+                    <span className="typo-caption text-text-3">{testCase.caseKey}</span>
+                    <span className="typo-body2-heading text-text-1 truncate">{testCase.title}</span>
+                  </div>
+                  <span className="typo-caption text-text-3 shrink-0">
+                    {new Date(testCase.createdAt).toLocaleDateString('ko-KR')}
+                  </span>
+                </Link>
+              ))}
+              {testCases.length > 5 && (
+                <Link
+                  href={`/projects/${slug}/cases`}
+                  className="flex items-center justify-center gap-2 px-5 py-3 text-primary hover:bg-bg-3 transition-colors"
+                >
+                  <span className="typo-body2-heading">전체 보기 ({testCases.length}개)</span>
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              )}
+            </div>
+          )}
         </section>
 
         {/* 테스트 스위트 섹션 */}
         <section className="col-span-6 flex flex-col gap-4">
-          <Link href={`/projects/${slug}/suites`} className="flex items-center gap-2 group">
-            <h2 className="typo-h2-heading text-text-1">테스트 스위트</h2>
-            <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
-          </Link>
-
-          {/* 빈 상태 카드 */}
-          <div className="rounded-3 border-line-2 bg-bg-2/50 border-2 border-dashed flex flex-col items-center justify-center gap-4 py-12">
-            <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
-              <FolderOpen className="h-6 w-6" strokeWidth={1.5} />
-            </div>
-
-            <div className="flex flex-col items-center gap-1 text-center">
-              <h3 className="typo-h3-heading text-text-1">테스트 스위트를 생성해보세요!</h3>
-              <p className="typo-body2-normal text-text-3">
-                아직 생성된 테스트 스위트가 없습니다.
-                <br />
-                테스트 스위트로, 테스트 케이스를 더 쉽게 관리해보세요!
-              </p>
-            </div>
-
-            <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('suite')}>
-              <Plus className="h-4 w-4" />
-              <span>테스트 스위트 만들기</span>
-            </DSButton>
+          <div className="flex items-center justify-between">
+            <Link href={`/projects/${slug}/suites`} className="flex items-center gap-2 group">
+              <h2 className="typo-h2-heading text-text-1">테스트 스위트</h2>
+              <span className="typo-body2-normal text-text-3">({testSuites.length})</span>
+              <ChevronRight className="text-text-3 group-hover:text-text-1 h-5 w-5 transition-colors" />
+            </Link>
+            {testSuites.length > 0 && (
+              <DSButton variant="ghost" size="small" className="flex items-center gap-1" onClick={() => onOpen('suite')}>
+                <Plus className="h-4 w-4" />
+                <span>추가</span>
+              </DSButton>
+            )}
           </div>
+
+          {testSuites.length === 0 ? (
+            /* 빈 상태 카드 */
+            <div className="rounded-3 border-line-2 bg-bg-2/50 border-2 border-dashed flex flex-col items-center justify-center gap-4 py-12">
+              <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
+                <FolderOpen className="h-6 w-6" strokeWidth={1.5} />
+              </div>
+
+              <div className="flex flex-col items-center gap-1 text-center">
+                <h3 className="typo-h3-heading text-text-1">테스트 스위트를 생성해보세요!</h3>
+                <p className="typo-body2-normal text-text-3">
+                  아직 생성된 테스트 스위트가 없습니다.
+                  <br />
+                  테스트 스위트로, 테스트 케이스를 더 쉽게 관리해보세요!
+                </p>
+              </div>
+
+              <DSButton variant="solid" className="flex items-center gap-2" onClick={() => onOpen('suite')}>
+                <Plus className="h-4 w-4" />
+                <span>테스트 스위트 만들기</span>
+              </DSButton>
+            </div>
+          ) : (
+            /* 테스트 스위트 목록 */
+            <div className="rounded-3 border-line-2 bg-bg-2 border flex flex-col divide-y divide-line-2">
+              {testSuites.slice(0, 5).map((suite) => (
+                <Link
+                  key={suite.id}
+                  href={`/projects/${slug}/suites/${suite.id}`}
+                  className="flex items-center gap-4 px-5 py-4 hover:bg-bg-3 transition-colors"
+                >
+                  <div className="bg-system-blue/10 text-system-blue rounded-2 flex h-10 w-10 items-center justify-center shrink-0">
+                    <FolderOpen className="h-5 w-5" />
+                  </div>
+                  <div className="flex flex-col gap-0.5 flex-1 min-w-0">
+                    <span className="typo-body2-heading text-text-1 truncate">{suite.name}</span>
+                    <span className="typo-caption text-text-3">
+                      {suite.description || '설명 없음'}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className="typo-caption text-text-3 bg-bg-3 px-2 py-1 rounded-1">
+                      케이스 {suite.case_count}개
+                    </span>
+                  </div>
+                </Link>
+              ))}
+              {testSuites.length > 5 && (
+                <Link
+                  href={`/projects/${slug}/suites`}
+                  className="flex items-center justify-center gap-2 px-5 py-3 text-primary hover:bg-bg-3 transition-colors"
+                >
+                  <span className="typo-body2-heading">전체 보기 ({testSuites.length}개)</span>
+                  <ChevronRight className="h-4 w-4" />
+                </Link>
+              )}
+            </div>
+          )}
         </section>
       </MainContainer>
 


### PR DESCRIPTION
## Summary
- 대시보드 UI/UX 개선 및 조건부 렌더링 로직 추가
- 마일스톤, 테스트 스위트, 테스트 실행 CRUD API 및 화면 구현
- 프로젝트/테스트 케이스 아카이브(Soft Delete) 기능 추가
- Lifecycle Status 기반 데이터 관리 체계 정립

## Changes
### 대시보드 개선
- 테스트 케이스/스위트 목록 조건부 렌더링 추가
- 프로젝트 링크 복사 기능 구현
- 레이아웃 및 모달 UX 최적화
- 사용자 흐름 개선

### 마일스톤 관리
- 마일스톤 CRUD API 구현 (`src/entities/milestone/api/server-actions.ts`)
- 마일스톤 상세/편집 페이지 추가
- 마일스톤-테스트 케이스 연결 스키마 구현
- 진행 상태(planned/inProgress/done) 관리

### 테스트 실행(Run) 관리
- 테스트 실행 상세 화면 및 API 구현
- 테스트 실행 생성 페이지 개선
- 테스트 케이스 실행 결과(test-case-run) 스키마 추가
- 마일스톤/스위트 기반 실행 필터링

### 테스트 스위트 관리
- 스위트 CRUD API 완성
- 스위트 상세/편집 화면 추가
- 스위트-테스트 케이스 관계 관리

###  데이터 아키텍처 개선
- Lifecycle Status(ACTIVE/ARCHIVED) 도입으로 Soft Delete 구현
- 프로젝트/마일스톤/테스트 케이스 아카이브 기능 추가
- DB 스키마 relations 정의 추가 (`src/shared/lib/db/schema/relations.ts`)
- 스키마 파일명 복수형 통일 (milestone → milestones, test-run → test-runs 등)

### 테스트 커버리지
- 엔티티 API 단위 테스트 추가
  - `create-milestone-action.test.ts`
  - `get-milestones-action.test.ts`
  - `update-milestone-action.test.ts`
  - `archive-case-action.test.ts`
  - `archive-project.test.ts`
- Mock DB 유틸리티 개선 (`src/shared/test/__mocks__/db.ts`)

###  개발 환경
- Storybook에서 `server-only` 모듈 모킹 처리
- `storybook-static` 빌드 디렉토리 gitignore 추가
- Query Key 상수 중앙화 (`src/shared/constants/query`)

## Test Plan
- [ ] 대시보드에서 프로젝트 링크 복사 동작 확인
- [ ] 마일스톤 생성/수정/삭제/상세 조회 기능 테스트
- [ ] 테스트 실행 생성 및 결과 기록 플로우 검증
- [ ] 스위트 생성 후 케이스 추가/제거 동작 확인
- [ ] 아카이브된 항목이 목록에서 제외되는지 확인
- [ ] 단위 테스트 실행: `npm test` 또는 `npx vitest`