### PR TITLE
Test: 서버 액션 테스트 커버리지 확대 및 누락 테스트 케이스 보완

### DIFF
--- a/src/entities/milestone/api/create-milestone-action.test.ts
+++ b/src/entities/milestone/api/create-milestone-action.test.ts
@@ -5,8 +5,8 @@ import { createMilestone } from './server-actions';
 
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
-  getDatabase: () => (mockGetDatabase as any)(),
-  milestones: { id: 'id', project_id: 'project_id', name: 'name' },
+  getDatabase: mockGetDatabase,
+  milestones: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 // uuid 모킹
@@ -45,9 +45,9 @@ describe('createMilestone', () => {
           projectId: mockRow.project_id,
           title: mockRow.name,
           description: mockRow.description,
-          startDate: mockRow.start_date,
-          endDate: mockRow.end_date,
-          status: mockRow.progress_status,
+          startDate: new Date(mockRow.start_date!),
+          endDate: new Date(mockRow.end_date!),
+          progressStatus: mockRow.progress_status,
           createdAt: mockRow.created_at,
           updatedAt: mockRow.updated_at,
           archivedAt: mockRow.archived_at,

--- a/src/entities/milestone/api/delete-milestone-action.test.ts
+++ b/src/entities/milestone/api/delete-milestone-action.test.ts
@@ -7,8 +7,8 @@ import {
 } from '@/shared/test/__mocks__/db';
 
 vi.mock('@/shared/lib/db', () => ({
-  getDatabase: () => mockGetDatabase,
-  milestones: { id: 'id', deleted_at: 'deleted_at' },
+  getDatabase: mockGetDatabase,
+  milestones: { id: 'id', archived_at: 'archived_at', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { deleteMilestone } from './server-actions';
@@ -31,7 +31,7 @@ describe('deleteMilestone', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.id).toBe(mockRow.id);
-      expect(result.message).toBe('마일스톤이 삭제되었습니다.');
+      expect(result.message).toBe('마일스톤이 성공적으로 삭제되었습니다.');
     }
   });
 
@@ -42,7 +42,7 @@ describe('deleteMilestone', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors._milestone).toContain('마일스톤 삭제에 실패했습니다.');
+      expect(result.errors._milestone).toContain('마일스톤 아카이브에 실패했습니다.');
     }
   });
 });

--- a/src/entities/milestone/api/get-milestones-action.test.ts
+++ b/src/entities/milestone/api/get-milestones-action.test.ts
@@ -9,8 +9,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getMilestoneById, getMilestones } from './server-actions';
 
 vi.mock('@/shared/lib/db', () => ({
-  getDatabase: () => mockGetDatabase,
-  milestones: { id: 'id', project_id: 'project_id' },
+  getDatabase: mockGetDatabase,
+  milestones: { id: 'id', project_id: 'project_id', lifecycle_status: 'lifecycle_status' },
 }));
 
 describe('getMilestones', () => {

--- a/src/entities/milestone/api/update-milestone-action.test.ts
+++ b/src/entities/milestone/api/update-milestone-action.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createMockMilestoneRow,
+  mockDb,
   mockGetDatabase,
   resetMockDb,
   setMockUpdateReturn,
@@ -44,5 +45,20 @@ describe('updateMilestone', () => {
     if (!result.success) {
       expect(result.errors._milestone).toContain('마일스톤 수정에 실패했습니다.');
     }
+  });
+
+  it('DB 에러 발생 시 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockDb.update.mockImplementationOnce(() => {
+      throw new Error('DB Error');
+    });
+
+    const result = await updateMilestone('any-id', { title: 'New Name' });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._milestone).toContain('마일스톤을 수정하는 도중 오류가 발생했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/entities/project/api/get-project.test.ts
+++ b/src/entities/project/api/get-project.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Custom mock for this test file - supports the exact chain pattern used in server-actions
+let mockSelectResult: unknown[] = [];
+
+const mockLimit = vi.fn(() => Promise.resolve(mockSelectResult));
+const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+const mockDb = {
+  select: mockSelect,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  projects: {
+    id: 'id',
+    name: 'name',
+    identifier: 'identifier',
+    description: 'description',
+    owner_name: 'owner_name',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a, b) => ({ field: a, value: b })),
+}));
+
+import { getProjectById, getProjectByName } from './server-actions';
+
+const createMockProjectRow = (overrides: Partial<{
+  id: string;
+  name: string;
+  identifier: string;
+  description: string | null;
+  owner_name: string | null;
+}> = {}) => ({
+  id: overrides.id ?? 'project-123',
+  name: overrides.name ?? '테스트 프로젝트',
+  identifier: overrides.identifier ?? 'TPJ',
+  description: 'description' in overrides ? overrides.description : '테스트 설명',
+  owner_name: 'owner_name' in overrides ? overrides.owner_name : '관리자',
+});
+
+describe('getProjectByName', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectResult = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('프로젝트명으로 조회 성공 시 프로젝트 정보를 반환한다', async () => {
+    const mockProject = createMockProjectRow({
+      id: 'proj-123',
+      name: 'Test Project',
+      identifier: 'TP',
+      description: '테스트 설명',
+      owner_name: '홍길동',
+    });
+    mockSelectResult = [mockProject];
+
+    const result = await getProjectByName('Test Project');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('proj-123');
+      expect(result.data.projectName).toBe('Test Project');
+      expect(result.data.identifier).toBe('TP');
+      expect(result.data.description).toBe('테스트 설명');
+      expect(result.data.ownerName).toBe('홍길동');
+    }
+  });
+
+  it('description과 owner_name이 null이면 undefined로 변환된다', async () => {
+    const mockProject = createMockProjectRow({
+      id: 'proj-123',
+      name: 'Test Project',
+      description: null,
+      owner_name: null,
+    });
+    mockSelectResult = [mockProject];
+
+    const result = await getProjectByName('Test Project');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBeUndefined();
+      expect(result.data.ownerName).toBeUndefined();
+    }
+  });
+
+  it('프로젝트가 존재하지 않으면 에러를 반환한다', async () => {
+    mockSelectResult = [];
+
+    const result = await getProjectByName('NonExistent');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._project).toContain('프로젝트를 찾을 수 없습니다.');
+    }
+  });
+
+  it('DB 에러 발생 시 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockSelect.mockImplementationOnce(() => {
+      throw new Error('DB Error');
+    });
+
+    const result = await getProjectByName('Test');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._project).toContain('프로젝트를 불러오는 도중 오류가 발생했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('getProjectById', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSelectResult = [];
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('ID로 조회 성공 시 프로젝트 정보를 반환한다', async () => {
+    const mockProject = createMockProjectRow({
+      id: 'proj-456',
+      name: 'Another Project',
+      identifier: 'AP',
+      description: '다른 프로젝트',
+      owner_name: '김철수',
+    });
+    mockSelectResult = [mockProject];
+
+    const result = await getProjectById('proj-456');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('proj-456');
+      expect(result.data.projectName).toBe('Another Project');
+      expect(result.data.identifier).toBe('AP');
+      expect(result.data.description).toBe('다른 프로젝트');
+      expect(result.data.ownerName).toBe('김철수');
+    }
+  });
+
+  it('description과 owner_name이 null이면 undefined로 변환된다', async () => {
+    const mockProject = createMockProjectRow({
+      id: 'proj-456',
+      name: 'Another Project',
+      description: null,
+      owner_name: null,
+    });
+    mockSelectResult = [mockProject];
+
+    const result = await getProjectById('proj-456');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.description).toBeUndefined();
+      expect(result.data.ownerName).toBeUndefined();
+    }
+  });
+
+  it('프로젝트가 존재하지 않으면 에러를 반환한다', async () => {
+    mockSelectResult = [];
+
+    const result = await getProjectById('non-existent-id');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._project).toContain('프로젝트를 찾을 수 없습니다.');
+    }
+  });
+
+  it('DB 에러 발생 시 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockSelect.mockImplementationOnce(() => {
+      throw new Error('DB Error');
+    });
+
+    const result = await getProjectById('proj-123');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._project).toContain('프로젝트를 불러오는 도중 오류가 발생했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/entities/test-case/api/create-case-action.test.ts
+++ b/src/entities/test-case/api/create-case-action.test.ts
@@ -43,9 +43,11 @@ describe('createTestCase', () => {
     steps: '테스트 스텝',
     expected_result: '기대 결과',
     sort_order: 1,
+    result_status: 'untested',
     created_at: new Date('2024-01-01T00:00:00Z'),
     updated_at: new Date('2024-01-01T00:00:00Z'),
-    deleted_at: null,
+    archived_at: null,
+    lifecycle_status: 'ACTIVE',
   };
 
   beforeEach(() => {
@@ -72,9 +74,11 @@ describe('createTestCase', () => {
         testSteps: '테스트 스텝',
         expectedResult: '기대 결과',
         sortOrder: 1,
+        resultStatus: 'untested',
         createdAt: new Date('2024-01-01T00:00:00Z'),
         updatedAt: new Date('2024-01-01T00:00:00Z'),
-        deletedAt: null,
+        archivedAt: null,
+        lifecycleStatus: 'ACTIVE',
       });
     }
     expect(mockInsert).toHaveBeenCalled();

--- a/src/entities/test-case/api/server-actions.test.ts
+++ b/src/entities/test-case/api/server-actions.test.ts
@@ -10,7 +10,7 @@ const mockDb = { select: mockSelect };
 
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: vi.fn(() => mockDb),
-  testCase: { project_id: 'project_id' },
+  testCases: { project_id: 'project_id', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { getTestCases } from './server-actions';
@@ -34,9 +34,11 @@ describe('getTestCases', () => {
         steps: '1. 로그인 페이지 접속\n2. 아이디/비밀번호 입력',
         expected_result: '로그인 성공',
         sort_order: 1,
+        result_status: 'untested',
         created_at: new Date('2024-01-01'),
         updated_at: new Date('2024-01-02'),
-        deleted_at: null,
+        archived_at: null,
+        lifecycle_status: 'ACTIVE',
       },
     ];
 
@@ -50,7 +52,6 @@ describe('getTestCases', () => {
       expect(result.data[0]).toEqual({
         id: 'tc-1',
         projectId: 'proj-1',
-        testSuiteId: 'suite-1',
         caseKey: 'TC-001',
         title: '로그인 테스트',
         testType: 'functional',
@@ -59,9 +60,11 @@ describe('getTestCases', () => {
         testSteps: '1. 로그인 페이지 접속\n2. 아이디/비밀번호 입력',
         expectedResult: '로그인 성공',
         sortOrder: 1,
+        resultStatus: 'untested',
         createdAt: new Date('2024-01-01'),
         updatedAt: new Date('2024-01-02'),
-        deletedAt: null,
+        archivedAt: null,
+        lifecycleStatus: 'ACTIVE',
       });
     }
 
@@ -96,7 +99,7 @@ describe('getTestCases', () => {
     const mockRows = [
       {
         id: 'tc-2',
-        project_id: null,
+        project_id: 'proj-1',
         test_suite_id: null,
         case_key: null,
         name: '테스트',
@@ -106,9 +109,11 @@ describe('getTestCases', () => {
         steps: null,
         expected_result: null,
         sort_order: null,
+        result_status: 'untested',
         created_at: new Date(),
         updated_at: new Date(),
-        deleted_at: null,
+        archived_at: null,
+        lifecycle_status: 'ACTIVE',
       },
     ];
 
@@ -118,8 +123,7 @@ describe('getTestCases', () => {
 
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data[0].projectId).toBe('');
-      expect(result.data[0].testSuiteId).toBe('');
+      expect(result.data[0].projectId).toBe('proj-1');
       expect(result.data[0].caseKey).toBe('');
       expect(result.data[0].testType).toBe('');
       expect(result.data[0].tags).toEqual([]);

--- a/src/entities/test-case/api/update-case-action.test.ts
+++ b/src/entities/test-case/api/update-case-action.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// Mock for update chain
+const mockReturning = vi.fn();
+const mockWhere = vi.fn(() => ({ returning: mockReturning }));
+const mockSet = vi.fn(() => ({ where: mockWhere }));
+const mockUpdate = vi.fn(() => ({ set: mockSet }));
+
+const mockDb = {
+  update: mockUpdate,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  testCases: {
+    id: 'id',
+    name: 'name',
+    test_type: 'test_type',
+    tags: 'tags',
+    pre_condition: 'pre_condition',
+    steps: 'steps',
+    expected_result: 'expected_result',
+    sort_order: 'sort_order',
+    updated_at: 'updated_at',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a, b) => ({ field: a, value: b })),
+}));
+
+import { updateTestCase } from './server-actions';
+
+describe('updateTestCase', () => {
+  const mockUpdatedRow = {
+    id: 'tc-123',
+    project_id: 'proj-1',
+    case_key: 'TC-001',
+    name: '수정된 테스트',
+    test_type: 'functional',
+    tags: ['tag1', 'tag2'],
+    pre_condition: '사전 조건',
+    steps: '1. 스텝 1\n2. 스텝 2',
+    expected_result: '기대 결과',
+    sort_order: 1,
+    result_status: 'untested',
+    created_at: new Date('2024-01-01'),
+    updated_at: new Date('2024-01-02'),
+    archived_at: null,
+    lifecycle_status: 'ACTIVE',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReturning.mockResolvedValue([mockUpdatedRow]);
+  });
+
+  it('테스트 케이스 수정 성공 시 수정된 데이터를 반환한다', async () => {
+    const result = await updateTestCase({
+      id: 'tc-123',
+      title: '수정된 테스트',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('tc-123');
+      expect(result.data.title).toBe('수정된 테스트');
+      expect(result.message).toBe('테스트케이스를 수정하였습니다.');
+    }
+    expect(mockUpdate).toHaveBeenCalled();
+    expect(mockSet).toHaveBeenCalled();
+    expect(mockWhere).toHaveBeenCalled();
+    expect(mockReturning).toHaveBeenCalled();
+  });
+
+  it('title 필드만 업데이트할 수 있다', async () => {
+    await updateTestCase({
+      id: 'tc-123',
+      title: '새 제목',
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '새 제목',
+      })
+    );
+  });
+
+  it('testType 필드를 업데이트할 수 있다', async () => {
+    await updateTestCase({
+      id: 'tc-123',
+      testType: 'regression',
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        test_type: 'regression',
+      })
+    );
+  });
+
+  it('tags 필드를 업데이트할 수 있다', async () => {
+    await updateTestCase({
+      id: 'tc-123',
+      tags: ['새태그1', '새태그2'],
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: ['새태그1', '새태그2'],
+      })
+    );
+  });
+
+  it('여러 필드를 동시에 업데이트할 수 있다', async () => {
+    await updateTestCase({
+      id: 'tc-123',
+      title: '새 제목',
+      testType: 'integration',
+      preCondition: '새 사전조건',
+      testSteps: '새 스텝',
+      expectedResult: '새 결과',
+      sortOrder: 5,
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: '새 제목',
+        test_type: 'integration',
+        pre_condition: '새 사전조건',
+        steps: '새 스텝',
+        expected_result: '새 결과',
+        sort_order: 5,
+      })
+    );
+  });
+
+  it('업데이트 시 항상 updated_at이 설정된다', async () => {
+    await updateTestCase({
+      id: 'tc-123',
+      title: '새 제목',
+    });
+
+    expect(mockSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        updated_at: expect.any(Date),
+      })
+    );
+  });
+
+  it('테스트 케이스가 존재하지 않으면 에러를 반환한다', async () => {
+    mockReturning.mockResolvedValue([]);
+
+    const result = await updateTestCase({
+      id: 'non-existent',
+      title: '새 제목',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._testCase).toContain('테스트케이스를 찾을 수 없습니다.');
+    }
+  });
+
+  it('DB 에러 발생 시 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockReturning.mockRejectedValue(new Error('DB Error'));
+
+    const result = await updateTestCase({
+      id: 'tc-123',
+      title: '새 제목',
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._testCase).toContain('테스트케이스를 수정하는 도중 오류가 발생했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/entities/test-suite/api/create-suite-action.test.ts
+++ b/src/entities/test-suite/api/create-suite-action.test.ts
@@ -15,7 +15,7 @@ import { createTestSuite } from './server-actions';
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: mockGetDatabase,
-  testSuite: { id: 'id', project_id: 'project_id', name: 'name' },
+  testSuites: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 // uuid 모킹

--- a/src/entities/test-suite/api/delete-suite-action.test.ts
+++ b/src/entities/test-suite/api/delete-suite-action.test.ts
@@ -9,7 +9,7 @@ import {
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: mockGetDatabase,
-  testSuite: { id: 'id', project_id: 'project_id', name: 'name' },
+  testSuites: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { deleteTestSuite } from './server-actions';
@@ -36,7 +36,7 @@ describe('deleteTestSuite', () => {
       expect(result.success).toBe(true);
       if (result.success) {
         expect(result.data.id).toBe('suite-123');
-        expect(result.message).toBe('테스트 스위트를 삭제하였습니다.');
+        expect(result.message).toBe('테스트 스위트를 아카이브하였습니다.');
       }
     });
 
@@ -74,7 +74,7 @@ describe('deleteTestSuite', () => {
 
       expect(result.success).toBe(false);
       if (!result.success) {
-        expect(result.errors._testSuite).toContain('테스트 스위트를 삭제하는 도중 오류가 발생했습니다.');
+        expect(result.errors._testSuite).toContain('테스트 스위트를 아카이브하는 도중 오류가 발생했습니다.');
       }
     });
   });

--- a/src/entities/test-suite/api/get-suite-by-id-action.test.ts
+++ b/src/entities/test-suite/api/get-suite-by-id-action.test.ts
@@ -9,7 +9,7 @@ import {
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: mockGetDatabase,
-  testSuite: { id: 'id', project_id: 'project_id', name: 'name' },
+  testSuites: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { getTestSuiteById } from './server-actions';
@@ -61,7 +61,8 @@ describe('getTestSuiteById', () => {
           sortOrder: 10,
           createdAt: new Date('2024-02-01'),
           updatedAt: new Date('2024-02-02'),
-          deletedAt: null,
+          archivedAt: null,
+          lifecycleStatus: 'ACTIVE',
         });
       }
     });

--- a/src/entities/test-suite/api/get-suites-action.test.ts
+++ b/src/entities/test-suite/api/get-suites-action.test.ts
@@ -9,7 +9,7 @@ import {
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: mockGetDatabase,
-  testSuite: { id: 'id', project_id: 'project_id', name: 'name' },
+  testSuites: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { getTestSuites } from './server-actions';
@@ -98,7 +98,8 @@ describe('getTestSuites', () => {
         expect(suite.sortOrder).toBe(5);
         expect(suite.createdAt).toEqual(new Date('2024-01-15'));
         expect(suite.updatedAt).toEqual(new Date('2024-01-16'));
-        expect(suite.deletedAt).toBeNull();
+        expect(suite.archivedAt).toBeNull();
+        expect(suite.lifecycleStatus).toBe('ACTIVE');
       }
     });
   });

--- a/src/entities/test-suite/api/update-suite-action.test.ts
+++ b/src/entities/test-suite/api/update-suite-action.test.ts
@@ -9,7 +9,7 @@ import {
 // DB 모듈 모킹
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: mockGetDatabase,
-  testSuite: { id: 'id', project_id: 'project_id', name: 'name' },
+  testSuites: { id: 'id', project_id: 'project_id', name: 'name', lifecycle_status: 'lifecycle_status' },
 }));
 
 import { updateTestSuite } from './server-actions';
@@ -131,7 +131,8 @@ describe('updateTestSuite', () => {
           sortOrder: 15,
           createdAt: new Date('2024-01-01'),
           updatedAt: new Date('2024-03-01'),
-          deletedAt: null,
+          archivedAt: null,
+          lifecycleStatus: 'ACTIVE',
         });
       }
     });

--- a/src/features/dashboard/api/get-dashboard-stats.test.ts
+++ b/src/features/dashboard/api/get-dashboard-stats.test.ts
@@ -2,32 +2,73 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('server-only', () => ({}));
 
-// DB 모킹
-const mockLimit = vi.fn();
-const mockWhere = vi.fn(() => ({ limit: mockLimit }));
-const mockFrom = vi.fn(() => ({ where: mockWhere }));
-const mockSelect = vi.fn(() => ({ from: mockFrom }));
+// 각 쿼리별 결과를 저장
+let queryResults: Map<string, unknown[]> = new Map();
+let callOrder: string[] = [];
 
-const mockGroupBy = vi.fn();
-const mockLeftJoinWhere = vi.fn(() => ({ groupBy: mockGroupBy }));
-const mockLeftJoin = vi.fn(() => ({ where: mockLeftJoinWhere }));
-const mockFromJoin = vi.fn(() => ({ leftJoin: mockLeftJoin }));
-const mockSelectJoin = vi.fn(() => ({ from: mockFromJoin }));
+// 각 select()마다 새로운 체인 생성
+const createQueryChain = (queryId: string) => {
+  callOrder.push(queryId);
 
-const mockOrderBy = vi.fn(() => ({ limit: vi.fn() }));
-const mockWhereOrder = vi.fn(() => ({ orderBy: mockOrderBy }));
-const mockFromOrder = vi.fn(() => ({ where: mockWhereOrder }));
-const mockSelectOrder = vi.fn(() => ({ from: mockFromOrder }));
+  const getResult = () => {
+    const results = queryResults.get(queryId) ?? [];
+    return Promise.resolve(results);
+  };
 
-const mockDb = {
-  select: vi.fn(),
+  const chain: any = {
+    select: vi.fn(() => chain),
+    from: vi.fn((table) => {
+      // from 호출 시 테이블 정보 기록
+      return chain;
+    }),
+    where: vi.fn(() => chain),
+    limit: vi.fn(() => chain),
+    offset: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    then: (resolve: (value: unknown) => void, reject?: (reason: unknown) => void) =>
+      getResult().then(resolve, reject),
+    catch: (reject: (reason: unknown) => void) => getResult().catch(reject),
+    finally: (callback: () => void) => getResult().finally(callback),
+  };
+
+  return chain;
 };
+
+let selectCallCount = 0;
+const mockSelect = vi.fn(() => {
+  const queryId = `query_${selectCallCount++}`;
+  return createQueryChain(queryId);
+});
+
+const mockDb = { select: mockSelect };
 
 vi.mock('@/shared/lib/db', () => ({
   getDatabase: vi.fn(() => mockDb),
-  project: { id: 'id', name: 'name' },
-  suite: { id: 'id', name: 'name', project_id: 'project_id' },
-  testCase: { id: 'id', name: 'name', project_id: 'project_id', test_suite_id: 'test_suite_id' },
+  projects: {
+    id: 'id',
+    name: 'name',
+    identifier: 'identifier',
+    description: 'description',
+    owner_name: 'owner_name',
+    created_at: 'created_at',
+  },
+  testSuites: {
+    id: 'id',
+    name: 'name',
+    project_id: 'project_id',
+    description: 'description',
+    created_at: 'created_at',
+  },
+  testCases: {
+    id: 'id',
+    name: 'name',
+    project_id: 'project_id',
+    created_at: 'created_at',
+  },
+  suiteTestCases: {
+    suite_id: 'suite_id',
+    test_case_id: 'test_case_id',
+  },
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -35,6 +76,8 @@ vi.mock('drizzle-orm', () => ({
   count: vi.fn(() => 'count'),
   desc: vi.fn((field) => ({ desc: field })),
   isNull: vi.fn((field) => ({ isNull: field })),
+  and: vi.fn((...conditions) => ({ and: conditions })),
+  notInArray: vi.fn((field, values) => ({ notInArray: { field, values } })),
 }));
 
 import { getDashboardStats } from './get-dashboard-stats';
@@ -42,6 +85,9 @@ import { getDashboardStats } from './get-dashboard-stats';
 describe('getDashboardStats', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    queryResults = new Map();
+    callOrder = [];
+    selectCallCount = 0;
   });
 
   it('프로젝트가 존재하면 대시보드 통계를 반환한다', async () => {
@@ -54,72 +100,25 @@ describe('getDashboardStats', () => {
       created_at: new Date('2024-01-01'),
     };
 
-    const mockTestCaseCount = { count: 10 };
-    const mockSuites = [
-      { id: 'suite-1', name: 'Suite 1', description: 'Desc 1', caseCount: 5 },
-      { id: 'suite-2', name: 'Suite 2', description: null, caseCount: 3 },
-    ];
-    const mockRecentCases = [
-      { id: 'tc-1', title: 'Test Case 1', createdAt: new Date('2024-01-05') },
-    ];
-    const mockRecentSuites = [
-      { id: 'suite-1', title: 'Suite 1', createdAt: new Date('2024-01-03') },
-    ];
-
-    let callCount = 0;
-    mockDb.select.mockImplementation(() => {
-      callCount++;
-      if (callCount === 1) {
-        // 프로젝트 조회
-        return {
-          from: vi.fn(() => ({
-            where: vi.fn(() => ({
-              limit: vi.fn().mockResolvedValue([mockProject]),
-            })),
-          })),
-        };
-      } else if (callCount === 2) {
-        // 테스트 케이스 카운트
-        return {
-          from: vi.fn(() => ({
-            where: vi.fn().mockResolvedValue([mockTestCaseCount]),
-          })),
-        };
-      } else if (callCount === 3) {
-        // 스위트 목록
-        return {
-          from: vi.fn(() => ({
-            leftJoin: vi.fn(() => ({
-              where: vi.fn(() => ({
-                groupBy: vi.fn().mockResolvedValue(mockSuites),
-              })),
-            })),
-          })),
-        };
-      } else if (callCount === 4) {
-        // 최근 테스트 케이스
-        return {
-          from: vi.fn(() => ({
-            where: vi.fn(() => ({
-              orderBy: vi.fn(() => ({
-                limit: vi.fn().mockResolvedValue(mockRecentCases),
-              })),
-            })),
-          })),
-        };
-      } else {
-        // 최근 스위트
-        return {
-          from: vi.fn(() => ({
-            where: vi.fn(() => ({
-              orderBy: vi.fn(() => ({
-                limit: vi.fn().mockResolvedValue(mockRecentSuites),
-              })),
-            })),
-          })),
-        };
-      }
-    });
+    // 쿼리 순서: 0=project, 1=testCaseCount, 2=subquery, 3=unassignedCount,
+    // 4=suiteRows, 5=suiteCaseCount(for suite-1), 6=suiteCaseCount(for suite-2),
+    // 7=recentTestCases, 8=recentSuites
+    queryResults.set('query_0', [mockProject]);
+    queryResults.set('query_1', [{ count: 10 }]);
+    queryResults.set('query_2', []); // subquery
+    queryResults.set('query_3', [{ count: 2 }]);
+    queryResults.set('query_4', [
+      { id: 'suite-1', name: 'Suite 1', description: 'Desc 1' },
+      { id: 'suite-2', name: 'Suite 2', description: null },
+    ]);
+    queryResults.set('query_5', [{ count: 5 }]);
+    queryResults.set('query_6', [{ count: 3 }]);
+    queryResults.set('query_7', [
+      { id: 'tc-1', title: 'Test Case 1', created_at: new Date('2024-01-05') },
+    ]);
+    queryResults.set('query_8', [
+      { id: 'suite-1', title: 'Suite 1', created_at: new Date('2024-01-03') },
+    ]);
 
     const result = await getDashboardStats({ slug: 'proj-1' });
 
@@ -128,20 +127,16 @@ describe('getDashboardStats', () => {
       expect(result.data.project.id).toBe('proj-1');
       expect(result.data.project.name).toBe('Test Project');
       expect(result.data.testCases.total).toBe(10);
+      expect(result.data.testCases.unassigned).toBe(2);
       expect(result.data.testSuites).toHaveLength(2);
       expect(result.data.testSuites[0].case_count).toBe(5);
+      expect(result.data.testSuites[1].case_count).toBe(3);
       expect(result.data.recentActivities).toHaveLength(2);
     }
   });
 
   it('프로젝트가 존재하지 않으면 에러를 반환한다', async () => {
-    mockDb.select.mockImplementation(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn().mockResolvedValue([]),
-        })),
-      })),
-    }));
+    queryResults.set('query_0', []);
 
     const result = await getDashboardStats({ slug: 'non-existent' });
 
@@ -152,13 +147,10 @@ describe('getDashboardStats', () => {
   });
 
   it('DB 에러 발생 시 에러를 반환한다', async () => {
-    mockDb.select.mockImplementation(() => ({
-      from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          limit: vi.fn().mockRejectedValue(new Error('DB Error')),
-        })),
-      })),
-    }));
+    // select를 호출하면 에러를 던지도록 설정
+    mockSelect.mockImplementationOnce(() => {
+      throw new Error('DB Error');
+    });
 
     const result = await getDashboardStats({ slug: 'proj-1' });
 

--- a/src/features/milestones-create/model/server-action.test.ts
+++ b/src/features/milestones-create/model/server-action.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// Insert chain mock
+const mockReturning = vi.fn();
+const mockValues = vi.fn(() => ({ returning: mockReturning }));
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+
+const mockDb = {
+  insert: mockInsert,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  milestones: {
+    id: 'id',
+    project_id: 'project_id',
+    name: 'name',
+    description: 'description',
+    start_date: 'start_date',
+    end_date: 'end_date',
+    progress_status: 'progress_status',
+    lifecycle_status: 'lifecycle_status',
+  },
+}));
+
+import { createMilestoneAction } from './server-action';
+
+describe('createMilestoneAction', () => {
+  const createFormData = (data: Record<string, string | Date | null | undefined>) => {
+    const formData = new Map<string, string>();
+    Object.entries(data).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        formData.set(key, value instanceof Date ? value.toISOString() : String(value));
+      }
+    });
+    return {
+      entries: () => formData.entries(),
+    };
+  };
+
+  const validProjectId = '01932d3e-4567-7890-abcd-ef1234567890';
+
+  const mockCreatedMilestone = {
+    id: 'milestone-123',
+    project_id: validProjectId,
+    name: '테스트 마일스톤',
+    description: '설명',
+    start_date: '2024-01-01',
+    end_date: '2024-12-31',
+    progress_status: 'planned',
+    lifecycle_status: 'ACTIVE',
+    created_at: new Date('2024-01-01'),
+    updated_at: new Date('2024-01-01'),
+    archived_at: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReturning.mockResolvedValue([mockCreatedMilestone]);
+  });
+
+  describe('유효성 검사', () => {
+    it('title이 없으면 유효성 검사 에러를 반환한다', async () => {
+      const formData = createFormData({
+        projectId: validProjectId,
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.title).toBeDefined();
+      }
+    });
+
+    it('title이 빈 문자열이면 유효성 검사 에러를 반환한다', async () => {
+      const formData = createFormData({
+        title: '',
+        projectId: validProjectId,
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.title).toBeDefined();
+      }
+    });
+
+    it('title이 50자를 초과하면 유효성 검사 에러를 반환한다', async () => {
+      const formData = createFormData({
+        title: 'a'.repeat(51),
+        projectId: validProjectId,
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.title).toBeDefined();
+      }
+    });
+
+    it('projectId가 없으면 유효성 검사 에러를 반환한다', async () => {
+      const formData = createFormData({
+        title: '테스트 마일스톤',
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.projectId).toBeDefined();
+      }
+    });
+
+    it('projectId가 유효한 UUID가 아니면 에러를 반환한다', async () => {
+      const formData = createFormData({
+        title: '테스트 마일스톤',
+        projectId: 'invalid-uuid',
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.projectId).toBeDefined();
+      }
+    });
+  });
+
+  describe('마일스톤 생성', () => {
+    it('유효한 데이터로 마일스톤을 성공적으로 생성한다', async () => {
+      const formData = createFormData({
+        title: '테스트 마일스톤',
+        projectId: validProjectId,
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.milestone).toBeDefined();
+        expect(result.milestone[0].id).toBe('milestone-123');
+      }
+      expect(mockInsert).toHaveBeenCalled();
+      expect(mockValues).toHaveBeenCalled();
+      expect(mockReturning).toHaveBeenCalled();
+    });
+
+    it('description이 포함된 마일스톤을 생성할 수 있다', async () => {
+      const formData = createFormData({
+        title: '테스트 마일스톤',
+        projectId: validProjectId,
+        description: '마일스톤 설명입니다',
+      });
+
+      const result = await createMilestoneAction(formData);
+
+      expect(result.success).toBe(true);
+      expect(mockValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: '마일스톤 설명입니다',
+        })
+      );
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('DB 에러 발생 시 에러를 throw한다', async () => {
+      mockReturning.mockRejectedValueOnce(new Error('DB Error'));
+
+      const formData = createFormData({
+        title: '테스트 마일스톤',
+        projectId: validProjectId,
+      });
+
+      await expect(createMilestoneAction(formData)).rejects.toThrow('DB Error');
+    });
+  });
+});

--- a/src/features/project-search/api/server-action.test.ts
+++ b/src/features/project-search/api/server-action.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// Chainable mock
+const mockLimit = vi.fn();
+const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
+const mockWhere = vi.fn(() => ({ orderBy: mockOrderBy }));
+const mockFrom = vi.fn(() => ({ where: mockWhere }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+const mockDb = {
+  select: mockSelect,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  projects: {
+    id: 'id',
+    name: 'name',
+    created_at: 'created_at',
+    owner_name: 'owner_name',
+    lifecycle_status: 'lifecycle_status',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a, b) => ({ field: a, value: b })),
+  ilike: vi.fn((field, pattern) => ({ ilike: { field, pattern } })),
+  and: vi.fn((...conditions) => ({ and: conditions })),
+  desc: vi.fn((field) => ({ desc: field })),
+}));
+
+import { searchProjects } from './server-action';
+
+describe('searchProjects', () => {
+  const mockProjectRows = [
+    {
+      id: 'proj-1',
+      name: 'Test Project',
+      created_at: new Date('2024-01-01T00:00:00Z'),
+      owner_name: '홍길동',
+    },
+    {
+      id: 'proj-2',
+      name: 'Another Test',
+      created_at: new Date('2024-01-02T00:00:00Z'),
+      owner_name: null,
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLimit.mockResolvedValue(mockProjectRows);
+  });
+
+  describe('유효성 검사', () => {
+    it('키워드가 2자 미만이면 에러를 반환한다', async () => {
+      const result = await searchProjects('a');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeDefined();
+      }
+    });
+
+    it('키워드가 50자 초과하면 에러를 반환한다', async () => {
+      const longKeyword = 'a'.repeat(51);
+
+      const result = await searchProjects(longKeyword);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeDefined();
+      }
+    });
+
+    it('허용되지 않는 특수문자가 포함되면 에러를 반환한다', async () => {
+      const result = await searchProjects('test@#$%');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeDefined();
+      }
+    });
+
+    it('빈 문자열은 에러를 반환한다', async () => {
+      const result = await searchProjects('');
+
+      expect(result.success).toBe(false);
+    });
+
+    it('공백만 있으면 에러를 반환한다', async () => {
+      const result = await searchProjects('   ');
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('검색 성공', () => {
+    it('유효한 키워드로 검색하면 프로젝트 목록을 반환한다', async () => {
+      const result = await searchProjects('Test');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toHaveLength(2);
+        expect(result.data[0].id).toBe('proj-1');
+        expect(result.data[0].projectName).toBe('Test Project');
+        expect(result.data[1].ownerName).toBeUndefined();
+      }
+    });
+
+    it('한글 키워드로 검색이 가능하다', async () => {
+      const result = await searchProjects('프로젝트');
+
+      expect(result.success).toBe(true);
+      expect(mockSelect).toHaveBeenCalled();
+    });
+
+    it('숫자가 포함된 키워드로 검색이 가능하다', async () => {
+      const result = await searchProjects('test123');
+
+      expect(result.success).toBe(true);
+      expect(mockSelect).toHaveBeenCalled();
+    });
+
+    it('하이픈과 언더스코어가 포함된 키워드로 검색이 가능하다', async () => {
+      const result = await searchProjects('test-project_name');
+
+      expect(result.success).toBe(true);
+      expect(mockSelect).toHaveBeenCalled();
+    });
+
+    it('검색 결과가 있으면 메시지를 포함한다', async () => {
+      const result = await searchProjects('Test');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.message).toContain('2건의 프로젝트');
+      }
+    });
+
+    it('검색 결과가 없으면 빈 배열과 메시지 없음을 반환한다', async () => {
+      mockLimit.mockResolvedValue([]);
+
+      const result = await searchProjects('NoMatch');
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual([]);
+        expect(result.message).toBeUndefined();
+      }
+    });
+
+    it('키워드 앞뒤 공백은 자동으로 제거된다', async () => {
+      const result = await searchProjects('  Test  ');
+
+      expect(result.success).toBe(true);
+      expect(mockSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('DB 에러 발생 시 에러 메시지를 반환한다', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockLimit.mockRejectedValue(new Error('DB Error'));
+
+      const result = await searchProjects('Test');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toContain('검색 중 오류가 발생했습니다');
+      }
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/src/features/projects-create/api/server-action.test.ts
+++ b/src/features/projects-create/api/server-action.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+// next/cache mock
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+// uuid mock
+vi.mock('uuid', () => ({
+  v7: vi.fn(() => 'test-uuid-123'),
+}));
+
+// password hash mock
+vi.mock('@/access/lib/password-hash', () => ({
+  hashPassword: vi.fn(() => Promise.resolve('hashed-identifier')),
+}));
+
+// DB mock
+const mockReturning = vi.fn();
+const mockValues = vi.fn(() => ({ returning: mockReturning }));
+const mockInsert = vi.fn(() => ({ values: mockValues }));
+const mockLimit = vi.fn();
+const mockWhere = vi.fn(() => ({ limit: mockLimit }));
+const mockOrderBy = vi.fn();
+const mockWhereSelect = vi.fn(() => ({ orderBy: mockOrderBy }));
+const mockFrom = vi.fn(() => ({ where: mockWhereSelect }));
+const mockSelect = vi.fn(() => ({ from: mockFrom }));
+
+const mockDb = {
+  insert: mockInsert,
+  select: mockSelect,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  projects: {
+    id: 'id',
+    name: 'name',
+    identifier: 'identifier',
+    description: 'description',
+    owner_name: 'owner_name',
+    created_at: 'created_at',
+    updated_at: 'updated_at',
+    archived_at: 'archived_at',
+    lifecycle_status: 'lifecycle_status',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((a, b) => ({ field: a, value: b })),
+}));
+
+import { checkProjectNameDuplicate, createProject, getProjects } from './server-action';
+
+describe('createProject', () => {
+  const mockInput = {
+    projectName: 'Test Project',
+    identifier: 'test-identifier-123',
+    description: '테스트 설명',
+    ownerName: '홍길동',
+  };
+
+  const mockInsertedRow = {
+    id: 'test-uuid-123',
+    name: 'Test Project',
+    identifier: 'hashed-identifier',
+    description: '테스트 설명',
+    owner_name: '홍길동',
+    created_at: new Date('2024-01-01T00:00:00Z'),
+    updated_at: new Date('2024-01-01T00:00:00Z'),
+    archived_at: null,
+    lifecycle_status: 'ACTIVE',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('프로젝트 생성 성공 시 success: true와 프로젝트 데이터를 반환한다', async () => {
+    mockReturning.mockResolvedValue([mockInsertedRow]);
+
+    const result = await createProject(mockInput);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.id).toBe('test-uuid-123');
+      expect(result.data.projectName).toBe('Test Project');
+      expect(result.data.description).toBe('테스트 설명');
+      expect(result.data.ownerName).toBe('홍길동');
+      expect(result.data.lifecycleStatus).toBe('ACTIVE');
+    }
+    expect(mockInsert).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalled();
+    expect(mockReturning).toHaveBeenCalled();
+  });
+
+  it('프로젝트명이 정규화되어 저장된다 (공백 제거)', async () => {
+    mockReturning.mockResolvedValue([mockInsertedRow]);
+
+    const inputWithSpaces = {
+      ...mockInput,
+      projectName: '  Test   Project  ',
+    };
+
+    await createProject(inputWithSpaces);
+
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Test Project',
+      })
+    );
+  });
+
+  it('inserted가 없을 경우 success: false와 에러를 반환한다', async () => {
+    mockReturning.mockResolvedValue([undefined]);
+
+    const result = await createProject(mockInput);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._form).toContain('프로젝트 생성에 실패했습니다.');
+    }
+  });
+
+  it('DB 에러 발생 시 success: false와 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockReturning.mockRejectedValue(new Error('DB Connection Error'));
+
+    const result = await createProject(mockInput);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._form).toContain('프로젝트 생성 중 오류가 발생했습니다.');
+    }
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('getProjects', () => {
+  const mockProjectRows = [
+    {
+      id: 'proj-1',
+      name: 'Project 1',
+      identifier: 'hashed-1',
+      description: '설명 1',
+      owner_name: '홍길동',
+      created_at: new Date('2024-01-01T00:00:00Z'),
+      updated_at: new Date('2024-01-02T00:00:00Z'),
+      archived_at: null,
+      lifecycle_status: 'ACTIVE',
+    },
+    {
+      id: 'proj-2',
+      name: 'Project 2',
+      identifier: 'hashed-2',
+      description: null,
+      owner_name: null,
+      created_at: new Date('2024-01-03T00:00:00Z'),
+      updated_at: new Date('2024-01-04T00:00:00Z'),
+      archived_at: null,
+      lifecycle_status: 'ACTIVE',
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('프로젝트 목록 조회 성공 시 success: true와 데이터를 반환한다', async () => {
+    mockOrderBy.mockResolvedValue(mockProjectRows);
+
+    const result = await getProjects();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toHaveLength(2);
+      expect(result.data[0].id).toBe('proj-1');
+      expect(result.data[0].projectName).toBe('Project 1');
+      expect(result.data[1].description).toBeUndefined();
+      expect(result.data[1].ownerName).toBeUndefined();
+    }
+  });
+
+  it('프로젝트가 없을 경우 빈 배열을 반환한다', async () => {
+    mockOrderBy.mockResolvedValue([]);
+
+    const result = await getProjects();
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual([]);
+    }
+  });
+
+  it('DB 에러 발생 시 success: false와 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockOrderBy.mockRejectedValue(new Error('DB Error'));
+
+    const result = await getProjects();
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._form).toContain('프로젝트 목록 조회에 실패했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('checkProjectNameDuplicate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // checkProjectNameDuplicate는 다른 체인을 사용하므로 재설정
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
+  });
+
+  it('중복된 프로젝트명이 있으면 true를 반환한다', async () => {
+    mockLimit.mockResolvedValue([{ id: 'existing-id' }]);
+
+    const result = await checkProjectNameDuplicate('Existing Project');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe(true);
+    }
+  });
+
+  it('중복된 프로젝트명이 없으면 false를 반환한다', async () => {
+    mockLimit.mockResolvedValue([undefined]);
+
+    const result = await checkProjectNameDuplicate('New Project');
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBe(false);
+    }
+  });
+
+  it('프로젝트명이 정규화되어 검사된다', async () => {
+    mockLimit.mockResolvedValue([undefined]);
+
+    await checkProjectNameDuplicate('  Test   Project  ');
+
+    // name 필드에 정규화된 값이 사용되었는지 확인
+    expect(mockSelect).toHaveBeenCalled();
+  });
+
+  it('DB 에러 발생 시 success: false와 에러 메시지를 반환한다', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mockLimit.mockRejectedValue(new Error('DB Error'));
+
+    const result = await checkProjectNameDuplicate('Test');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors._form).toContain('중복 체크 중 오류가 발생했습니다.');
+    }
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/features/projects-create/ui/project-create-form.test.tsx
+++ b/src/features/projects-create/ui/project-create-form.test.tsx
@@ -1,21 +1,33 @@
-import { ProjectCreateForm, createProject } from '@/features';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectDomain } from '@/entities';
 import type { ActionResult } from '@/features';
 
-// createProject 함수 mock
-vi.mock('@/features/projects-create/model/server-action', () => ({
-  createProject: vi.fn(),
+// Next.js router mock
+const mockReplace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+    push: vi.fn(),
+    back: vi.fn(),
+  }),
 }));
 
-const mockedCreateProject = vi.mocked(createProject);
+// createProject 함수 mock
+const mockCreateProject = vi.fn();
+vi.mock('@/features/projects-create/api/server-action', () => ({
+  createProject: (...args: unknown[]) => mockCreateProject(...args),
+}));
+
+// Import after mocks
+import { ProjectCreateForm } from './project-create-form';
 
 const mockSuccessResponse: ActionResult<ProjectDomain> = {
   success: true,
   data: {
     id: 'test-uuid-123',
     projectName: 'Test Project',
+    slug: 'test-project-slug',
     identifier: 'hashed_identifier',
     description: undefined,
     ownerName: undefined,
@@ -72,6 +84,9 @@ describe('ProjectCreateForm 통합 테스트', () => {
         target: { value: 'Test Project' },
       });
       fireEvent.click(screen.getByText(/프로젝트 생성 시작/i));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/식별번호를 입력하세요/i)).toBeInTheDocument();
+      });
 
       const input = screen.getByPlaceholderText(/식별번호를 입력하세요/i);
       const confirmInput = screen.getByPlaceholderText(/식별번호를 다시 입력하세요/i);
@@ -89,6 +104,9 @@ describe('ProjectCreateForm 통합 테스트', () => {
         target: { value: 'Test Project' },
       });
       fireEvent.click(screen.getByText(/프로젝트 생성 시작/i));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/식별번호를 입력하세요/i)).toBeInTheDocument();
+      });
       const xBtn = screen.getByRole('button', { name: '' });
       fireEvent.click(xBtn);
       expect(mockOnClick).toHaveBeenCalled();
@@ -103,6 +121,9 @@ describe('ProjectCreateForm 통합 테스트', () => {
         target: { value: 'Test Project' },
       });
       fireEvent.click(screen.getByText(/프로젝트 생성 시작/i));
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText(/식별번호를 입력하세요/i)).toBeInTheDocument();
+      });
       fireEvent.change(screen.getByPlaceholderText(/식별번호를 입력하세요/i), {
         target: { value: '1234567890' },
       });
@@ -110,13 +131,17 @@ describe('ProjectCreateForm 통합 테스트', () => {
         target: { value: '1234567890' },
       });
       fireEvent.click(screen.getByText(/프로젝트 생성하기/i));
-
+      await waitFor(() => {
+        expect(screen.getByText(/프로젝트를 생성하시겠습니까/i)).toBeInTheDocument();
+      });
       const cancelBtn = screen.getByText(/취소/i);
       fireEvent.click(cancelBtn);
       expect(mockOnClick).toHaveBeenCalled();
     });
 
-    it('3단계에서 생성하기 버튼을 누르면 4단계로 이동한다', async () => {
+    it('3단계에서 생성하기 버튼을 누르면 서버 액션이 호출되고 4단계로 이동한다', async () => {
+      mockCreateProject.mockResolvedValue(mockSuccessResponse);
+
       render(<ProjectCreateForm />);
       // Step 1
       fireEvent.change(screen.getByPlaceholderText(/프로젝트 이름을 입력하세요/i), {
@@ -147,9 +172,8 @@ describe('ProjectCreateForm 통합 테스트', () => {
   });
 
   describe('Step4: 완료 및 서버 액션', () => {
-    it('프로젝트 생성에 성공하면 성공 메시지를 표시한다', async () => {
-      mockedCreateProject.mockResolvedValue(mockSuccessResponse);
-      const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    it('프로젝트 생성에 성공하면 성공 화면을 표시하고 시작하기 버튼으로 이동한다', async () => {
+      mockCreateProject.mockResolvedValue(mockSuccessResponse);
 
       render(<ProjectCreateForm />);
       // Step 1 -> 4
@@ -178,23 +202,19 @@ describe('ProjectCreateForm 통합 테스트', () => {
         expect(screen.getByText(/프로젝트 생성 완료!/i)).toBeInTheDocument();
       });
 
-      // Submit 버튼 클릭
+      expect(mockCreateProject).toHaveBeenCalled();
+
+      // 시작하기 버튼 클릭 시 라우터 이동
       fireEvent.click(screen.getByText(/시작하기/i));
-
-      await waitFor(() => {
-        expect(mockedCreateProject).toHaveBeenCalled();
-        expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('프로젝트 생성 완료!'));
-      });
-
-      alertSpy.mockRestore();
+      expect(mockReplace).toHaveBeenCalledWith('/projects/test-project-slug');
     });
 
     it('프로젝트 생성에 실패하면 에러 메시지를 표시한다', async () => {
-      mockedCreateProject.mockResolvedValue(mockErrorResponse);
+      mockCreateProject.mockResolvedValue(mockErrorResponse);
       const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
 
       render(<ProjectCreateForm />);
-      // Step 1 -> 4
+      // Step 1 -> 3
       fireEvent.change(screen.getByPlaceholderText(/프로젝트 이름을 입력하세요/i), {
         target: { value: 'Test Project' },
       });
@@ -217,13 +237,7 @@ describe('ProjectCreateForm 통합 테스트', () => {
       fireEvent.click(screen.getByText(/생성하기/i));
 
       await waitFor(() => {
-        expect(screen.getByText(/프로젝트 생성 완료!/i)).toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText(/시작하기/i));
-
-      await waitFor(() => {
-        expect(mockedCreateProject).toHaveBeenCalled();
+        expect(mockCreateProject).toHaveBeenCalled();
         expect(alertSpy).toHaveBeenCalledWith(expect.stringContaining('생성 실패'));
       });
 

--- a/src/features/runs-create/model/server-action.test.ts
+++ b/src/features/runs-create/model/server-action.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 트랜잭션 내부의 insert mock
+const mockTxReturning = vi.fn();
+const mockTxValues = vi.fn(() => ({ returning: mockTxReturning }));
+const mockTxInsert = vi.fn(() => ({ values: mockTxValues }));
+
+// 트랜잭션 객체
+const mockTx = {
+  insert: mockTxInsert,
+};
+
+// 트랜잭션 실행 - callback을 실행하고 결과 반환
+const mockTransaction = vi.fn(async (callback) => {
+  return callback(mockTx);
+});
+
+const mockDb = {
+  transaction: mockTransaction,
+};
+
+vi.mock('@/shared/lib/db', () => ({
+  getDatabase: vi.fn(() => mockDb),
+  testRuns: {
+    id: 'id',
+    project_id: 'project_id',
+    name: 'name',
+    description: 'description',
+    status: 'status',
+    created_at: 'created_at',
+    updated_at: 'updated_at',
+    archived_at: 'archived_at',
+    lifecycle_status: 'lifecycle_status',
+  },
+  testRunSuites: {
+    test_run_id: 'test_run_id',
+    test_suite_id: 'test_suite_id',
+  },
+  testRunMilestones: {
+    test_run_id: 'test_run_id',
+    milestone_id: 'milestone_id',
+  },
+}));
+
+import { createTestRunAction } from './server-action';
+
+describe('createTestRunAction', () => {
+  const validInput = {
+    project_id: '550e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Run 1',
+    description: '테스트 설명',
+  };
+
+  const mockCreatedRun = {
+    id: 'run-uuid-123',
+    project_id: '550e8400-e29b-41d4-a716-446655440000',
+    name: 'Test Run 1',
+    description: '테스트 설명',
+    status: 'NOT_STARTED',
+    created_at: new Date('2024-01-01T00:00:00Z'),
+    updated_at: new Date('2024-01-01T00:00:00Z'),
+    archived_at: null,
+    lifecycle_status: 'ACTIVE',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // 기본적으로 insert().values().returning()이 mockCreatedRun 반환
+    mockTxReturning.mockResolvedValue([mockCreatedRun]);
+  });
+
+  describe('유효성 검사', () => {
+    it('project_id가 없으면 유효성 검사 에러를 반환한다', async () => {
+      const invalidInput = {
+        name: 'Test Run',
+      };
+
+      const result = await createTestRunAction(invalidInput as any);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.project_id).toBeDefined();
+      }
+    });
+
+    it('project_id가 유효한 UUID가 아니면 에러를 반환한다', async () => {
+      const invalidInput = {
+        project_id: 'invalid-uuid',
+        name: 'Test Run',
+      };
+
+      const result = await createTestRunAction(invalidInput);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.project_id).toBeDefined();
+      }
+    });
+
+    it('name이 없으면 유효성 검사 에러를 반환한다', async () => {
+      const invalidInput = {
+        project_id: '550e8400-e29b-41d4-a716-446655440000',
+        name: '',
+      };
+
+      const result = await createTestRunAction(invalidInput);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.fieldErrors.name).toBeDefined();
+      }
+    });
+  });
+
+  describe('테스트 런 생성', () => {
+    it('기본 입력으로 테스트 런을 성공적으로 생성한다', async () => {
+      const result = await createTestRunAction(validInput);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.testRun.id).toBe('run-uuid-123');
+        expect(result.testRun.name).toBe('Test Run 1');
+      }
+      expect(mockTransaction).toHaveBeenCalled();
+      expect(mockTxInsert).toHaveBeenCalled();
+    });
+
+    it('suite_ids가 제공되면 테스트 스위트를 연결한다', async () => {
+      const inputWithSuites = {
+        ...validInput,
+        suite_ids: [
+          '660e8400-e29b-41d4-a716-446655440001',
+          '660e8400-e29b-41d4-a716-446655440002',
+        ],
+      };
+
+      const result = await createTestRunAction(inputWithSuites);
+
+      expect(result.success).toBe(true);
+      // insert가 2번 호출됨 (testRuns + testRunSuites)
+      expect(mockTxInsert).toHaveBeenCalledTimes(2);
+    });
+
+    it('milestone_ids가 제공되면 마일스톤을 연결한다', async () => {
+      const inputWithMilestones = {
+        ...validInput,
+        milestone_ids: [
+          '770e8400-e29b-41d4-a716-446655440001',
+          '770e8400-e29b-41d4-a716-446655440002',
+        ],
+      };
+
+      const result = await createTestRunAction(inputWithMilestones);
+
+      expect(result.success).toBe(true);
+      // insert가 2번 호출됨 (testRuns + testRunMilestones)
+      expect(mockTxInsert).toHaveBeenCalledTimes(2);
+    });
+
+    it('suite_ids와 milestone_ids 모두 제공되면 둘 다 연결한다', async () => {
+      const inputWithBoth = {
+        ...validInput,
+        suite_ids: ['660e8400-e29b-41d4-a716-446655440001'],
+        milestone_ids: ['770e8400-e29b-41d4-a716-446655440001'],
+      };
+
+      const result = await createTestRunAction(inputWithBoth);
+
+      expect(result.success).toBe(true);
+      // insert가 3번 호출됨 (testRuns + testRunSuites + testRunMilestones)
+      expect(mockTxInsert).toHaveBeenCalledTimes(3);
+    });
+
+    it('description이 없어도 생성에 성공한다', async () => {
+      const inputWithoutDescription = {
+        project_id: '550e8400-e29b-41d4-a716-446655440000',
+        name: 'Test Run Without Description',
+      };
+
+      const result = await createTestRunAction(inputWithoutDescription);
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('에러 처리', () => {
+    it('트랜잭션 에러 발생 시 에러를 반환한다', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTransaction.mockRejectedValueOnce(new Error('Transaction failed'));
+
+      const result = await createTestRunAction(validInput);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.formErrors[0]).toContain('테스트 실행 생성에 실패했습니다');
+      }
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('insert 에러 발생 시 에러를 반환한다', async () => {
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockTxReturning.mockRejectedValueOnce(new Error('Insert failed'));
+
+      const result = await createTestRunAction(validInput);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.errors.formErrors[0]).toContain('테스트 실행 생성에 실패했습니다');
+      }
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 테스트 커버리지가 없던 서버 액션에 대한 단위 테스트 추가
- 기존 테스트 파일의 누락된 테스트 케이스 보완
- 테스트 실패 로직 수정 및 mock 구조 개선

## Changes
### 신규 테스트 파일 (6개) 

| 파일 | 테스트 대상 | 테스트 수 |
|------|------------|----------|
| `projects-create/api/server-action.test.ts` | createProject, getProjects, checkProjectNameDuplicate | 11 |
| `runs-create/model/server-action.test.ts` | createTestRunAction (트랜잭션) | 10 |
| `project-search/api/server-action.test.ts` | searchProjects | 13 |
| `project/api/get-project.test.ts` | getProjectByName, getProjectById | 8 |
| `test-case/api/update-case-action.test.ts` | updateTestCase | 8 |
| `milestones-create/model/server-action.test.ts` | createMilestoneAction | 8 |                                                                                                          

### 기존 테스트 파일 수정 (13개)
- `update-milestone-action.test.ts`: DB 에러 케이스 추가
- `dashboard/get-dashboard-stats.test.ts`: mock 구조 및 필드 매핑 수정
- 기타 테스트 파일: mock 유틸리티 import 정리 및 테스트 데이터 구조 업데이트

### 테스트 결과
- **테스트 파일**: 31개
- **전체 테스트**: 197개 통과 [x]
- **실패**: 0개

## Test plan
- [x] `npm run test` 실행하여 모든 테스트 통과 확인
- [x] 신규 테스트 파일 개별 실행 확인
- [x] 기존 테스트 회귀 없음 확인