### PR TITLE
refactor: 테스트 케이스 카드 UI 리디자인 및 뷰 레이아웃 사이드바 중복 제거

### DIFF
--- a/src/entities/test-case/ui/test-case-card.tsx
+++ b/src/entities/test-case/ui/test-case-card.tsx
@@ -1,43 +1,90 @@
 import React from 'react';
 
-import type { TestCaseCardType } from '@/entities/test-case';
+import type { TestCaseCardType, TestCaseResultStatus } from '@/entities/test-case';
 import { MoreHorizontal } from 'lucide-react';
-import { formatDate } from '@/shared/utils/date-format';
+import { formatRelativeTime } from '@/shared/utils/date-format';
+import { cn } from '@/shared/utils';
+
+const STATUS_CONFIG: Record<TestCaseResultStatus, { bar: string; dot: string; label: string; badge: string }> = {
+  untested: {
+    bar: 'bg-text-4',
+    dot: 'bg-text-4',
+    label: 'Untested',
+    badge: 'bg-bg-3 text-text-3',
+  },
+  pass: {
+    bar: 'bg-emerald-500',
+    dot: 'bg-emerald-500',
+    label: 'Pass',
+    badge: 'bg-emerald-500/10 text-emerald-600',
+  },
+  fail: {
+    bar: 'bg-red-500',
+    dot: 'bg-red-500',
+    label: 'Fail',
+    badge: 'bg-red-500/10 text-red-600',
+  },
+  blocked: {
+    bar: 'bg-amber-500',
+    dot: 'bg-amber-500',
+    label: 'Blocked',
+    badge: 'bg-amber-500/10 text-amber-600',
+  },
+};
 
 interface TestCaseCardProps {
   testCase: TestCaseCardType;
 }
 
 export const TestCaseCard = ({ testCase }: TestCaseCardProps) => {
+  const status = STATUS_CONFIG[testCase.resultStatus] ?? STATUS_CONFIG.untested;
+
   return (
-    <>
-      <div className="col-span-2">
-        <span className="typo-body2-heading text-text-1 group-hover:text-primary transition-colors">
-          {testCase.caseKey}
-        </span>
+    <div className="flex items-stretch gap-0 w-full min-w-0">
+      {/* Left color bar */}
+      <div className={cn('w-[3px] shrink-0 rounded-full self-stretch', status.bar)} />
+
+      {/* Content */}
+      <div className="flex flex-1 flex-col gap-1 pl-3 min-w-0">
+        {/* Line 1: caseKey + title + time */}
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="typo-caption-normal text-text-3 shrink-0">
+            {testCase.caseKey}
+          </span>
+          <span className="typo-body2-normal text-text-1 w-[600px] shrink-0 truncate group-hover:text-primary transition-colors">
+            {testCase.title}
+          </span>
+          <span className="typo-caption-normal text-text-4 ml-auto shrink-0">
+            {formatRelativeTime(testCase.updatedAt)}
+          </span>
+        </div>
+
+        {/* Line 2: status badge + suite pill */}
+        <div className="flex items-center gap-2">
+          {testCase.resultStatus !== 'untested' && (
+            <span className={cn('inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium', status.badge)}>
+              <span className={cn('h-1.5 w-1.5 rounded-full', status.dot)} />
+              {status.label}
+            </span>
+          )}
+
+          {testCase.suiteTitle && (
+            <span className="inline-flex items-center rounded-full bg-bg-3 px-2 py-0.5 text-xs text-text-3 truncate max-w-[160px]">
+              {testCase.suiteTitle}
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="col-span-6 flex flex-col gap-1">
-        <span className="typo-body2-heading text-text-1 group-hover:text-primary transition-colors">
-          {testCase.title}
-        </span>
-        <span className="typo-caption-normal text-text-3 hover:underline">
-          {testCase.suiteTitle}
-        </span>
-      </div>
-
-      <div className="typo-caption-normal text-text-3 col-span-3 text-center">
-        {formatDate(testCase.updatedAt)}
-      </div>
-
-      <div className="col-span-1 flex justify-end">
+      {/* Hover-reveal menu */}
+      <div className="flex items-center shrink-0 pl-2">
         <button
-          className="rounded-1 text-text-3 hover:bg-bg-4 hover:text-text-1 p-1 transition-colors cursor-pointer group"
+          className="rounded-1 text-text-4 hover:bg-bg-4 hover:text-text-1 p-1 transition-all cursor-pointer opacity-0 group-hover:opacity-100"
           onClick={(e) => e.stopPropagation()}
         >
           <MoreHorizontal className="h-4 w-4" />
         </button>
       </div>
-    </>
+    </div>
   );
 };

--- a/src/view/project/cases/test-cases-view.tsx
+++ b/src/view/project/cases/test-cases-view.tsx
@@ -43,12 +43,6 @@ const SORT_OPTIONS = [
 
 type SortValue = (typeof SORT_OPTIONS)[number]['value'];
 
-const TABLE_HEADERS = [
-  { id: 'id', label: 'ID', colSpan: 'col-span-2' },
-  { id: 'title', label: '제목', colSpan: 'col-span-6' },
-  { id: 'updatedAt', label: '최종 수정', colSpan: 'col-span-3', textAlign: 'text-center' },
-  { id: 'actions', label: '메뉴', colSpan: 'col-span-1', textAlign: 'text-right' },
-] as const;
 
 const PAGE_SIZE = 15;
 
@@ -187,28 +181,25 @@ export const TestCasesView = () => {
               <div className="h-9 w-40 animate-pulse rounded-2 bg-bg-3" />
             </div>
           </div>
-          <section className="rounded-4 border-line-2 bg-bg-2 col-span-6 overflow-hidden border">
-            <div className="grid grid-cols-12 gap-4 border-b border-line-2 px-6 py-3">
-              <div className="col-span-2 h-4 w-8 animate-pulse rounded bg-bg-3" />
-              <div className="col-span-6 h-4 w-12 animate-pulse rounded bg-bg-3" />
-              <div className="col-span-3 flex justify-center"><div className="h-4 w-16 animate-pulse rounded bg-bg-3" /></div>
-              <div className="col-span-1 flex justify-end"><div className="h-4 w-10 animate-pulse rounded bg-bg-3" /></div>
-            </div>
-            <div className="grid grid-cols-12 gap-4 border-b border-line-2 bg-primary/5 px-6 py-3">
-              <div className="col-span-12 flex items-center gap-3">
-                <div className="rounded-1 bg-primary/20 h-6 w-6 animate-pulse rounded" />
-                <div className="h-5 flex-1 animate-pulse rounded bg-bg-3" />
-              </div>
+          <section className="rounded-3 border-line-2 bg-bg-2 col-span-6 border">
+            <div className="flex items-center gap-3 border-b border-line-2 bg-primary/5 px-4 py-2.5">
+              <div className="rounded-1 bg-primary/20 h-6 w-6 animate-pulse rounded" />
+              <div className="h-5 flex-1 animate-pulse rounded bg-bg-3" />
             </div>
             {Array.from({ length: 15 }).map((_, i) => (
-              <div key={i} className="grid grid-cols-12 gap-4 border-b border-line-2 px-6 py-4">
-                <div className="col-span-2"><div className="h-4 w-16 animate-pulse rounded bg-bg-3" /></div>
-                <div className="col-span-6 flex flex-col gap-1.5">
-                  <div className="h-4 animate-pulse rounded bg-bg-3" style={{ width: `${SKELETON_WIDTHS[i % SKELETON_WIDTHS.length]}%` }} />
-                  <div className="h-3 w-20 animate-pulse rounded bg-bg-3" />
+              <div key={i} className="flex items-stretch gap-0 border-b border-line-2 px-4 py-3">
+                <div className="w-[3px] shrink-0 rounded-full bg-bg-3 animate-pulse" />
+                <div className="flex flex-1 flex-col gap-1.5 pl-3">
+                  <div className="flex items-center gap-2">
+                    <div className="h-3 w-12 animate-pulse rounded bg-bg-3" />
+                    <div className="h-4 animate-pulse rounded bg-bg-3" style={{ width: `${SKELETON_WIDTHS[i % SKELETON_WIDTHS.length]}%` }} />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="h-5 w-16 animate-pulse rounded-full bg-bg-3" />
+                    <div className="h-5 w-20 animate-pulse rounded-full bg-bg-3" />
+                    <div className="ml-auto h-3 w-12 animate-pulse rounded bg-bg-3" />
+                  </div>
                 </div>
-                <div className="col-span-3 flex justify-center"><div className="h-4 w-24 animate-pulse rounded bg-bg-3" /></div>
-                <div className="col-span-1 flex justify-end"><div className="h-4 w-4 animate-pulse rounded bg-bg-3" /></div>
               </div>
             ))}
           </section>
@@ -388,66 +379,72 @@ export const TestCasesView = () => {
 
           {/* Test Case List Container */}
           <section className={cn(
-            "rounded-4 border-line-2 bg-bg-2 shadow-1 col-span-6 border transition-opacity",
+            "rounded-3 border-line-2 bg-bg-2 shadow-1 col-span-6 border transition-opacity",
             isFetching && testCasesData ? 'opacity-60' : 'opacity-100'
           )}>
-            <TestTable.Root>
-              <TestTable.Header headers={TABLE_HEADERS} />
-              <TestTable.Row className="group border-line-2 bg-primary/5 hover:bg-primary/10 grid grid-cols-12 gap-4 border-b px-6 py-3 transition-colors">
-                <div className="col-span-12 flex items-center gap-3">
-                  <div className="rounded-1 bg-primary/20 text-primary flex h-6 w-6 items-center justify-center">
-                    <Plus className="h-4 w-4" />
-                  </div>
-                  <Input
-                    ref={inputRef}
-                    type="text"
-                    placeholder="새로운 테스트 케이스 이름을 입력하고 Enter를 누르세요..."
-                    className="typo-body2-normal text-text-1 placeholder:text-text-3 flex-1 bg-transparent focus:outline-none"
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        handleCreateTestCase();
-                      }
+            {/* Quick-create row */}
+            <div className="flex items-center gap-3 border-b border-line-2 bg-primary/5 px-4 py-3 transition-colors hover:bg-primary/10">
+              <div className="rounded-1 bg-primary/20 text-primary flex h-6 w-6 shrink-0 items-center justify-center">
+                <Plus className="h-4 w-4" />
+              </div>
+              <Input
+                ref={inputRef}
+                type="text"
+                placeholder="새로운 테스트 케이스 이름을 입력하고 Enter를 누르세요..."
+                className="typo-body2-normal text-text-1 placeholder:text-text-3 flex-1 bg-transparent focus:outline-none"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleCreateTestCase();
+                  }
+                }}
+              />
+            </div>
+
+            {/* List */}
+            {testCaseItems.length === 0 && pagination && pagination.totalItems === 0 ? (
+              <div className="flex flex-col items-center justify-center gap-2 py-12">
+                <p className="typo-body2-normal text-text-3">
+                  {debouncedSearch || selectedSuiteId !== 'all' ? '검색 결과가 없습니다.' : '테스트 케이스가 없습니다.'}
+                </p>
+                {(debouncedSearch || selectedSuiteId !== 'all') && (
+                  <button
+                    onClick={() => {
+                      setSearchQuery('');
+                      setSelectedSuiteId('all');
                     }}
-                  />
-                </div>
-              </TestTable.Row>
-              {testCaseItems.length === 0 && pagination && pagination.totalItems === 0 ? (
-                <div className="col-span-12 flex flex-col items-center justify-center gap-2 py-12">
-                  <p className="typo-body2-normal text-text-3">
-                    {debouncedSearch || selectedSuiteId !== 'all' ? '검색 결과가 없습니다.' : '테스트 케이스가 없습니다.'}
-                  </p>
-                  {(debouncedSearch || selectedSuiteId !== 'all') && (
-                    <button
-                      onClick={() => {
-                        setSearchQuery('');
-                        setSelectedSuiteId('all');
-                      }}
-                      className="typo-body2-normal text-primary hover:underline"
-                    >
-                      필터 초기화
-                    </button>
-                  )}
-                </div>
-              ) : (
-                testCaseItems.map((item) => (
-                  <TestTable.Row key={item.caseKey} onClick={() => {
-                    track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });
-                    setSelectedTestCaseId(item.id);
-                    onOpen('detail');
-                  }}>
+                    className="typo-body2-normal text-primary hover:underline"
+                  >
+                    필터 초기화
+                  </button>
+                )}
+              </div>
+            ) : (
+              <div className="divide-y divide-line-2">
+                {testCaseItems.map((item) => (
+                  <div
+                    key={item.caseKey}
+                    className="group flex cursor-pointer items-center overflow-hidden px-4 py-3 transition-colors hover:bg-bg-3"
+                    onClick={() => {
+                      track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });
+                      setSelectedTestCaseId(item.id);
+                      onOpen('detail');
+                    }}
+                  >
                     <TestCaseCard testCase={item} />
-                  </TestTable.Row>
-                ))
-              )}
-              {pagination && (
-                <TestTable.Pagination
-                  page={pagination.page}
-                  totalPages={pagination.totalPages}
-                  totalItems={pagination.totalItems}
-                  onPageChange={handlePageChange}
-                />
-              )}
-            </TestTable.Root>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {pagination && (
+              <TestTable.Pagination
+                page={pagination.page}
+                totalPages={pagination.totalPages}
+                totalItems={pagination.totalItems}
+                onPageChange={handlePageChange}
+              />
+            )}
           </section>
         </div>
       </MainContainer>

--- a/src/view/project/milestones/milestones-view.tsx
+++ b/src/view/project/milestones/milestones-view.tsx
@@ -9,10 +9,10 @@ import { projectIdQueryOptions } from '@/entities/project';
 import { MilestoneCreateForm, milestonesQueryOptions } from '@/features/milestones-create';
 import { MilestoneEditForm } from '@/features/milestones-edit';
 import { dashboardQueryOptions } from '@/features/dashboard';
-import { Container, MainContainer } from '@/shared/lib/primitives';
+import { MainContainer } from '@/shared/lib/primitives';
 import { LoadingSpinner } from '@/shared/ui';
 import { useDisclosure } from '@/shared/hooks';
-import { ActionToolbar, Aside } from '@/widgets';
+import { ActionToolbar } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { FolderOpen } from 'lucide-react';
 import { track, MILESTONE_EVENTS } from '@/shared/lib/analytics';
@@ -91,33 +91,23 @@ export const MilestonesView = () => {
   // 로딩 상태
   if (isLoadingProject || isLoadingMilestones) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <LoadingSpinner size="lg" />
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </MainContainer>
     );
   }
 
   // 에러 상태
   if (!dashboardData?.success) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
+      </MainContainer>
     );
   }
 
   return (
-    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-      {/* Aside */}
-      <Aside />
-      {/* Main Content */}
-      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
+    <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex w-full items-start justify-between gap-6">
           <div className="flex flex-col gap-2">
             <h1 className="typo-title-heading">마일스톤 & 테스트 진행 현황</h1>
@@ -222,6 +212,5 @@ export const MilestonesView = () => {
         {isOpen && projectId && <MilestoneCreateForm onClose={onClose} projectId={projectId} />}
         {editingMilestone && <MilestoneEditForm milestone={editingMilestone} onClose={handleCloseEdit} />}
       </MainContainer>
-    </Container>
   );
 };

--- a/src/view/project/runs/test-runs-list-view.tsx
+++ b/src/view/project/runs/test-runs-list-view.tsx
@@ -1,9 +1,8 @@
 'use client';
 import React, { useState, useRef, useEffect } from 'react';
-import { Container, MainContainer } from '@/shared/lib/primitives';
+import { MainContainer } from '@/shared/lib/primitives';
 import { LoadingSpinner } from '@/shared/ui';
 import { useOutsideClick } from '@/shared/hooks';
-import { Aside } from '@/widgets';
 import {
   Search,
   Filter,
@@ -153,20 +152,14 @@ export const TestRunsListView = () => {
 
   if (isLoadingProject || (projectId && isLoadingRuns)) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen items-center justify-center font-sans">
-        <Aside />
-        <MainContainer className="flex-1 flex items-center justify-center">
-          <LoadingSpinner size="lg" />
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </MainContainer>
     );
   }
 
   return (
-    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-      <Aside />
-
-      <MainContainer className="grid min-h-screen w-full flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 py-8 max-w-[1200px] mx-auto px-10">
+    <MainContainer className="grid min-h-screen w-full flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 py-8 max-w-[1200px] mx-auto px-10">
         <header className="col-span-6 flex items-start justify-between border-b border-line-2 pb-6">
           <div className="flex flex-col gap-1">
             <h2 className="typo-h1-heading text-text-1">테스트 실행 목록</h2>
@@ -439,6 +432,5 @@ export const TestRunsListView = () => {
           )}
         </section>
       </MainContainer>
-    </Container>
   );
 };

--- a/src/view/project/suites/test-suites-view.tsx
+++ b/src/view/project/suites/test-suites-view.tsx
@@ -10,10 +10,10 @@ import { projectIdQueryOptions } from '@/entities/project';
 import { dashboardQueryOptions } from '@/features/dashboard';
 import { SuiteEditForm } from '@/features/suites-edit';
 import { SuiteCreateForm } from '@/features/suites-create';
-import { Container, MainContainer } from '@/shared/lib/primitives';
+import { MainContainer } from '@/shared/lib/primitives';
 import { LoadingSpinner } from '@/shared/ui';
 import { useDisclosure } from '@/shared/hooks';
-import { ActionToolbar, Aside, testSuitesQueryOptions } from '@/widgets';
+import { ActionToolbar, testSuitesQueryOptions } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { track, TESTSUITE_EVENTS } from '@/shared/lib/analytics';
 
@@ -90,33 +90,23 @@ export const TestSuitesView = () => {
   // 로딩 상태
   if (isLoadingProject || isLoadingSuites) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <LoadingSpinner size="lg" />
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </MainContainer>
     );
   }
 
   // 에러 상태
   if (!dashboardData?.success) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
+      </MainContainer>
     );
   }
 
   return (
-    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-      {/* Aside */}
-      <Aside />
-      {/* Main Content */}
-      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
+    <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         {/* 헤더 영역 */}
         <header className="col-span-6 flex w-full items-start justify-between gap-6">
           <div className="flex flex-col gap-2">
@@ -162,6 +152,5 @@ export const TestSuitesView = () => {
         {isOpen && projectId && <SuiteCreateForm onClose={onClose} projectId={projectId} />}
         {editingSuite && <SuiteEditForm suite={editingSuite} onClose={handleCloseEdit} />}
       </MainContainer>
-    </Container>
   );
 };

--- a/src/view/project/trash/trash-view.tsx
+++ b/src/view/project/trash/trash-view.tsx
@@ -12,10 +12,9 @@ import {
 } from '@/features/trash';
 import type { TrashItem, TrashItemType } from '@/features/trash';
 import { dashboardQueryOptions } from '@/features/dashboard';
-import { Container, MainContainer } from '@/shared/lib/primitives';
+import { MainContainer } from '@/shared/lib/primitives';
 import { DSButton, LoadingSpinner } from '@/shared/ui';
 import { Dialog } from '@/shared/lib/primitives';
-import { Aside } from '@/widgets';
 import {
   Trash2,
   RotateCcw,
@@ -277,29 +276,22 @@ export const TrashView = () => {
 
   if (isLoadingProject || isLoadingTrash) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <LoadingSpinner size="lg" />
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </MainContainer>
     );
   }
 
   if (!dashboardData?.success) {
     return (
-      <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-        <Aside />
-        <MainContainer className="flex flex-1 items-center justify-center">
-          <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
-        </MainContainer>
-      </Container>
+      <MainContainer className="flex flex-1 items-center justify-center">
+        <div className="text-red-400">프로젝트를 불러올 수 없습니다.</div>
+      </MainContainer>
     );
   }
 
   return (
-    <Container className="bg-bg-1 text-text-1 flex min-h-screen font-sans">
-      <Aside />
+    <>
       <MainContainer className="flex min-h-screen w-full flex-1">
         <div className="mx-auto grid w-full max-w-[1000px] flex-1 content-start gap-y-6 px-10 py-8">
           {/* Header */}
@@ -576,6 +568,6 @@ export const TrashView = () => {
           </Dialog.Portal>
         </Dialog.Root>
       )}
-    </Container>
+    </>
   );
 };


### PR DESCRIPTION
## 변경 사항
### 테스트 케이스 카드 UI 개선
- 테이블 그리드 기반에서 컬러바 + 플렉스 레이아웃으로 변경
- 제목 너비 600px 고정으로 시간 표시 정렬 통일
- 테스트번호, 제목, 시간 사이 간격 조정 (gap-3)
- untested 상태 뱃지 비노출 처리
- quick-create 입력 행 높이를 리스트 아이템과 동일하게 맞춤
- 스켈레톤 로딩을 새 카드 레이아웃에 맞게 수정

### 뷰 레이아웃 사이드바 중복 제거
- 휴지통, 마일스톤, 실행, 스위트 뷰에서 Container와 Aside 제거
- layout.tsx에서 제공하는 글로벌 사이드바만 사용하도록 통일
- 사이드바 2개 겹침 현상 및 메인 콘텐츠 위치/너비 문제 해결

## 영향 범위
- test-case-card.tsx
- test-cases-view.tsx
- trash-view.tsx
- milestones-view.tsx
- test-runs-list-view.tsx
- test-suites-view.tsx
