### PR TITLE
fix: 빈 스위트 마일스톤 추가 시 test_run_suites 링크 누락 수정

### DIFF
--- a/src/entities/milestone/api/server-actions.ts
+++ b/src/entities/milestone/api/server-actions.ts
@@ -402,6 +402,17 @@ export const addTestSuitesToMilestone = async (
       .where(eq(testRuns.milestone_id, milestoneId));
 
     if (linkedRuns.length > 0) {
+      // Always link suites to runs (even if suites are empty)
+      for (const run of linkedRuns) {
+        await db
+          .insert(testRunSuites)
+          .values(testSuiteIds.map((suiteId) => ({
+            test_run_id: run.id,
+            test_suite_id: suiteId,
+          })))
+          .onConflictDoNothing();
+      }
+
       // Get individual test cases from the added suites
       const suiteCaseRows = await db
         .select({ id: testCases.id, test_suite_id: testCases.test_suite_id })
@@ -423,15 +434,6 @@ export const addTestSuitesToMilestone = async (
         const caseIds = Array.from(caseIdToSuite.keys());
 
         for (const run of linkedRuns) {
-          // Link suites to the run
-          await db
-            .insert(testRunSuites)
-            .values(testSuiteIds.map((suiteId) => ({
-              test_run_id: run.id,
-              test_suite_id: suiteId,
-            })))
-            .onConflictDoNothing();
-
           // Find which cases already exist in this run
           const existingRows = await db
             .select({ test_case_id: testCaseRuns.test_case_id })


### PR DESCRIPTION
## Summary
- 빈 스위트를 마일스톤에 추가할 때 `test_run_suites` 엔트리가 생성되지 않는 버그 수정
- `test_run_suites` INSERT를 `suiteCaseRows.length > 0` 조건 밖으로 이동하여 빈 스위트도 테스트 실행에 링크되도록 변경
- 이로써 `syncCaseToLinkedRuns`가 나중에 추가된 케이스를 정상적으로 테스트 실행에 반영 가능

## Root Cause
`addTestSuitesToMilestone`에서 스위트에 케이스가 없으면(`suiteCaseRows.length === 0`) `test_run_suites` INSERT가 스킵됨. 이후 해당 스위트에 케이스를 추가해도 `syncCaseToLinkedRuns`가 `test_run_suites`에서 연결된 런을 찾지 못해 동기화 실패.

## Test plan
- [ ] 빈 스위트를 마일스톤에 추가 후 케이스 생성 → 테스트 실행에 반영되는지 확인
- [ ] 케이스가 있는 스위트를 마일스톤에 추가 → 기존 동작 정상 확인