### PR TITLE
fix(#110): vitest setupFiles 경로 정정

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: ['./src/shared/test/setup-scenario.ts'],
+    setupFiles: ['./src/shared/test/setup-tests.ts'],
     // vitest 는 src/ 의 .test.* 만 본다.
     // Playwright(e2e) 는 tests/ 의 .spec.* 를 본다 — 경로로 분리(아래 exclude 의 tests/**)해
     // 같은 .spec.* 라도 vitest 가 tests 를 수집하지 않는다.


### PR DESCRIPTION
## 개요

테스트 설정이 존재하지 않는 셋업 파일을 가리켜 웹 앱 단위테스트가 dev에서 전부 즉시 실패하던 문제를 핫픽스합니다.

## 원인

테스트 케이스 시나리오 작업이 스쿼시 머지되며 들어온 테스트 설정이, 실제로 없는 셋업 파일을 참조하고 있었습니다. 그 결과 어떤 웹 단위테스트도 실행되지 못했습니다(레포 전반 영향, 다른 작업 검증까지 차단).

## 변경 사항

- 테스트 실행 전 셋업 경로를 실제로 존재하는 파일로 바로잡아, 웹 단위테스트가 다시 실행되도록 복구했습니다.

## 검증

- 수정 후 기존 단위테스트 스위트가 정상 로드·실행됨을 확인했습니다.
- 참고: 스위트가 살아나며 기존에 가려져 있던 별개의 잠재 실패 1건(생성 케이스 저장 카운트)이 드러났습니다. 이 핫픽스의 원인과 무관한 선행 결함으로, 별도 추적이 필요합니다.


Closes #110
