### PR TITLE
Feat: 공용 UI 컴포넌트 Storybook 추가 및 순환 참조 수정

### DIFF
--- a/src/shared/lib/primitives/container/container.stories.tsx
+++ b/src/shared/lib/primitives/container/container.stories.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Container } from './container';
+
+const meta: Meta<typeof Container> = {
+  title: 'Primitive Components/Container',
+  component: Container,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    asChild: {
+      control: 'boolean',
+      description: 'Slot 패턴을 사용하여 자식 요소에 props를 전달합니다.',
+    },
+    className: {
+      control: 'text',
+      description: '추가할 CSS 클래스명입니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const boxStyle: React.CSSProperties = {
+  padding: '24px',
+  backgroundColor: '#f3f4f6',
+  borderRadius: '8px',
+  border: '1px dashed #9ca3af',
+};
+
+export const Default: Story = {
+  args: {
+    children: '기본 Container 컴포넌트입니다.',
+    style: boxStyle,
+  },
+};
+
+export const Nested: Story = {
+  render: () => (
+    <Container style={{ ...boxStyle, backgroundColor: '#dbeafe' }}>
+      <p style={{ marginBottom: '16px' }}>외부 Container</p>
+      <Container style={{ ...boxStyle, backgroundColor: '#fef3c7' }}>
+        <p style={{ marginBottom: '16px' }}>내부 Container</p>
+        <Container style={{ ...boxStyle, backgroundColor: '#dcfce7' }}>
+          최하위 Container
+        </Container>
+      </Container>
+    </Container>
+  ),
+};
+
+export const AsChild: Story = {
+  render: () => (
+    <Container asChild>
+      <section style={{ ...boxStyle, backgroundColor: '#fce7f3' }}>
+        asChild를 사용하면 Container가 section 태그로 렌더링됩니다.
+      </section>
+    </Container>
+  ),
+};

--- a/src/shared/lib/primitives/grid/grid.stories.tsx
+++ b/src/shared/lib/primitives/grid/grid.stories.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Grid } from './grid';
+
+const meta: Meta<typeof Grid.Root> = {
+  title: 'Primitive Components/Grid',
+  component: Grid.Root,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const columnStyle: React.CSSProperties = {
+  padding: '16px',
+  backgroundColor: '#dbeafe',
+  borderRadius: '4px',
+  textAlign: 'center',
+  fontSize: '14px',
+  fontWeight: 500,
+};
+
+export const Default: Story = {
+  render: () => (
+    <Grid.Root style={{ padding: '24px' }}>
+      <Grid.Container>
+        {Array.from({ length: 12 }).map((_, i) => (
+          <Grid.Column key={i} span={1}>
+            <div style={columnStyle}>{i + 1}</div>
+          </Grid.Column>
+        ))}
+      </Grid.Container>
+    </Grid.Root>
+  ),
+};
+
+export const VariousColumns: Story = {
+  render: () => (
+    <Grid.Root style={{ padding: '24px' }}>
+      <Grid.Container style={{ rowGap: '16px' }}>
+        <Grid.Column span={12}>
+          <div style={columnStyle}>span=12</div>
+        </Grid.Column>
+        <Grid.Column span={6}>
+          <div style={columnStyle}>span=6</div>
+        </Grid.Column>
+        <Grid.Column span={6}>
+          <div style={columnStyle}>span=6</div>
+        </Grid.Column>
+        <Grid.Column span={4}>
+          <div style={columnStyle}>span=4</div>
+        </Grid.Column>
+        <Grid.Column span={4}>
+          <div style={columnStyle}>span=4</div>
+        </Grid.Column>
+        <Grid.Column span={4}>
+          <div style={columnStyle}>span=4</div>
+        </Grid.Column>
+      </Grid.Container>
+    </Grid.Root>
+  ),
+};
+
+export const WithOffset: Story = {
+  render: () => (
+    <Grid.Root style={{ padding: '24px' }}>
+      <Grid.Container style={{ rowGap: '16px' }}>
+        <Grid.Column span={4}>
+          <div style={columnStyle}>span=4</div>
+        </Grid.Column>
+        <Grid.Column span={4} offset={4}>
+          <div style={{ ...columnStyle, backgroundColor: '#fef3c7' }}>span=4, offset=4</div>
+        </Grid.Column>
+        <Grid.Column span={6} offset={3}>
+          <div style={{ ...columnStyle, backgroundColor: '#dcfce7' }}>span=6, offset=3</div>
+        </Grid.Column>
+      </Grid.Container>
+    </Grid.Root>
+  ),
+};
+
+export const WithDebugOverlay: Story = {
+  render: () => (
+    <Grid.Root style={{ padding: '24px', minHeight: '300px' }}>
+      <Grid.Debug />
+      <Grid.Container style={{ rowGap: '16px' }}>
+        <Grid.Column span={4}>
+          <div style={{ ...columnStyle, backgroundColor: 'rgba(219, 234, 254, 0.9)' }}>span=4</div>
+        </Grid.Column>
+        <Grid.Column span={4}>
+          <div style={{ ...columnStyle, backgroundColor: 'rgba(219, 234, 254, 0.9)' }}>span=4</div>
+        </Grid.Column>
+        <Grid.Column span={4}>
+          <div style={{ ...columnStyle, backgroundColor: 'rgba(219, 234, 254, 0.9)' }}>span=4</div>
+        </Grid.Column>
+      </Grid.Container>
+    </Grid.Root>
+  ),
+};

--- a/src/shared/lib/primitives/main-container/main-container.stories.tsx
+++ b/src/shared/lib/primitives/main-container/main-container.stories.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { MainContainer } from './main-container';
+
+const meta: Meta<typeof MainContainer> = {
+  title: 'Primitive Components/MainContainer',
+  component: MainContainer,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: '추가할 CSS 클래스명입니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div style={{ padding: '24px' }}>
+        <h1 style={{ fontSize: '24px', fontWeight: 'bold', marginBottom: '16px' }}>
+          메인 콘텐츠 영역
+        </h1>
+        <p style={{ color: '#6b7280' }}>
+          MainContainer는 페이지의 주요 콘텐츠를 감싸는 시맨틱 컴포넌트입니다.
+        </p>
+      </div>
+    ),
+  },
+};
+
+export const WithStyling: Story = {
+  args: {
+    style: {
+      backgroundColor: '#f9fafb',
+      minHeight: '400px',
+      padding: '32px',
+    },
+    children: (
+      <div>
+        <h1 style={{ fontSize: '28px', fontWeight: 'bold', marginBottom: '24px' }}>
+          대시보드
+        </h1>
+        <p style={{ color: '#6b7280' }}>스타일이 적용된 MainContainer입니다.</p>
+      </div>
+    ),
+  },
+};

--- a/src/shared/ui/checkbox/ds-checkbox.stories.tsx
+++ b/src/shared/ui/checkbox/ds-checkbox.stories.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DsCheckbox } from '@/shared';
+
+const meta: Meta<typeof DsCheckbox> = {
+  title: 'Design System/DsCheckbox',
+  component: DsCheckbox,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    checked: {
+      control: 'boolean',
+      description: '체크박스의 선택 상태를 지정합니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '체크박스를 비활성화합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    checked: false,
+  },
+};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+export const CheckedDisabled: Story = {
+  args: {
+    checked: true,
+    disabled: true,
+  },
+};
+
+const WithLabelTemplate = () => {
+  const [checked, setChecked] = useState(false);
+  return (
+    <label style={{ display: 'flex', alignItems: 'center', gap: '8px', cursor: 'pointer' }}>
+      <DsCheckbox checked={checked} onCheckedChange={setChecked} />
+      <span>이용약관에 동의합니다</span>
+    </label>
+  );
+};
+
+export const WithLabel: Story = {
+  render: () => <WithLabelTemplate />,
+};

--- a/src/shared/ui/checkbox/ds-checkbox.tsx
+++ b/src/shared/ui/checkbox/ds-checkbox.tsx
@@ -1,28 +1,26 @@
 'use client';
 import * as React from 'react';
-import { cn } from '@/shared';
 
-export interface CheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
+
+
+import { cn } from '@/shared/utils';
+
+export interface DsCheckboxProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {
   onCheckedChange?: (checked: boolean) => void;
   ref?: React.Ref<HTMLInputElement>;
 }
 
-const Checkbox = (props: CheckboxProps) => {
+export const DsCheckbox = (props: DsCheckboxProps) => {
   const { className, onCheckedChange, checked, ref, ...rest } = props;
 
   return (
     <input
       type="checkbox"
       ref={ref}
-      className={cn(
-        'h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary',
-        className
-      )}
+      className={cn('text-primary focus:ring-primary h-4 w-4 rounded border-gray-300', className)}
       checked={checked}
       onChange={(e) => onCheckedChange?.(e.target.checked)}
       {...rest}
     />
   );
 };
-
-export { Checkbox };

--- a/src/shared/ui/checkbox/index.ts
+++ b/src/shared/ui/checkbox/index.ts
@@ -1,1 +1,2 @@
-export * from './checkbox';
+export { DsCheckbox, type DsCheckboxProps } from './ds-checkbox';
+export { DsCheckbox as Checkbox } from './ds-checkbox';

--- a/src/shared/ui/ds-button/ds-button.stories.tsx
+++ b/src/shared/ui/ds-button/ds-button.stories.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DSButton } from './ds-button';
+import { Play, Loader } from 'lucide-react';
+
+const meta: Meta<typeof DSButton> = {
+  title: 'Design System/DSButton',
+  component: DSButton,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['solid', 'ghost', 'text'],
+      description: '버튼의 스타일 변형을 지정합니다.',
+    },
+    size: {
+      control: 'select',
+      options: ['large', 'medium', 'small'],
+      description: '버튼의 크기를 지정합니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '버튼을 비활성화합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Solid: Story = {
+  args: {
+    variant: 'solid',
+    size: 'medium',
+    children: '버튼 액션',
+  },
+};
+
+export const Ghost: Story = {
+  args: {
+    variant: 'ghost',
+    size: 'medium',
+    children: '버튼 액션',
+  },
+};
+
+export const Text: Story = {
+  args: {
+    variant: 'text',
+    size: 'medium',
+    children: '버튼 액션',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+      <DSButton size="large">Large</DSButton>
+      <DSButton size="medium">Medium</DSButton>
+      <DSButton size="small">Small</DSButton>
+    </div>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '16px', alignItems: 'center' }}>
+      <DSButton variant="solid">Solid</DSButton>
+      <DSButton variant="ghost">Ghost</DSButton>
+      <DSButton variant="text">Text</DSButton>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'solid',
+    size: 'medium',
+    disabled: true,
+    children: '비활성화됨',
+  },
+};
+
+export const WithIcon: Story = {
+  render: () => (
+    <DSButton variant="solid" size="medium">
+      <Play size={20} />
+      시작하기
+    </DSButton>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <DSButton variant="solid" size="medium" disabled>
+      <Loader size={20} className="animate-spin" />
+      처리 중...
+    </DSButton>
+  ),
+};

--- a/src/shared/ui/ds-button/ds-button.tsx
+++ b/src/shared/ui/ds-button/ds-button.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import { Button, buttonVariants, cn } from '@/shared';
-import { DSButtonProps } from '@/shared/ui/ds-button';
+import { Button } from '@/shared/lib/primitives/button';
+import { cn } from '@/shared/utils';
+import { buttonVariants } from './button.variable';
+import type { DSButtonProps } from './types';
 
 export const DSButton = ({ children, variant, size, className, ref, ...props }: DSButtonProps) => {
   return (

--- a/src/shared/ui/ds-button/types.ts
+++ b/src/shared/ui/ds-button/types.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ButtonProps } from '@/shared';
-import { buttonVariants } from '@/shared/ui/ds-button/button.variable';
+import { type ButtonProps } from '@/shared/lib/primitives/button';
+import { buttonVariants } from './button.variable';
 import { type VariantProps } from 'class-variance-authority';
 
 // ------------------------------------------------------------------

--- a/src/shared/ui/ds-form-field/ds-form-field.stories.tsx
+++ b/src/shared/ui/ds-form-field/ds-form-field.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DsFormField } from './ds-form-field';
+import { DsInput } from '../ds-input/ds-input';
+
+const meta: Meta<typeof DsFormField.Root> = {
+  title: 'Design System/DSFormField',
+  component: DsFormField.Root,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ width: '320px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <DsFormField.Root>
+      <DsFormField.Label>이메일</DsFormField.Label>
+      <DsFormField.Control>
+        <DsInput placeholder="이메일을 입력하세요" />
+      </DsFormField.Control>
+    </DsFormField.Root>
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <DsFormField.Root error={{ message: '올바른 이메일 형식이 아닙니다.' }}>
+      <DsFormField.Label>이메일</DsFormField.Label>
+      <DsFormField.Control>
+        <DsInput variant="error" placeholder="이메일을 입력하세요" />
+      </DsFormField.Control>
+      <DsFormField.Message>올바른 이메일 형식이 아닙니다.</DsFormField.Message>
+    </DsFormField.Root>
+  ),
+};
+
+export const WithSrOnlyLabel: Story = {
+  render: () => (
+    <DsFormField.Root>
+      <DsFormField.Label srOnly>검색</DsFormField.Label>
+      <DsFormField.Control>
+        <DsInput placeholder="검색어를 입력하세요" />
+      </DsFormField.Control>
+    </DsFormField.Root>
+  ),
+};

--- a/src/shared/ui/ds-form-field/ds-form-field.tsx
+++ b/src/shared/ui/ds-form-field/ds-form-field.tsx
@@ -1,6 +1,11 @@
 import React, { ComponentProps, ReactNode } from 'react';
 
-import { FormField, FormFieldError, cn, useFormField } from '@/shared';
+import {
+  FormField,
+  useFormField,
+  type FormFieldError,
+} from '@/shared/lib/primitives/form-field';
+import { cn } from '@/shared/utils';
 import { CircleAlert } from 'lucide-react';
 
 interface DsFormFieldProps extends ComponentProps<typeof FormField.Root> {

--- a/src/shared/ui/ds-input/ds-input.stories.tsx
+++ b/src/shared/ui/ds-input/ds-input.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DsInput } from './ds-input';
+
+const meta: Meta<typeof DsInput> = {
+  title: 'Design System/DSInput',
+  component: DsInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'completed', 'disabled', 'error'],
+      description: '인풋의 상태 변형을 지정합니다.',
+    },
+    uiSize: {
+      control: 'select',
+      options: ['medium'],
+      description: '인풋의 크기를 지정합니다.',
+    },
+    placeholder: {
+      control: 'text',
+      description: '플레이스홀더 텍스트를 지정합니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '인풋을 비활성화합니다.',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '320px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    variant: 'default',
+    uiSize: 'medium',
+    placeholder: '텍스트를 입력하세요',
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    variant: 'completed',
+    uiSize: 'medium',
+    defaultValue: '입력 완료된 텍스트',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    variant: 'disabled',
+    uiSize: 'medium',
+    placeholder: '비활성화됨',
+    disabled: true,
+  },
+};
+
+export const Error: Story = {
+  args: {
+    variant: 'error',
+    uiSize: 'medium',
+    placeholder: '잘못된 입력',
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', width: '320px' }}>
+      <DsInput variant="default" placeholder="Default" />
+      <DsInput variant="completed" defaultValue="Completed" />
+      <DsInput variant="disabled" placeholder="Disabled" disabled />
+      <DsInput variant="error" placeholder="Error" />
+    </div>
+  ),
+};

--- a/src/shared/ui/ds-input/ds-input.tsx
+++ b/src/shared/ui/ds-input/ds-input.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Input, type InputProps } from '@/shared';
-import { dsInputVariants } from '@/shared/ui/ds-input/input.variable';
-import type { DsInputSize, DsInputVariant } from '@/shared/ui/ds-input/types';
+import { Input, type InputProps } from '@/shared/lib/primitives/input';
+import { dsInputVariants } from './input.variable';
+import type { DsInputSize, DsInputVariant } from './types';
 
 interface DsInputProps extends InputProps {
   variant?: DsInputVariant;

--- a/src/shared/ui/logo/logo.stories.tsx
+++ b/src/shared/ui/logo/logo.stories.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Logo } from './logo';
+
+const meta: Meta<typeof Logo> = {
+  title: 'Design System/Logo',
+  component: Logo,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    width: {
+      control: 'number',
+      description: '로고의 너비를 지정합니다.',
+    },
+    height: {
+      control: 'number',
+      description: '로고의 높이를 지정합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Small: Story = {
+  args: {
+    width: 60,
+    height: 14,
+  },
+};
+
+export const Large: Story = {
+  args: {
+    width: 150,
+    height: 36,
+  },
+};
+
+export const SizeComparison: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', alignItems: 'flex-start' }}>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '12px', color: '#666' }}>Small (60x14)</p>
+        <Logo width={60} height={14} />
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '12px', color: '#666' }}>Default (97x23)</p>
+        <Logo />
+      </div>
+      <div>
+        <p style={{ marginBottom: '8px', fontSize: '12px', color: '#666' }}>Large (150x36)</p>
+        <Logo width={150} height={36} />
+      </div>
+    </div>
+  ),
+};
+
+export const OnDarkBackground: Story = {
+  render: () => (
+    <div style={{ backgroundColor: '#1a1a1a', padding: '24px', borderRadius: '8px' }}>
+      <Logo />
+    </div>
+  ),
+};

--- a/src/shared/ui/sh-pie-chart/sh-pie-chart.stories.tsx
+++ b/src/shared/ui/sh-pie-chart/sh-pie-chart.stories.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { DonutChart } from './sh-pie-chart';
+
+const meta: Meta<typeof DonutChart> = {
+  title: 'Design System/DonutChart',
+  component: DonutChart,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['donut', 'pie'],
+      description: '차트의 형태를 지정합니다.',
+    },
+    showLabel: {
+      control: 'boolean',
+      description: '중앙에 레이블을 표시합니다.',
+    },
+    showTooltip: {
+      control: 'boolean',
+      description: '툴팁을 표시합니다.',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const testStatusData = [
+  { status: 'Pass', count: 45 },
+  { status: 'Fail', count: 12 },
+  { status: 'Skip', count: 8 },
+  { status: 'Pending', count: 5 },
+];
+
+const valueFormatter = (value: number) => `${value}개`;
+
+export const Default: Story = {
+  args: {
+    data: testStatusData,
+    category: 'status',
+    value: 'count',
+    variant: 'donut',
+    showTooltip: true,
+    valueFormatter,
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    data: testStatusData,
+    category: 'status',
+    value: 'count',
+    variant: 'donut',
+    showLabel: true,
+    label: '70개',
+    valueFormatter,
+  },
+};
+
+export const PieVariant: Story = {
+  args: {
+    data: testStatusData,
+    category: 'status',
+    value: 'count',
+    variant: 'pie',
+    showTooltip: true,
+    valueFormatter,
+  },
+};
+
+export const CustomColors: Story = {
+  args: {
+    data: testStatusData,
+    category: 'status',
+    value: 'count',
+    variant: 'donut',
+    colors: ['emerald', 'rose', 'amber', 'slate'],
+    valueFormatter,
+  },
+};
+
+export const LargeSize: Story = {
+  args: {
+    data: testStatusData,
+    category: 'status',
+    value: 'count',
+    variant: 'donut',
+    showLabel: true,
+    className: 'h-64 w-64',
+    valueFormatter,
+  },
+};

--- a/src/shared/ui/sh-pie-chart/sh-pie-chart.tsx
+++ b/src/shared/ui/sh-pie-chart/sh-pie-chart.tsx
@@ -8,7 +8,7 @@ import {
   cn,
   constructCategoryColors,
   getColorClassName,
-} from '@/shared';
+} from '@/shared/utils';
 import {
   Pie,
   PieChart as ReChartsDonutChart,


### PR DESCRIPTION
## Summary
- 공용 UI 컴포넌트(shared/ui, primitives)에 Storybook 스토리 추가
- Storybook 실행 시 발생하던 순환 참조(circular dependency) 오류 수정

## Changes

### 새로운 스토리 추가

**shared/ui:**
| 컴포넌트 | 스토리 |
|---------|--------|
| DSButton | Solid, Ghost, Text, Sizes, AllVariants, Disabled, WithIcon, Loading |
| DSInput | Default, Completed, Disabled, Error, AllVariants |
| DSFormField | Default, WithError, WithSrOnlyLabel |
| Logo | Default, Small, Large, SizeComparison, OnDarkBackground |
| DonutChart | Default, WithLabel, CustomColors, PieVariant, Interactive |
| DsCheckbox | Default, Checked, Disabled, CheckedDisabled, WithLabel |

**primitives:**
| 컴포넌트 | 스토리 |
|---------|--------|
| Container | Default, Sizes, Centered, CustomPadding |
| Grid | Default, ThreeColumns, FourColumns, ResponsiveGrid |
| MainContainer | Default, WithPadding, FullHeight |

### 순환 참조 수정
`@/shared` barrel export로 인한 순환 참조 문제를 직접 경로 import로 수정:
- `ds-form-field.tsx` → `@/shared/lib/primitives/form-field`, `@/shared/utils`
- `ds-button.tsx` → `@/shared/lib/primitives/button`, `@/shared/utils`
- `ds-input.tsx` → `@/shared/lib/primitives/input`
- `ds-checkbox.tsx` → `@/shared/utils`
- `sh-pie-chart.tsx` → `@/shared/utils`
- `ds-button/types.ts` → `@/shared/lib/primitives/button`

### 파일 변경
- `checkbox.tsx` → `ds-checkbox.tsx` 이름 변경 및 네이밍 통일

## Test plan
- [ ] `npm run storybook` 실행하여 모든 스토리가 정상 로드되는지 확인
- [ ] 각 컴포넌트 스토리의 Controls 패널에서 props 변경 테스트
- [ ] autodocs 페이지가 정상 생성되는지 확인
