### PR TITLE
fix(app): GTM을 production 배포에서만 로드하도록 가드 추가

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -212,7 +212,8 @@ export default function RootLayout({
             __html: `var f=document.querySelector('[data-font-css]');if(f){if(f.sheet){f.media='all'}else{f.addEventListener('load',function(){this.media='all'})}}`,
           }}
         />
-        {process.env.NEXT_PUBLIC_GTM_ID && (
+        {/* GTM은 production 배포에서만 로드. preview(dev 브랜치)·로컬은 GTM_ID가 주입돼도 차단 */}
+        {process.env.NEXT_PUBLIC_GTM_ID && process.env.VERCEL_ENV === 'production' && (
           <>
             <Script
               id="gtm-init"


### PR DESCRIPTION
## 작업 유형

- [x] fix — 버그 수정

## 요약

GTM(구글 태그 매니저) 스크립트가 운영 배포에서만 로드되도록 방어 조건을 추가합니다. 기존에는 GTM 식별자 환경변수의 존재 여부에만 의존했습니다.

## 배경 / 동기

dev 도메인이 분석 도구에 수집되는지 점검한 결과, 현재는 dev/프리뷰 환경에 GTM 식별자가 주입되지 않아 우연히 차단되고 있을 뿐 코드 차원의 안전장치가 없었습니다. 누군가 프리뷰 환경에 식별자를 잘못 주입하면 즉시 dev 트래픽이 운영 분석에 섞이게 됩니다. 이를 코드 레벨에서 막기 위한 변경입니다.

- 관련 이슈: #
- 관련 FDD / 문서: 분석 환경 게이팅 점검 (내부 메모)

## 변경 사항

- 구글 태그 매니저는 운영 배포에서만 로드되도록 제한했습니다.
- 프리뷰(dev 브랜치)나 로컬에서는 분석 식별자가 주입되어 있어도 태그 매니저가 로드되지 않습니다.
- 정적 렌더링을 유지하기 위해 기존 색인 허용 분기와 동일한 방식의 환경 판별을 사용했습니다.

## 테스트 방법

1. 운영 배포에서 페이지 소스에 태그 매니저 스크립트가 포함되는지 확인
2. dev 도메인에서 태그 매니저 스크립트 및 관련 네트워크 요청이 없는지 확인
3. 로컬 실행 시 분석 스크립트가 로드되지 않는지 확인

## 영향 범위 / 주의사항

- [x] 위 항목 모두 해당 없음

운영 외 환경에서 분석 수집이 비활성화되는 동작 변경입니다. 운영 동작은 기존과 동일합니다.

## 체크리스트

- [x] 로컬에서 빌드 / 타입 체크 통과 확인
- [x] 기존 기능에 회귀가 없는지 확인
- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음
