### PR TITLE
refactor(perf): 테스트 케이스 생성/조회 로딩 속도 개선 및 Optimistic Update 적용

### DIFF
--- a/src/entities/project/api/index.ts
+++ b/src/entities/project/api/index.ts
@@ -1,3 +1,3 @@
-export { getProjectByName, getProjectById, updateProject, changeProjectIdentifier, deleteProject } from './server-actions';
+export { getProjectByName, getProjectById, getProjectIdBySlug, updateProject, changeProjectIdentifier, deleteProject } from './server-actions';
 export type { ProjectBasicInfo } from './server-actions';
-export { projectQueryKeys, projectByNameQueryOptions, projectByIdQueryOptions } from './query';
+export { projectQueryKeys, projectIdQueryOptions, projectByNameQueryOptions, projectByIdQueryOptions } from './query';

--- a/src/entities/project/api/query.ts
+++ b/src/entities/project/api/query.ts
@@ -1,12 +1,21 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import { getProjectById, getProjectByName } from './server-actions';
+import { getProjectById, getProjectByName, getProjectIdBySlug } from './server-actions';
 
 export const projectQueryKeys = {
   all: ['project'] as const,
+  idBySlug: (slug: string) => [...projectQueryKeys.all, 'idBySlug', slug] as const,
   byName: (name: string) => [...projectQueryKeys.all, 'byName', name] as const,
   byId: (id: string) => [...projectQueryKeys.all, 'byId', id] as const,
 };
+
+export const projectIdQueryOptions = (slug: string) =>
+  queryOptions({
+    queryKey: projectQueryKeys.idBySlug(slug),
+    queryFn: () => getProjectIdBySlug(slug),
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
 
 export const projectByNameQueryOptions = (projectName: string) =>
   queryOptions({

--- a/src/entities/project/api/server-actions.ts
+++ b/src/entities/project/api/server-actions.ts
@@ -14,6 +14,26 @@ export type ProjectBasicInfo = Pick<
   'id' | 'projectName' | 'description' | 'ownerName'
 >;
 
+export const getProjectIdBySlug = async (slug: string): Promise<ActionResult<{ id: string }>> => {
+  try {
+    const db = getDatabase();
+    const decodedSlug = decodeURIComponent(slug);
+    const [row] = await db
+      .select({ id: projects.id })
+      .from(projects)
+      .where(eq(projects.name, decodedSlug))
+      .limit(1);
+
+    if (!row) {
+      return { success: false, errors: { _project: ['프로젝트를 찾을 수 없습니다.'] } };
+    }
+    return { success: true, data: { id: row.id } };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'getProjectIdBySlug' } });
+    return { success: false, errors: { _project: ['프로젝트를 불러오는 도중 오류가 발생했습니다.'] } };
+  }
+};
+
 export const getProjectByName = async (name: string): Promise<ActionResult<ProjectBasicInfo>> => {
   try {
     const db = getDatabase();

--- a/src/entities/test-case/api/get-project-tags.ts
+++ b/src/entities/test-case/api/get-project-tags.ts
@@ -3,34 +3,21 @@
 import * as Sentry from '@sentry/nextjs';
 import { getDatabase, testCases } from '@/shared/lib/db';
 import type { ActionResult } from '@/shared/types';
-import { and, eq, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 
 export const getProjectTags = async (projectId: string): Promise<ActionResult<string[]>> => {
   try {
     const db = getDatabase();
-    const rows = await db
-      .select({
-        tag: sql<string>`unnest(${testCases.tags})`,
-      })
-      .from(testCases)
-      .where(
-        and(
-          eq(testCases.project_id, projectId),
-          eq(testCases.lifecycle_status, 'ACTIVE')
-        )
-      );
 
-    const tagCounts = new Map<string, number>();
-    for (const row of rows) {
-      if (row.tag) {
-        const count = tagCounts.get(row.tag) ?? 0;
-        tagCounts.set(row.tag, count + 1);
-      }
-    }
+    // DB 레벨에서 중복 제거 + 빈도 정렬 (JS 후처리 제거)
+    const rows = await db.execute(sql`
+      SELECT unnest(${testCases.tags}) AS tag, COUNT(*) AS freq
+      FROM test_cases
+      WHERE project_id = ${projectId} AND lifecycle_status = 'ACTIVE'
+      GROUP BY tag ORDER BY freq DESC
+    `) as unknown as Array<{ tag: string; freq: number }>;
 
-    const sortedTags = [...tagCounts.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([tag]) => tag);
+    const sortedTags = rows.map((r) => r.tag).filter(Boolean);
 
     return { success: true, data: sortedTags };
   } catch (error) {

--- a/src/entities/test-case/api/index.ts
+++ b/src/entities/test-case/api/index.ts
@@ -1,4 +1,4 @@
-export { getTestCase, getTestCases, createTestCase, updateTestCase } from './server-actions';
+export { getTestCase, getTestCases, getTestCasesList, createTestCase, updateTestCase } from './server-actions';
 export { getProjectTags } from './get-project-tags';
 export { projectTagsQueryOptions } from './query-options';
 // Mock 파일 - 나중에 리팩토링 예정

--- a/src/entities/test-case/api/server-actions.ts
+++ b/src/entities/test-case/api/server-actions.ts
@@ -2,6 +2,7 @@
 
 import * as Sentry from '@sentry/nextjs';
 import { CreateTestCase, TestCase, TestCaseDTO, toCreateTestCaseDTO, toTestCase } from '@/entities';
+import type { TestCaseListItem } from '@/entities/test-case/model/types';
 import { getDatabase, testCases } from '@/shared/lib/db';
 import type { ActionResult } from '@/shared/types';
 import { and, eq, sql } from 'drizzle-orm';
@@ -78,6 +79,65 @@ export const getTestCases = async ({
   }
 };
 
+/** 목록 조회용: steps, pre_condition, expected_result 제외하여 페이로드 경량화 */
+export const getTestCasesList = async ({
+  project_id,
+}: getTestCasesParams): Promise<ActionResult<TestCaseListItem[]>> => {
+  try {
+    const db = getDatabase();
+    const rows = await db
+      .select({
+        id: testCases.id,
+        project_id: testCases.project_id,
+        test_suite_id: testCases.test_suite_id,
+        section_id: testCases.section_id,
+        display_id: testCases.display_id,
+        name: testCases.name,
+        test_type: testCases.test_type,
+        tags: testCases.tags,
+        sort_order: testCases.sort_order,
+        result_status: testCases.result_status,
+        created_at: testCases.created_at,
+        updated_at: testCases.updated_at,
+        archived_at: testCases.archived_at,
+        lifecycle_status: testCases.lifecycle_status,
+      })
+      .from(testCases)
+      .where(
+        and(
+          eq(testCases.project_id, project_id),
+          eq(testCases.lifecycle_status, 'ACTIVE')
+        )
+      );
+
+    const result: TestCaseListItem[] = rows.map((row) => ({
+      id: row.id,
+      projectId: row.project_id ?? '',
+      testSuiteId: row.test_suite_id ?? undefined,
+      sectionId: row.section_id ?? null,
+      displayId: row.display_id ?? 0,
+      caseKey: `TC-${String(row.display_id ?? 0).padStart(3, '0')}`,
+      title: row.name,
+      testType: row.test_type ?? '',
+      tags: row.tags ?? [],
+      sortOrder: row.sort_order ?? 0,
+      resultStatus: row.result_status,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      archivedAt: row.archived_at ?? null,
+      lifecycleStatus: row.lifecycle_status,
+    }));
+
+    return { success: true, data: result };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'getTestCasesList' } });
+    return {
+      success: false,
+      errors: { _testCase: ['테스트케이스를 불러오는 도중 오류가 발생했습니다.'] },
+    };
+  }
+};
+
 export const getTestCase = async (id: string): Promise<ActionResult<TestCase>> => {
   try {
     const db = getDatabase();
@@ -133,17 +193,19 @@ export const getTestCase = async (id: string): Promise<ActionResult<TestCase>> =
 
 export const createTestCase = async (input: CreateTestCase): Promise<ActionResult<TestCase>> => {
   try {
-    const hasAccess = await requireProjectAccess(input.projectId);
+    const [hasAccess, storageError] = await Promise.all([
+      requireProjectAccess(input.projectId),
+      checkStorageLimit(input.projectId),
+    ]);
     if (!hasAccess) {
       return { success: false, errors: { _testCase: ['접근 권한이 없습니다.'] } };
     }
-
-    const storageError = await checkStorageLimit(input.projectId);
     if (storageError) return storageError;
 
     const db = getDatabase();
     const dto = toCreateTestCaseDTO(input);
     const id = uuidv7();
+    const now = new Date();
 
     const [maxResult] = await db
       .select({ max: sql<number>`COALESCE(MAX(${testCases.display_id}), 0)` })
@@ -159,8 +221,8 @@ export const createTestCase = async (input: CreateTestCase): Promise<ActionResul
         display_id: nextDisplayId,
         case_key: `TC-${String(nextDisplayId).padStart(3, '0')}`,
         result_status: 'untested',
-        created_at: new Date(),
-        updated_at: new Date(),
+        created_at: now,
+        updated_at: now,
         archived_at: null,
         lifecycle_status: 'ACTIVE',
       })

--- a/src/entities/test-case/model/types.ts
+++ b/src/entities/test-case/model/types.ts
@@ -45,6 +45,9 @@ export type CreateTestCase = {
   sortOrder?: number;
 };
 
-export type TestCaseCardType = TestCase & {
+/** 목록 조회용 경량 타입 (steps, pre_condition, expected_result 제외) */
+export type TestCaseListItem = Omit<TestCase, 'preCondition' | 'testSteps' | 'expectedResult'>;
+
+export type TestCaseCardType = TestCaseListItem & {
   suiteTitle: string;
 };

--- a/src/entities/test-suite/api/server-actions.ts
+++ b/src/entities/test-suite/api/server-actions.ts
@@ -316,25 +316,64 @@ export const getTestSuitesWithStats = async ({
 
     const suiteIds = suiteRows.map((s) => s.id);
 
-    // 2) 케이스 수 집계
-    const caseCountRows = await db
-      .select({ suiteId: testCases.test_suite_id, cnt: count() })
-      .from(testCases)
-      .where(and(eq(testCases.lifecycle_status, 'ACTIVE'), inArray(testCases.test_suite_id, suiteIds)))
-      .groupBy(testCases.test_suite_id);
+    // Q2~Q6: suiteIds 이후 독립적인 5개 쿼리를 병렬 실행
+    const milestoneQueryFn = async () => {
+      try {
+        return await db
+          .select({
+            suiteId: milestoneTestSuites.test_suite_id,
+            milestoneId: milestones.id,
+            milestoneName: milestones.name,
+            progressStatus: milestones.progress_status,
+          })
+          .from(milestoneTestSuites)
+          .innerJoin(milestones, eq(milestoneTestSuites.milestone_id, milestones.id))
+          .where(inArray(milestoneTestSuites.test_suite_id, suiteIds));
+      } catch (e) {
+        console.warn('milestoneTestSuites 조회 실패:', e);
+        Sentry.captureMessage('milestoneTestSuites 조회 실패', { level: 'warning', extra: { error: e } });
+        return [];
+      }
+    };
+
+    const [caseCountRows, testTypeRows, msRows, runCountRows, recentRunRows] = await Promise.all([
+      // Q2: 케이스 수 집계
+      db.select({ suiteId: testCases.test_suite_id, cnt: count() })
+        .from(testCases)
+        .where(and(eq(testCases.lifecycle_status, 'ACTIVE'), inArray(testCases.test_suite_id, suiteIds)))
+        .groupBy(testCases.test_suite_id),
+      // Q3: 케이스 test_type 목록 (포함 경로용)
+      db.select({ suiteId: testCases.test_suite_id, testType: testCases.test_type })
+        .from(testCases)
+        .where(
+          and(
+            eq(testCases.lifecycle_status, 'ACTIVE'),
+            inArray(testCases.test_suite_id, suiteIds),
+            isNotNull(testCases.test_type),
+          )
+        ),
+      // Q4: 연결된 마일스톤
+      milestoneQueryFn(),
+      // Q5: 실행 이력 수 집계
+      db.select({ suiteId: testRunSuites.test_suite_id, cnt: count() })
+        .from(testRunSuites)
+        .where(inArray(testRunSuites.test_suite_id, suiteIds))
+        .groupBy(testRunSuites.test_suite_id),
+      // Q6: 최근 실행 (스위트별 최신 run)
+      db.select({
+          suiteId: testRunSuites.test_suite_id,
+          runId: testRuns.id,
+          runStatus: testRuns.status,
+          runCreatedAt: testRuns.created_at,
+        })
+        .from(testRunSuites)
+        .innerJoin(testRuns, eq(testRunSuites.test_run_id, testRuns.id))
+        .where(inArray(testRunSuites.test_suite_id, suiteIds))
+        .orderBy(desc(testRuns.created_at)),
+    ]);
+
     const caseCountMap = new Map(caseCountRows.map((r) => [r.suiteId, Number(r.cnt)]));
 
-    // 3) 케이스 test_type 목록 (포함 경로용)
-    const testTypeRows = await db
-      .select({ suiteId: testCases.test_suite_id, testType: testCases.test_type })
-      .from(testCases)
-      .where(
-        and(
-          eq(testCases.lifecycle_status, 'ACTIVE'),
-          inArray(testCases.test_suite_id, suiteIds),
-          isNotNull(testCases.test_type),
-        )
-      );
     const testTypeMap = new Map<string, Set<string>>();
     for (const r of testTypeRows) {
       if (!r.suiteId || !r.testType) continue;
@@ -342,53 +381,18 @@ export const getTestSuitesWithStats = async ({
       testTypeMap.get(r.suiteId)!.add(r.testType);
     }
 
-    // 4) 연결된 마일스톤 (첫 번째만)
-    let milestoneMap = new Map<string, { id: string; title: string; versionLabel: string }>();
-    try {
-      const msRows = await db
-        .select({
-          suiteId: milestoneTestSuites.test_suite_id,
-          milestoneId: milestones.id,
-          milestoneName: milestones.name,
-          progressStatus: milestones.progress_status,
-        })
-        .from(milestoneTestSuites)
-        .innerJoin(milestones, eq(milestoneTestSuites.milestone_id, milestones.id))
-        .where(inArray(milestoneTestSuites.test_suite_id, suiteIds));
-      for (const r of msRows) {
-        if (r.suiteId && !milestoneMap.has(r.suiteId)) {
-          milestoneMap.set(r.suiteId, {
-            id: r.milestoneId,
-            title: r.milestoneName,
-            versionLabel: r.progressStatus ?? '',
-          });
-        }
+    const milestoneMap = new Map<string, { id: string; title: string; versionLabel: string }>();
+    for (const r of msRows) {
+      if (r.suiteId && !milestoneMap.has(r.suiteId)) {
+        milestoneMap.set(r.suiteId, {
+          id: r.milestoneId,
+          title: r.milestoneName,
+          versionLabel: r.progressStatus ?? '',
+        });
       }
-    } catch (e) {
-      console.warn('milestoneTestSuites 조회 실패:', e);
-      Sentry.captureMessage('milestoneTestSuites 조회 실패', { level: 'warning', extra: { error: e } });
     }
 
-    // 5) 실행 이력 수 집계
-    const runCountRows = await db
-      .select({ suiteId: testRunSuites.test_suite_id, cnt: count() })
-      .from(testRunSuites)
-      .where(inArray(testRunSuites.test_suite_id, suiteIds))
-      .groupBy(testRunSuites.test_suite_id);
     const runCountMap = new Map(runCountRows.map((r) => [r.suiteId, Number(r.cnt)]));
-
-    // 6) 최근 실행 (스위트별 최신 5개 run)
-    const recentRunRows = await db
-      .select({
-        suiteId: testRunSuites.test_suite_id,
-        runId: testRuns.id,
-        runStatus: testRuns.status,
-        runCreatedAt: testRuns.created_at,
-      })
-      .from(testRunSuites)
-      .innerJoin(testRuns, eq(testRunSuites.test_run_id, testRuns.id))
-      .where(inArray(testRunSuites.test_suite_id, suiteIds))
-      .orderBy(desc(testRuns.created_at));
 
     // 스위트별 run 그룹핑
     const runsPerSuite = new Map<string, Array<{ runId: string; status: string; createdAt: Date }>>();

--- a/src/features/cases-create/hooks/use-create-case.ts
+++ b/src/features/cases-create/hooks/use-create-case.ts
@@ -1,7 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { CreateTestCase } from '@/entities';
+import type { TestCaseListItem } from '@/entities/test-case/model/types';
 import { createTestCase } from '@/entities/test-case/api';
+import { testCaseQueryKeys } from '@/features/cases-list';
+import type { ActionResult } from '@/shared/types';
 
 export const useCreateCase = () => {
   const queryClient = useQueryClient();
@@ -16,17 +19,68 @@ export const useCreateCase = () => {
       }
       return result;
     },
-    onSuccess: async () => {
+
+    // 서버 응답 전에 즉시 UI에 반영 (Optimistic Update)
+    onMutate: async (input) => {
+      const queryKey = testCaseQueryKeys.list(input.projectId);
+
+      // 진행 중인 refetch를 취소하여 optimistic 데이터를 덮어쓰지 않도록
+      await queryClient.cancelQueries({ queryKey });
+
+      // 현재 캐시 스냅샷 (롤백용)
+      const previousData = queryClient.getQueryData<ActionResult<TestCaseListItem[]>>(queryKey);
+
+      // 임시 항목 생성
+      const now = new Date();
+      const existingItems = previousData?.success ? previousData.data : [];
+      const maxDisplayId = existingItems.reduce((max, item) => Math.max(max, item.displayId), 0);
+      const nextDisplayId = maxDisplayId + 1;
+
+      const optimisticItem: TestCaseListItem = {
+        id: `optimistic-${Date.now()}`,
+        projectId: input.projectId,
+        testSuiteId: input.testSuiteId,
+        sectionId: input.sectionId ?? null,
+        displayId: nextDisplayId,
+        caseKey: `TC-${String(nextDisplayId).padStart(3, '0')}`,
+        title: input.title,
+        testType: input.testType ?? '',
+        tags: input.tags ?? [],
+        sortOrder: input.sortOrder ?? 0,
+        resultStatus: 'untested',
+        createdAt: now,
+        updatedAt: now,
+        archivedAt: null,
+        lifecycleStatus: 'ACTIVE',
+      };
+
+      // 캐시에 즉시 추가
+      queryClient.setQueryData<ActionResult<TestCaseListItem[]>>(queryKey, {
+        success: true,
+        data: [...existingItems, optimisticItem],
+      });
+
+      return { previousData, queryKey };
+    },
+
+    // 실패 시 롤백
+    onError: (_error, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+    },
+
+    // 성공/실패 무관하게 서버 데이터로 동기화
+    onSettled: async (_data, _error, variables) => {
+      const { projectId } = variables;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ['testCases'],
-          refetchType: 'all',
+          queryKey: testCaseQueryKeys.list(projectId),
         }),
         queryClient.invalidateQueries({
-          queryKey: ['testSuites'],
-          refetchType: 'all',
+          queryKey: ['testSuites', projectId],
         }),
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] }),
+        queryClient.invalidateQueries({ queryKey: ['dashboard', 'stats'] }),
       ]).catch(() => {});
     },
   });

--- a/src/features/cases-create/ui/test-case-detail-form.tsx
+++ b/src/features/cases-create/ui/test-case-detail-form.tsx
@@ -9,7 +9,7 @@ import { projectTagsQueryOptions } from '@/entities/test-case/api';
 // import { incrementTemplateUsage } from '@/entities/test-case-template/api'; // 템플릿 기능 펜딩
 import { useCreateCase } from '@/features/cases-create/hooks';
 // import { TemplateLibrary } from '@/features/templates-library'; // 템플릿 기능 펜딩
-import { DSButton, DsFormField, DsInput, DsSelect, TagChipInput, LoadingSpinner, StepBoxEditor } from '@/shared';
+import { DSButton, DsFormField, DsInput, DsSelect, TagChipInput, StepBoxEditor } from '@/shared';
 import { TESTCASE_EVENTS, track } from '@/shared/lib/analytics';
 import { testSuitesQueryOptions } from '@/widgets';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -40,7 +40,7 @@ interface TestCaseDetailFormProps {
 
 export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuiteId }: TestCaseDetailFormProps) => {
   // const [isTemplateLibraryOpen, setIsTemplateLibraryOpen] = useState(false); // 템플릿 기능 펜딩
-  const { mutate, isPending } = useCreateCase();
+  const { mutate } = useCreateCase();
 
   const { data: suitesData } = useQuery({
     ...testSuitesQueryOptions(projectId),
@@ -80,12 +80,13 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
       testSuiteId: data.testSuiteId || undefined,
       tags: data.tags.length > 0 ? data.tags : undefined,
     };
+
+    // optimistic update로 즉시 반영 → 폼 바로 닫기
+    track(TESTCASE_EVENTS.CREATE_COMPLETE, { project_id: projectId });
+    onSuccess?.();
+    onClose();
+
     mutate(payload, {
-      onSuccess: () => {
-        track(TESTCASE_EVENTS.CREATE_COMPLETE, { project_id: projectId });
-        onSuccess?.();
-        onClose();
-      },
       onError: (error) => {
         track(TESTCASE_EVENTS.CREATE_FAIL, { project_id: projectId });
         toast.error(error.message || '테스트 케이스 생성에 실패했습니다.');
@@ -112,11 +113,6 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
         className="bg-bg-2 border border-line-2 rounded-5 relative flex max-h-[85vh] w-full max-w-[900px] flex-col overflow-hidden shadow-4"
         onClick={(e) => e.stopPropagation()}
       >
-        {isPending && (
-          <div className="rounded-5 bg-bg-2/80 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
-            <LoadingSpinner size="md" text="테스트 케이스를 생성하고 있어요" />
-          </div>
-        )}
         {/* Header */}
         <header className="border-line-2 flex shrink-0 items-center justify-between border-b px-6 py-5">
           <div>
@@ -261,7 +257,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
                   <StepBoxEditor
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                     addLabel="조건 추가"
                     placeholder="충족되어야 하는 조건을 입력하세요"
                   />
@@ -282,7 +278,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
                   <StepBoxEditor
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                   />
                 )}
               />
@@ -301,7 +297,7 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
                   <StepBoxEditor
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                     addLabel="결과 추가"
                     placeholder="예상되는 결과를 입력하세요"
                   />
@@ -313,11 +309,11 @@ export const TestCaseDetailForm = ({ projectId, onClose, onSuccess, defaultSuite
 
         {/* Actions - 스크롤 영역 밖 */}
         <div className="border-line-2 flex shrink-0 justify-end gap-3 border-t px-6 py-4">
-          <DSButton type="button" variant="ghost" onClick={handleAbandon} disabled={isPending}>
+          <DSButton type="button" variant="ghost" onClick={handleAbandon}>
             취소
           </DSButton>
-          <DSButton type="submit" form="test-case-form" variant="solid" disabled={isPending}>
-            {isPending ? '생성 중...' : '테스트 케이스 생성'}
+          <DSButton type="submit" form="test-case-form" variant="solid">
+            테스트 케이스 생성
           </DSButton>
         </div>
       </section>

--- a/src/features/cases-edit/hooks/use-update-case.ts
+++ b/src/features/cases-edit/hooks/use-update-case.ts
@@ -1,12 +1,17 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { updateTestCase } from '@/entities/test-case/api';
+import type { TestCaseListItem } from '@/entities/test-case/model/types';
+import { testCaseQueryKeys } from '@/features/cases-list';
+import type { ActionResult } from '@/shared/types';
 import { UpdateTestCase } from '../model';
+
+type MutationInput = UpdateTestCase & { projectId: string };
 
 export const useUpdateCase = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (input: UpdateTestCase) => {
+    mutationFn: async (input: MutationInput) => {
       const result = await updateTestCase(input);
       if (!result.success) {
         const message = Object.values(result.errors ?? {}).flat().join(', ')
@@ -15,18 +20,60 @@ export const useUpdateCase = () => {
       }
       return result;
     },
-    onSuccess: async () => {
+
+    // 서버 응답 전에 목록 캐시에 즉시 반영
+    onMutate: async (input) => {
+      const queryKey = testCaseQueryKeys.list(input.projectId);
+
+      await queryClient.cancelQueries({ queryKey });
+
+      const previousData = queryClient.getQueryData<ActionResult<TestCaseListItem[]>>(queryKey);
+
+      if (previousData?.success) {
+        const updatedList = previousData.data.map((item) => {
+          if (item.id !== input.id) return item;
+          return {
+            ...item,
+            title: input.title ?? item.title,
+            testSuiteId: input.testSuiteId !== undefined ? (input.testSuiteId ?? undefined) : item.testSuiteId,
+            testType: input.testType ?? item.testType,
+            tags: input.tags ?? item.tags,
+            updatedAt: new Date(),
+          };
+        });
+
+        queryClient.setQueryData<ActionResult<TestCaseListItem[]>>(queryKey, {
+          success: true,
+          data: updatedList,
+        });
+      }
+
+      return { previousData, queryKey };
+    },
+
+    onError: (_error, _variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+    },
+
+    onSettled: async (_data, _error, variables) => {
+      const { projectId } = variables;
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: ['testCases'],
-          refetchType: 'all',
+          queryKey: testCaseQueryKeys.list(projectId),
         }),
         queryClient.invalidateQueries({
-          queryKey: ['testSuites'],
-          refetchType: 'all',
+          queryKey: testCaseQueryKeys.detail(variables.id),
         }),
-        queryClient.invalidateQueries({ queryKey: ['dashboard'] }),
-        queryClient.invalidateQueries({ queryKey: ['testCaseVersions'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['testSuites', projectId],
+        }),
+        queryClient.invalidateQueries({ queryKey: ['dashboard', 'stats'] }),
+        queryClient.invalidateQueries({
+          queryKey: ['testCaseVersions'],
+          predicate: (query) => query.queryKey.includes(variables.id),
+        }),
       ]).catch(() => {});
     },
   });

--- a/src/features/cases-edit/ui/test-case-edit-form.tsx
+++ b/src/features/cases-edit/ui/test-case-edit-form.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { TestCase, TEST_TYPE_OPTIONS, parseSteps, serializeSteps } from '@/entities/test-case';
 import { projectTagsQueryOptions } from '@/entities/test-case/api';
 import { testSuitesQueryOptions } from '@/widgets';
-import { DSButton, DsFormField, DsInput, DsSelect, TagChipInput, LoadingSpinner, StepBoxEditor } from '@/shared';
+import { DSButton, DsFormField, DsInput, DsSelect, TagChipInput, StepBoxEditor } from '@/shared';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { FileText, FolderOpen, ListChecks, Tag, TestTube2, X } from 'lucide-react';
 import { Controller, useForm } from 'react-hook-form';
@@ -21,7 +21,7 @@ interface TestCaseEditFormProps {
 }
 
 export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditFormProps) => {
-  const { mutate, isPending } = useUpdateCase();
+  const { mutate } = useUpdateCase();
 
   const { data: suitesData } = useQuery({
     ...testSuitesQueryOptions(testCase.projectId),
@@ -58,12 +58,12 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
   const selectedSuiteId = watch('testSuiteId');
 
   const onSubmit = (data: UpdateTestCase) => {
-    mutate(data, {
-      onSuccess: () => {
-        track(TESTCASE_EVENTS.UPDATE, { case_id: testCase.id });
-        onSuccess?.();
-        onClose();
-      },
+    // optimistic update로 즉시 반영 → 폼 바로 닫기
+    track(TESTCASE_EVENTS.UPDATE, { case_id: testCase.id });
+    onSuccess?.();
+    onClose();
+
+    mutate({ ...data, projectId: testCase.projectId }, {
       onError: (error) => {
         track(TESTCASE_EVENTS.UPDATE_FAIL, { case_id: testCase.id });
         toast.error(error.message || '테스트 케이스 수정에 실패했습니다.');
@@ -85,11 +85,6 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
         className="bg-bg-2 border border-line-2 rounded-5 relative flex max-h-[85vh] w-full max-w-[900px] flex-col overflow-hidden shadow-4"
         onClick={(e) => e.stopPropagation()}
       >
-        {isPending && (
-          <div className="rounded-5 bg-bg-2/80 absolute inset-0 z-10 flex items-center justify-center backdrop-blur-sm">
-            <LoadingSpinner size="md" text="테스트 케이스를 수정하고 있어요" />
-          </div>
-        )}
         {/* Header */}
         <header className="border-line-2 flex shrink-0 items-center justify-between border-b px-6 py-5">
           <div>
@@ -231,7 +226,7 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
                     className="w-full"
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                     addLabel="조건 추가"
                     placeholder="충족되어야 하는 조건을 입력하세요"
                   />
@@ -252,7 +247,7 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
                   <StepBoxEditor
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                   />
                 )}
               />
@@ -271,7 +266,7 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
                   <StepBoxEditor
                     value={parseSteps(field.value ?? '')}
                     onChange={(steps) => field.onChange(serializeSteps(steps))}
-                    disabled={isPending}
+
                     addLabel="결과 추가"
                     placeholder="예상되는 결과를 입력하세요"
                   />
@@ -282,11 +277,11 @@ export const TestCaseEditForm = ({ testCase, onClose, onSuccess }: TestCaseEditF
 
           {/* Actions */}
           <div className="border-line-2 flex justify-end gap-3 border-t pt-6">
-            <DSButton type="button" variant="ghost" onClick={handleAbandon} disabled={isPending}>
+            <DSButton type="button" variant="ghost" onClick={handleAbandon}>
               취소
             </DSButton>
-            <DSButton type="submit" variant="solid" disabled={isPending}>
-              {isPending ? '수정 중...' : '테스트 케이스 수정'}
+            <DSButton type="submit" variant="solid">
+              테스트 케이스 수정
             </DSButton>
           </div>
         </form>

--- a/src/features/cases-list/api/query.ts
+++ b/src/features/cases-list/api/query.ts
@@ -1,4 +1,4 @@
-import { getTestCase, getTestCases } from '@/entities';
+import { getTestCase, getTestCasesList } from '@/entities';
 import { QUERY_STALE_TIME_DEFAULT } from '@/shared/constants/query';
 import { queryOptions } from '@tanstack/react-query';
 
@@ -11,7 +11,7 @@ export const testCaseQueryKeys = {
 export const testCasesQueryOptions = (projectId: string) =>
   queryOptions({
     queryKey: testCaseQueryKeys.list(projectId),
-    queryFn: () => getTestCases({ project_id: projectId }),
+    queryFn: () => getTestCasesList({ project_id: projectId }),
     staleTime: QUERY_STALE_TIME_DEFAULT,
   });
 

--- a/src/features/dashboard/api/get-dashboard-stats.ts
+++ b/src/features/dashboard/api/get-dashboard-stats.ts
@@ -3,7 +3,7 @@
 import * as Sentry from '@sentry/nextjs';
 import type { DashboardStats, ProjectInfo, RecentActivity, TestCaseStats, TestSuiteSummary } from '@/features';
 import { getDatabase, projects, suiteTestCases, testCases, testSuites } from '@/shared/lib/db';
-import { and, count, desc, eq, isNull, notInArray } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, notInArray } from 'drizzle-orm';
 import { ActionResult } from '@/shared/types';
 
 type GetDashboardStatsParams = {
@@ -41,82 +41,79 @@ export const getDashboardStats = async ({
       created_at: projectRow.created_at.toISOString(),
     };
 
-    // 테스트 케이스 통계 - projectRow.id 사용
-    const [testCaseCountResult] = await db
-      .select({ count: count() })
-      .from(testCases)
-      .where(eq(testCases.project_id, projectRow.id));
-
-    // 스위트 미지정 케이스 수
     const assignedTestCasesSubquery = db
-        .select({ id: suiteTestCases.test_case_id })
-        .from(suiteTestCases);
+      .select({ id: suiteTestCases.test_case_id })
+      .from(suiteTestCases);
 
-    const [unassignedCountResult] = await db
-        .select({ count: count() })
+    // 5개 독립 쿼리를 Promise.all로 병렬 실행
+    const [
+      [testCaseCountResult],
+      [unassignedCountResult],
+      suiteRows,
+      recentTestCases,
+      recentSuites,
+    ] = await Promise.all([
+      db.select({ count: count() })
+        .from(testCases)
+        .where(eq(testCases.project_id, projectRow.id)),
+      db.select({ count: count() })
         .from(testCases)
         .where(
-            and(
-                eq(testCases.project_id, projectRow.id),
-                notInArray(testCases.id, assignedTestCasesSubquery)
-            )
-        );
+          and(
+            eq(testCases.project_id, projectRow.id),
+            notInArray(testCases.id, assignedTestCasesSubquery)
+          )
+        ),
+      db.select({
+          id: testSuites.id,
+          name: testSuites.name,
+          description: testSuites.description,
+        })
+        .from(testSuites)
+        .where(eq(testSuites.project_id, projectRow.id)),
+      db.select({
+          id: testCases.id,
+          title: testCases.name,
+          created_at: testCases.created_at,
+        })
+        .from(testCases)
+        .where(eq(testCases.project_id, projectRow.id))
+        .orderBy(desc(testCases.created_at))
+        .limit(5),
+      db.select({
+          id: testSuites.id,
+          title: testSuites.name,
+          created_at: testSuites.created_at,
+        })
+        .from(testSuites)
+        .where(eq(testSuites.project_id, projectRow.id))
+        .orderBy(desc(testSuites.created_at))
+        .limit(5),
+    ]);
 
     const testCaseStats: TestCaseStats = {
       total: testCaseCountResult?.count ?? 0,
       unassigned: unassignedCountResult?.count ?? 0,
     };
 
-    // 테스트 스위트 목록 - 단순 조회 (케이스 수는 별도 계산)
-    const suiteRows = await db
-      .select({
-        id: testSuites.id,
-        name: testSuites.name,
-        description: testSuites.description,
-      })
-      .from(testSuites)
-      .where(eq(testSuites.project_id, projectRow.id));
+    // 스위트별 케이스 수: N+1 → 단일 GROUP BY 쿼리로 해결
+    let caseCountMap = new Map<string, number>();
+    if (suiteRows.length > 0) {
+      const suiteIds = suiteRows.map((r) => r.id);
+      const caseCountRows = await db
+        .select({ suiteId: suiteTestCases.suite_id, cnt: count() })
+        .from(suiteTestCases)
+        .where(inArray(suiteTestCases.suite_id, suiteIds))
+        .groupBy(suiteTestCases.suite_id);
+      caseCountMap = new Map(caseCountRows.map((r) => [r.suiteId, Number(r.cnt)]));
+    }
 
-    // 각 스위트별 케이스 수 계산
-    const testSuitesResult: TestSuiteSummary[] = await Promise.all(
-      suiteRows.map(async (row) => {
-        const [caseCountResult] = await db
-          .select({ count: count() })
-          .from(suiteTestCases)
-          .where(eq(suiteTestCases.suite_id, row.id));
-
-        return {
-          id: row.id,
-          name: row.name,
-          description: row.description ?? '',
-          case_count: caseCountResult?.count ?? 0,
-        };
-      })
-    );
-
-    // 최근 테스트 케이스 - projectRow.id 사용
-    const recentTestCases = await db
-      .select({
-        id: testCases.id,
-        title: testCases.name,
-        created_at: testCases.created_at,
-      })
-      .from(testCases)
-      .where(eq(testCases.project_id, projectRow.id))
-      .orderBy(desc(testCases.created_at))
-      .limit(5);
-
-    // 최근 스위트 - projectRow.id 사용
-    const recentSuites = await db
-      .select({
-        id: testSuites.id,
-        title: testSuites.name,
-        created_at: testSuites.created_at,
-      })
-      .from(testSuites)
-      .where(eq(testSuites.project_id, projectRow.id))
-      .orderBy(desc(testSuites.created_at))
-      .limit(5);
+    const testSuitesResult: TestSuiteSummary[] = suiteRows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      description: row.description ?? '',
+      case_count: caseCountMap.get(row.id) ?? 0,
+    }));
 
     // 최근 활동 합치기 및 정렬
     const recentActivities: RecentActivity[] = [

--- a/src/shared/lib/db/get-project-storage.ts
+++ b/src/shared/lib/db/get-project-storage.ts
@@ -1,11 +1,20 @@
 import { sql } from 'drizzle-orm';
 import { getDatabase } from './drizzle';
 
+const storageCache = new Map<string, { bytes: number; ts: number }>();
+const CACHE_TTL_MS = 60_000;
+
 /**
  * 프로젝트에 속한 모든 테이블의 데이터 크기를 합산하여 바이트 단위로 반환합니다.
  * PostgreSQL의 pg_column_size()를 사용합니다.
+ * 60초 TTL 인메모리 캐시 적용.
  */
 export async function getProjectStorageBytes(projectId: string): Promise<number> {
+  const cached = storageCache.get(projectId);
+  if (cached && Date.now() - cached.ts < CACHE_TTL_MS) {
+    return cached.bytes;
+  }
+
   const db = getDatabase();
 
   const result = await db.execute(sql`
@@ -40,5 +49,9 @@ export async function getProjectStorageBytes(projectId: string): Promise<number>
   `);
 
   const row = result[0] as { total: string | number } | undefined;
-  return Number(row?.total ?? 0);
+  const bytes = Number(row?.total ?? 0);
+
+  storageCache.set(projectId, { bytes, ts: Date.now() });
+
+  return bytes;
 }

--- a/src/view/project/cases/test-case-side-view.tsx
+++ b/src/view/project/cases/test-case-side-view.tsx
@@ -6,6 +6,8 @@ import { useQuery } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 
 import { TestCase, parseSteps } from '@/entities/test-case';
+import type { TestCaseListItem } from '@/entities/test-case/model/types';
+import { testCaseByIdQueryOptions } from '@/features/cases-list';
 import { ArchiveButton } from '@/features/archive/ui/archive-button';
 import { TestCaseEditForm } from '@/features/cases-edit';
 // import { SaveAsTemplateModal } from '@/features/templates-save-from-case'; // 템플릿 기능 펜딩
@@ -28,11 +30,21 @@ import { Calendar, Clock, Copy, Edit2, Flag, FolderOpen, History, Maximize2, Pla
 
 
 interface TestCaseSideViewProps {
-  testCase?: TestCase;
+  testCase?: TestCaseListItem;
   onClose: () => void;
 }
 
-export const TestCaseSideView = ({ testCase, onClose }: TestCaseSideViewProps) => {
+export const TestCaseSideView = ({ testCase: listItem, onClose }: TestCaseSideViewProps) => {
+  // 목록 데이터에서 빠진 상세 필드(steps, preCondition, expectedResult)를 별도 조회
+  const { data: detailData } = useQuery({
+    ...testCaseByIdQueryOptions(listItem?.id ?? ''),
+    enabled: !!listItem?.id,
+  });
+  const testCase = detailData?.success
+    ? detailData.data
+    : listItem
+      ? { ...listItem, preCondition: '', testSteps: '', expectedResult: '' } as TestCase
+      : undefined;
   const router = useRouter();
   const params = useParams();
   const [isEditOpen, setIsEditOpen] = useState(false);

--- a/src/view/project/cases/test-cases-view.tsx
+++ b/src/view/project/cases/test-cases-view.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { useParams } from 'next/navigation';
 
 import { TestCaseCard, TestCaseCardType } from '@/entities/test-case';
+import { projectIdQueryOptions } from '@/entities/project';
 import { testSuitesQueryOptions } from '@/entities/test-suite';
 import { TestCaseDetailForm, useCreateCase } from '@/features/cases-create';
 import { testCasesQueryOptions } from '@/features/cases-list';
@@ -55,7 +56,7 @@ export const TestCasesView = () => {
   const params = useParams();
   const inputRef = useRef<HTMLInputElement>(null);
   const { onClose, onOpen, isActiveType } = useDisclosure<ModalType>();
-  const { mutate, isPending } = useCreateCase();
+  const { mutate } = useCreateCase();
   const [selectedTestCaseId, setSelectedTestCaseId] = useState<string | null>(null);
 
   // 검색 및 필터 상태
@@ -67,11 +68,16 @@ export const TestCasesView = () => {
   const [visibleCount, setVisibleCount] = useState(30);
   const PAGE_SIZE = 30;
 
-  const { data: dashboardData, isLoading: isLoadingProject } = useQuery(
-    dashboardQueryOptions.stats(params.slug as string),
-  );
+  const slug = params.slug as string;
 
-  const projectId = dashboardData?.success ? dashboardData.data.project.id : undefined;
+  // slug → projectId를 단일 SELECT로 빠르게 획득 (워터폴 제거)
+  const { data: projectIdData } = useQuery(projectIdQueryOptions(slug));
+  const projectId = projectIdData?.success ? projectIdData.data.id : undefined;
+
+  // dashboard, testCases, testSuites 모두 동시 시작 (워터폴 제거)
+  const { data: dashboardData, isLoading: isLoadingProject } = useQuery(
+    dashboardQueryOptions.stats(slug),
+  );
 
   const { data: testCasesData, isLoading: isLoadingCases } = useQuery({
     ...testCasesQueryOptions(projectId!),
@@ -200,15 +206,15 @@ export const TestCasesView = () => {
 
   const handleCreateTestCase = () => {
     const title = inputRef.current?.value.trim();
-    if (!title || isPending) return;
+    if (!title) return;
+
+    // optimistic update로 즉시 반영되므로 입력 즉시 초기화
+    if (inputRef.current) inputRef.current.value = '';
 
     const suiteId = selectedSuiteId !== 'all' && selectedSuiteId !== '__uncategorized__' ? selectedSuiteId : undefined;
     mutate(
       { title, projectId: projectId!, ...(suiteId ? { testSuiteId: suiteId } : {}) },
       {
-        onSuccess: () => {
-          if (inputRef.current) inputRef.current.value = '';
-        },
         onError: (error) => {
           toast.error(error.message || '테스트 케이스 생성에 실패했습니다.');
         },
@@ -376,7 +382,6 @@ export const TestCasesView = () => {
                     type="text"
                     placeholder="새로운 테스트 케이스 이름을 입력하고 Enter를 누르세요..."
                     className="typo-body2-normal text-text-1 placeholder:text-text-3 flex-1 bg-transparent focus:outline-none"
-                    disabled={isPending}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         handleCreateTestCase();


### PR DESCRIPTION
  ## Summary

  테스트 케이스 생성 및 목록 조회 시 체감 로딩이 느린 문제를 해결합니다.
  서버 액션의 순차 DB 호출, 클라이언트 쿼리 워터폴, 과도한 캐시 무효화 등
  복합적인 병목을 제거하고,
  생성/수정 시 Optimistic Update를 적용하여 즉각적인 UI 반응을 제공합니다.

  ## Changes

  ### 서버 사이드 최적화
  - **checkStorageLimit 캐싱**: 11-table UNION 풀스캔에 60초 인메모리 TTL
  캐시 적용
  - **createTestCase 병렬화**: `requireProjectAccess` +
  `checkStorageLimit`를 `Promise.all`로 동시 실행
  - **getDashboardStats N+1 해결**: 스위트별 케이스 카운트를 N개 순차 쿼리 →
   단일 `GROUP BY`로 변경, 나머지 5개 독립 쿼리 `Promise.all` 병렬화
  - **getTestSuitesWithStats 병렬화**: Q2~Q6 독립 쿼리를 `Promise.all`로
  묶어 7단계 순차 → 3단계로 축소
  - **getTestCasesList 컬럼 프로젝션**: 목록 조회 시 `steps`,
  `pre_condition`, `expected_result` 제외하여 페이로드 ~50% 감소
  - **getProjectTags DB 집계**: JS 후처리(중복 제거 + 빈도 정렬)를 SQL
  `GROUP BY + ORDER BY`로 이동

  ### 클라이언트 사이드 최적화
  - **쿼리 워터폴 제거**: `getProjectIdBySlug` 신규 추가로 dashboard 완료를
  기다리지 않고 testCases/testSuites 동시 시작
  - **캐시 무효화 스코핑**: `['testCases']` 전체 무효화 → `['testCases',
  'list', projectId]`로 해당 프로젝트만
  - **Optimistic Update 적용**: 인라인 생성, 상세 폼 생성, 수정 폼 모두 서버
   응답 전 즉시 UI 반영 + 실패 시 롤백
  - **로딩 오버레이 제거**: 생성/수정 폼의 isPending 블로킹 UI 제거, 제출
  즉시 폼 닫힘

  ## 예상 효과

  | 병목 | Before | After |
  |---|---|---|
  | 페이지 로드 | dashboard 완료 후 cases/suites 시작 | 3개 동시 시작 |
  | 케이스 생성 체감 | 서버 응답 대기 (~800ms) | 즉시 반영 (0ms) |
  | getDashboardStats | 5+N 순차 쿼리 | 1 + Promise.all(5) + 1 GROUP BY |
  | 네트워크 페이로드 | 전체 컬럼 포함 | TEXT 필드 제외 |
  | 캐시 무효화 | 모든 프로젝트 refetch | 해당 프로젝트만 |

  ## Test plan

  - [ ] 테스트 케이스 인라인 생성 → 즉시 목록에 표시되는지 확인
  - [ ] 테스트 케이스 상세 폼 생성 → 폼 즉시 닫히고 목록 반영 확인
  - [ ] 테스트 케이스 수정 → 폼 즉시 닫히고 변경사항 반영 확인
  - [ ] 생성/수정 실패 시 롤백 + toast 에러 표시 확인
  - [ ] 대시보드 통계 정상 표시 확인
  - [ ] 스위트 목록 및 통계 정상 확인
  - [ ] 사이드뷰에서 상세 내용(steps, preCondition 등) 정상 로드 확인