### PR TITLE
feat: 기존 테스트 실행 누락 케이스 백필 API

### DIFF
--- a/app/api/backfill-test-runs/route.ts
+++ b/app/api/backfill-test-runs/route.ts
@@ -1,0 +1,201 @@
+import { NextResponse } from 'next/server';
+import {
+  getDatabase,
+  testRuns,
+  testRunSuites,
+  testCaseRuns,
+  testCases,
+  milestoneTestSuites,
+  milestoneTestCases,
+} from '@/shared/lib/db';
+import { eq, and, inArray } from 'drizzle-orm';
+import { v7 as uuidv7 } from 'uuid';
+
+export async function POST(request: Request) {
+  // Simple auth: require a secret header to prevent unauthorized access
+  const authHeader = request.headers.get('x-backfill-secret');
+  if (authHeader !== process.env.BACKFILL_SECRET && authHeader !== 'backfill-2024') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const db = getDatabase();
+  const log: string[] = [];
+
+  try {
+    // 1. Get all test runs that have a milestone
+    const allRuns = await db
+      .select({ id: testRuns.id, milestone_id: testRuns.milestone_id, name: testRuns.name })
+      .from(testRuns)
+      .where(eq(testRuns.status, 'IN_PROGRESS'));
+
+    log.push(`Found ${allRuns.length} in-progress test runs`);
+
+    let totalSuiteLinksCreated = 0;
+    let totalCaseRunsCreated = 0;
+
+    for (const run of allRuns) {
+      if (!run.milestone_id) continue;
+
+      // 2. Get all suites linked to this milestone
+      const msSuites = await db
+        .select({ test_suite_id: milestoneTestSuites.test_suite_id })
+        .from(milestoneTestSuites)
+        .where(eq(milestoneTestSuites.milestone_id, run.milestone_id));
+
+      const suiteIds = msSuites
+        .map((s) => s.test_suite_id)
+        .filter(Boolean) as string[];
+
+      if (suiteIds.length > 0) {
+        // 3. Ensure test_run_suites entries exist
+        const existingRunSuites = await db
+          .select({ test_suite_id: testRunSuites.test_suite_id })
+          .from(testRunSuites)
+          .where(eq(testRunSuites.test_run_id, run.id));
+
+        const existingSuiteIds = new Set(
+          existingRunSuites.map((s) => s.test_suite_id)
+        );
+        const missingSuiteIds = suiteIds.filter(
+          (id) => !existingSuiteIds.has(id)
+        );
+
+        if (missingSuiteIds.length > 0) {
+          await db
+            .insert(testRunSuites)
+            .values(
+              missingSuiteIds.map((suiteId) => ({
+                test_run_id: run.id,
+                test_suite_id: suiteId,
+              }))
+            )
+            .onConflictDoNothing();
+
+          totalSuiteLinksCreated += missingSuiteIds.length;
+          log.push(
+            `Run "${run.name}": added ${missingSuiteIds.length} missing suite links`
+          );
+        }
+
+        // 4. Get all ACTIVE cases from these suites
+        const suiteCaseRows = await db
+          .select({ id: testCases.id, test_suite_id: testCases.test_suite_id })
+          .from(testCases)
+          .where(
+            and(
+              inArray(testCases.test_suite_id, suiteIds),
+              eq(testCases.lifecycle_status, 'ACTIVE')
+            )
+          );
+
+        if (suiteCaseRows.length > 0) {
+          const caseIds = suiteCaseRows
+            .map((r) => r.id)
+            .filter(Boolean) as string[];
+
+          // 5. Check which cases already exist in test_case_runs
+          const existingCaseRuns = await db
+            .select({ test_case_id: testCaseRuns.test_case_id })
+            .from(testCaseRuns)
+            .where(
+              and(
+                eq(testCaseRuns.test_run_id, run.id),
+                inArray(testCaseRuns.test_case_id, caseIds)
+              )
+            );
+
+          const existingCaseIds = new Set(
+            existingCaseRuns.map((r) => r.test_case_id)
+          );
+          const missingCases = suiteCaseRows.filter(
+            (r) => r.id && !existingCaseIds.has(r.id)
+          );
+
+          if (missingCases.length > 0) {
+            await db.insert(testCaseRuns).values(
+              missingCases.map((c) => ({
+                id: uuidv7(),
+                test_run_id: run.id,
+                test_case_id: c.id,
+                status: 'untested' as const,
+                source_type: 'suite' as const,
+                source_id: c.test_suite_id,
+                created_at: new Date(),
+                updated_at: new Date(),
+              }))
+            );
+
+            totalCaseRunsCreated += missingCases.length;
+            log.push(
+              `Run "${run.name}": added ${missingCases.length} missing case runs from suites`
+            );
+          }
+        }
+      }
+
+      // 6. Also handle direct milestone-case links
+      const msCases = await db
+        .select({ test_case_id: milestoneTestCases.test_case_id })
+        .from(milestoneTestCases)
+        .where(eq(milestoneTestCases.milestone_id, run.milestone_id));
+
+      const msCaseIds = msCases
+        .map((c) => c.test_case_id)
+        .filter(Boolean) as string[];
+
+      if (msCaseIds.length > 0) {
+        const existingMsCaseRuns = await db
+          .select({ test_case_id: testCaseRuns.test_case_id })
+          .from(testCaseRuns)
+          .where(
+            and(
+              eq(testCaseRuns.test_run_id, run.id),
+              inArray(testCaseRuns.test_case_id, msCaseIds)
+            )
+          );
+
+        const existingMsCaseIds = new Set(
+          existingMsCaseRuns.map((r) => r.test_case_id)
+        );
+        const missingMsCaseIds = msCaseIds.filter(
+          (id) => !existingMsCaseIds.has(id)
+        );
+
+        if (missingMsCaseIds.length > 0) {
+          await db.insert(testCaseRuns).values(
+            missingMsCaseIds.map((caseId) => ({
+              id: uuidv7(),
+              test_run_id: run.id,
+              test_case_id: caseId,
+              status: 'untested' as const,
+              source_type: 'milestone' as const,
+              source_id: run.milestone_id,
+              created_at: new Date(),
+              updated_at: new Date(),
+            }))
+          );
+
+          totalCaseRunsCreated += missingMsCaseIds.length;
+          log.push(
+            `Run "${run.name}": added ${missingMsCaseIds.length} missing case runs from milestone`
+          );
+        }
+      }
+    }
+
+    log.push(`--- DONE ---`);
+    log.push(`Total suite links created: ${totalSuiteLinksCreated}`);
+    log.push(`Total case runs created: ${totalCaseRunsCreated}`);
+
+    return NextResponse.json({
+      success: true,
+      suiteLinksCreated: totalSuiteLinksCreated,
+      caseRunsCreated: totalCaseRunsCreated,
+      log,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.push(`ERROR: ${message}`);
+    return NextResponse.json({ success: false, error: message, log }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- 기존 테스트 실행에 누락된 `test_run_suites`와 `test_case_runs`를 일괄 백필하는 API
- `POST /api/backfill-test-runs` (x-backfill-secret 헤더: `backfill-2024`)
- IN_PROGRESS 상태의 모든 테스트 실행 대상

## 동작
1. 마일스톤에 연결된 스위트 → `test_run_suites` 누락분 생성
2. 해당 스위트의 ACTIVE 케이스 → `test_case_runs` 누락분 생성
3. 마일스톤 직접 연결 케이스 → `test_case_runs` 누락분 생성

## 사용법
```bash
curl -X POST https://your-domain.vercel.app/api/backfill-test-runs \
  -H "x-backfill-secret: backfill-2024"
```

## Test plan
- [ ] 머지 후 배포된 URL에 POST 요청 → 누락 케이스 백필 확인
- [ ] 백필 후 테스트 실행 상세에서 모든 스위트 케이스 노출 확인
- [ ] 백필 완료 후 이 API 루트 삭제 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)