### PR TITLE
fix: 테스트 스위트 목록 10개 제한 제거

### DIFF
--- a/src/entities/test-suite/api/server-actions.ts
+++ b/src/entities/test-suite/api/server-actions.ts
@@ -88,11 +88,11 @@ export const createTestSuite = async (input: CreateTestSuite): Promise<ActionRes
 
 export const getTestSuites = async ({
   projectId,
-  limits = { offset: 0, limit: 10 },
+  limits = { offset: 0, limit: Infinity },
 }: GetTestSuitesParams): Promise<ActionResult<TestSuite[]>> => {
   try {
     const db = getDatabase();
-    const rows = await db
+    let query = db
       .select()
       .from(testSuites)
       .where(
@@ -101,8 +101,13 @@ export const getTestSuites = async ({
           eq(testSuites.lifecycle_status, 'ACTIVE')
         )
       )
-      .limit(limits.limit)
-      .offset(limits.offset);
+      .$dynamic();
+
+    if (Number.isFinite(limits.limit)) {
+      query = query.limit(limits.limit).offset(limits.offset);
+    }
+
+    const rows = await query;
 
     if (!rows) {
       return {
@@ -297,18 +302,23 @@ export const updateTestSuite = async (params: UpdateTestSuiteParams): Promise<Ac
  */
 export const getTestSuitesWithStats = async ({
   projectId,
-  limits = { offset: 0, limit: 50 },
+  limits = { offset: 0, limit: Infinity },
 }: GetTestSuitesParams): Promise<ActionResult<TestSuiteCard[]>> => {
   try {
     const db = getDatabase();
 
     // 1) 기본 스위트 목록
-    const suiteRows = await db
+    let suiteQuery = db
       .select()
       .from(testSuites)
       .where(and(eq(testSuites.project_id, projectId), eq(testSuites.lifecycle_status, 'ACTIVE')))
-      .limit(limits.limit)
-      .offset(limits.offset);
+      .$dynamic();
+
+    if (Number.isFinite(limits.limit)) {
+      suiteQuery = suiteQuery.limit(limits.limit).offset(limits.offset);
+    }
+
+    const suiteRows = await suiteQuery;
 
     if (suiteRows.length === 0) {
       return { success: true, data: [] };


### PR DESCRIPTION
## Summary
- `getTestSuites` 기본 limit 10 → Infinity로 변경
- `getTestSuitesWithStats` 기본 limit 50 → Infinity로 변경
- `Number.isFinite()` 체크로 유한 limit일 때만 DB에 LIMIT/OFFSET 적용
- 향후 SaaS 유료 플랜 도입 시 limit 파라미터로 차별화 가능

## 영향 범위
- 테스트케이스 목록 스위트 사이드바
- 마일스톤 생성/편집 시 스위트 선택
- 스위트 목록 페이지

## Test plan
- [ ] 스위트 10개 이상인 프로젝트에서 테스트케이스 목록 사이드바에 전체 표시 확인
- [ ] 마일스톤 편집 시 스위트 선택 목록에 전체 표시 확인
- [ ] 스위트 목록 페이지 정상 동작 확인