### PR TITLE
chore(config): CodeRabbit 리뷰 범위에 App Router 디렉터리 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -52,6 +52,7 @@ reviews:
   path_filters:
     # 포함 경로
     - 'apps/**/src/**' # 모든 앱(web, backoffice)의 소스 코드
+    - 'apps/web/app/**' # Next.js App Router (layout/page/route handler) — app/api 보안 라우트 포함
     - 'apps/web/tests/**' # E2E 스펙/POM — 없으면 아래 path_instructions 가 적용될 대상이 리뷰 안 됨
     - 'packages/**/src/**' # 모든 패키지(ui, icons)의 소스 코드
     - '.github/**' # 워크플로우/템플릿 리뷰


### PR DESCRIPTION
## 작업 유형

- [x] chore — 빌드·툴링·의존성 등 기타

## 요약

CodeRabbit 자동 리뷰 범위에 웹 앱의 App Router 디렉터리를 포함시킵니다. 기존 설정은 소스 디렉터리만 포함해 라우트 핸들러·레이아웃 등이 리뷰에서 빠져 있었습니다.

## 배경 / 동기

GTM 가드 변경(#104) 검토 중, 자동 코드 리뷰가 계속 스킵되는 원인을 추적한 결과 리뷰 대상 경로 설정에서 App Router 디렉터리가 포함 목록에 없다는 것을 확인했습니다. 이로 인해 레이아웃뿐 아니라 외부 연동 웹훅·AI 생성 등 보안에 민감한 서버 라우트 핸들러까지 자동 리뷰 사각지대에 있었습니다.

- 관련 이슈: #
- 관련 PR: #104

## 변경 사항

- 웹 앱의 App Router 디렉터리가 자동 리뷰 범위에 포함되도록 했습니다.
- 이에 따라 레이아웃과 서버 라우트 핸들러 변경도 앞으로 자동 리뷰 대상이 됩니다.

## 테스트 방법

1. 이 PR 머지 후, App Router 디렉터리만 수정한 PR을 dev 대상으로 열어 CodeRabbit 자동 리뷰가 동작하는지 확인

## 영향 범위 / 주의사항

- [x] 위 항목 모두 해당 없음

리뷰 도구 설정 변경으로 런타임 동작에는 영향이 없습니다. 자동 리뷰 대상 파일 수가 늘어 리뷰 코멘트가 다소 증가할 수 있습니다.

## 체크리스트

- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음
