### PR TITLE
fix(#102): AI 초안 생성 불투명 500 제거 및 에러 분류 전면 개선

### DIFF
--- a/apps/web/src/entities/ai-config/api/server-actions.test.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.test.ts
@@ -268,6 +268,20 @@ describe('getDecryptedApiKey', () => {
     expect(err.report).toBe(true);
   });
 
+  it('암호화 데이터 손상(MALFORMED)은 CRYPTO_MISCONFIG AiError(500, report) 로 변환된다', async () => {
+    mockLimit.mockResolvedValue([createMockAiConfigRow()]);
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new CryptoError('MALFORMED', 'ciphertext too short');
+    });
+
+    const err = await getDecryptedApiKey(PROJECT_ID).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AiError);
+    expect(err.kind).toBe('CRYPTO_MISCONFIG');
+    expect(err.httpStatus).toBe(500);
+    expect(err.report).toBe(true);
+  });
+
   it('CryptoError 가 아닌 예외는 그대로 전파한다', async () => {
     mockLimit.mockResolvedValue([createMockAiConfigRow()]);
     mockDecrypt.mockImplementationOnce(() => {

--- a/apps/web/src/entities/ai-config/api/server-actions.test.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.test.ts
@@ -240,7 +240,7 @@ describe('getDecryptedApiKey', () => {
     expect(mockDecrypt).not.toHaveBeenCalled();
   });
 
-  it('복호화 인증 실패(키 불일치)는 KEY_UNDECRYPTABLE AiError 로 변환된다', async () => {
+  it('복호화 인증 실패는 KEY_UNDECRYPTABLE AiError 로 변환되며 report 는 켜져있다 (키 불일치와 데이터 변조 구분 불가)', async () => {
     mockLimit.mockResolvedValue([createMockAiConfigRow()]);
     mockDecrypt.mockImplementationOnce(() => {
       throw new CryptoError('AUTH_FAILED', 'unable to authenticate data');
@@ -251,7 +251,7 @@ describe('getDecryptedApiKey', () => {
     expect(err).toBeInstanceOf(AiError);
     expect(err.kind).toBe('KEY_UNDECRYPTABLE');
     expect(err.httpStatus).toBe(409);
-    expect(err.report).toBe(false);
+    expect(err.report).toBe(true);
   });
 
   it('암호화 키 env 누락은 CRYPTO_MISCONFIG AiError(500, report) 로 변환된다', async () => {

--- a/apps/web/src/entities/ai-config/model/ai-error.test.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.test.ts
@@ -26,17 +26,28 @@ describe('AiError.fromCryptoError', () => {
     expect(e.kind).toBe('CRYPTO_MISCONFIG');
     expect(e.httpStatus).toBe(500);
   });
+
+  it('MALFORMED → CRYPTO_MISCONFIG (500, report=true) (데이터 손상은 운영 알림 대상)', () => {
+    const e = AiError.fromCryptoError(new CryptoError('MALFORMED', 'ciphertext too short'));
+    expect(e.kind).toBe('CRYPTO_MISCONFIG');
+    expect(e.httpStatus).toBe(500);
+    expect(e.report).toBe(true);
+    expect(e.context).toMatchObject({ cryptoCode: 'MALFORMED' });
+  });
 });
 
 describe('AiError.fromProviderResponse', () => {
   const cases: Array<[number, string, number]> = [
     [401, 'PROVIDER_UNAUTHORIZED', 401],
-    [403, 'PROVIDER_UNAUTHORIZED', 401],
+    [403, 'PROVIDER_FORBIDDEN', 403],
     [404, 'PROVIDER_BAD_MODEL', 400],
     [429, 'PROVIDER_RATE_LIMITED', 429],
+    [400, 'PROVIDER_BAD_REQUEST', 400],
+    [413, 'PROVIDER_BAD_REQUEST', 400],
+    [418, 'PROVIDER_BAD_REQUEST', 400],
     [500, 'PROVIDER_UNAVAILABLE', 502],
     [503, 'PROVIDER_UNAVAILABLE', 502],
-    [418, 'PROVIDER_ERROR', 502],
+    [301, 'PROVIDER_ERROR', 502],
   ];
 
   it.each(cases)('status %i → kind %s (http %i)', (status, kind, http) => {
@@ -53,8 +64,17 @@ describe('AiError.fromProviderResponse', () => {
     expect(e.userMessage).not.toContain('x');
   });
 
-  it('비정상 상태(418)는 report=true', () => {
-    expect(AiError.fromProviderResponse('anthropic', 418, '').report).toBe(true);
+  it('403 은 키 무효(401) 와 분리되어 권한/지역 안내 메시지로 응답한다', () => {
+    const e = AiError.fromProviderResponse('openai', 403, '');
+    expect(e.kind).toBe('PROVIDER_FORBIDDEN');
+    expect(e.userMessage).toContain('권한');
+  });
+
+  it('알려지지 않은 4xx(418)는 PROVIDER_BAD_REQUEST 로 분류되어 502 가 아닌 400 으로 응답한다', () => {
+    const e = AiError.fromProviderResponse('anthropic', 418, '');
+    expect(e.kind).toBe('PROVIDER_BAD_REQUEST');
+    expect(e.httpStatus).toBe(400);
+    expect(e.report).toBe(true);
   });
 
   it('레이트리밋(429)은 report=false', () => {

--- a/apps/web/src/entities/ai-config/model/ai-error.test.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.test.ts
@@ -4,13 +4,13 @@ import { describe, expect, it } from 'vitest';
 import { AiError } from './ai-error';
 
 describe('AiError.fromCryptoError', () => {
-  it('AUTH_FAILED → KEY_UNDECRYPTABLE (409, report=false)', () => {
+  it('AUTH_FAILED → KEY_UNDECRYPTABLE (409). 키 불일치와 데이터 변조 구분이 불가능하므로 운영 보고는 켜둔다', () => {
     const e = AiError.fromCryptoError(new CryptoError('AUTH_FAILED', 'bad tag'));
     expect(e).toBeInstanceOf(AiError);
     expect(e).toBeInstanceOf(Error);
     expect(e.kind).toBe('KEY_UNDECRYPTABLE');
     expect(e.httpStatus).toBe(409);
-    expect(e.report).toBe(false);
+    expect(e.report).toBe(true);
     expect(e.context).toMatchObject({ cryptoCode: 'AUTH_FAILED' });
   });
 

--- a/apps/web/src/entities/ai-config/model/ai-error.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.ts
@@ -12,11 +12,13 @@ import { CryptoError } from '@/shared/lib/crypto';
 export type AiErrorKind =
   | 'CRYPTO_MISCONFIG' // 서버 암호화 키 env 누락/형식 오류 (운영 대응)
   | 'KEY_UNDECRYPTABLE' // 저장된 키를 현재 키로 복호화 불가 (재등록 필요)
-  | 'PROVIDER_UNAUTHORIZED' // provider 401/403 — API 키 무효
-  | 'PROVIDER_BAD_MODEL' // provider 404 — 모델 설정 오류
+  | 'PROVIDER_UNAUTHORIZED' // provider 401 (API 키 무효)
+  | 'PROVIDER_FORBIDDEN' // provider 403 (지역/권한 제한, 키 유효)
+  | 'PROVIDER_BAD_MODEL' // provider 404 (모델 설정 오류)
   | 'PROVIDER_RATE_LIMITED' // provider 429
+  | 'PROVIDER_BAD_REQUEST' // provider 그 외 4xx (입력 형식/요청 구조 오류 등)
   | 'PROVIDER_UNAVAILABLE' // provider 5xx
-  | 'PROVIDER_ERROR' // provider 그 외 비-2xx (예상 밖)
+  | 'PROVIDER_ERROR' // provider 그 외 비-2xx (예상 밖, 3xx 또는 알 수 없는 상태)
   | 'RESPONSE_UNPARSABLE'; // LLM 응답이 JSON 으로 해석 불가
 
 interface AiErrorSpec {
@@ -44,6 +46,12 @@ const SPECS: Record<AiErrorKind, AiErrorSpec> = {
     userMessage: 'API 키가 유효하지 않습니다. 설정 페이지에서 키를 확인해주세요.',
     report: false,
   },
+  PROVIDER_FORBIDDEN: {
+    httpStatus: 403,
+    userMessage:
+      'AI 제공자가 요청을 거절했습니다. 지역 또는 계정 권한 제한일 수 있어, 제공자 콘솔에서 권한·결제 상태를 확인해주세요.',
+    report: false,
+  },
   PROVIDER_BAD_MODEL: {
     httpStatus: 400,
     userMessage: 'AI 모델 설정이 올바르지 않습니다. 설정 페이지에서 모델을 확인해주세요.',
@@ -53,6 +61,11 @@ const SPECS: Record<AiErrorKind, AiErrorSpec> = {
     httpStatus: 429,
     userMessage: 'AI 제공자의 요청 한도에 걸렸습니다. 잠시 후 다시 시도해주세요.',
     report: false,
+  },
+  PROVIDER_BAD_REQUEST: {
+    httpStatus: 400,
+    userMessage: 'AI 제공자가 요청을 거절했습니다. 입력 길이나 형식을 줄여 다시 시도해주세요.',
+    report: true,
   },
   PROVIDER_UNAVAILABLE: {
     httpStatus: 502,
@@ -92,6 +105,8 @@ export class AiError extends Error {
 
   /** 복호화 계층(CryptoError)을 도메인 에러로 변환 */
   static fromCryptoError(error: CryptoError): AiError {
+    // AUTH_FAILED 는 사용자 환경 이슈(키 로테이션·환경 불일치) 라 키 재등록 안내.
+    // 그 외 KEY_NOT_SET/KEY_INVALID/MALFORMED 는 서버 환경 또는 데이터 무결성 문제라 운영 알림.
     const kind: AiErrorKind =
       error.code === 'AUTH_FAILED' ? 'KEY_UNDECRYPTABLE' : 'CRYPTO_MISCONFIG';
     return new AiError(kind, { cryptoCode: error.code }, error);
@@ -100,9 +115,11 @@ export class AiError extends Error {
   /** provider 비-2xx 응답을 상태코드 기준으로 분류 */
   static fromProviderResponse(provider: string, status: number, bodyText: string): AiError {
     let kind: AiErrorKind;
-    if (status === 401 || status === 403) kind = 'PROVIDER_UNAUTHORIZED';
+    if (status === 401) kind = 'PROVIDER_UNAUTHORIZED';
+    else if (status === 403) kind = 'PROVIDER_FORBIDDEN';
     else if (status === 404) kind = 'PROVIDER_BAD_MODEL';
     else if (status === 429) kind = 'PROVIDER_RATE_LIMITED';
+    else if (status >= 400 && status < 500) kind = 'PROVIDER_BAD_REQUEST';
     else if (status >= 500) kind = 'PROVIDER_UNAVAILABLE';
     else kind = 'PROVIDER_ERROR';
     return new AiError(kind, {

--- a/apps/web/src/entities/ai-config/model/ai-error.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.ts
@@ -39,7 +39,10 @@ const SPECS: Record<AiErrorKind, AiErrorSpec> = {
     httpStatus: 409,
     userMessage:
       '저장된 API 키를 복호화할 수 없습니다. 설정 페이지에서 API 키를 다시 등록해주세요.',
-    report: false,
+    // GCM 인증 실패는 키 불일치(사용자 환경 이슈) 와 ciphertext 변조(데이터 무결성 이슈) 가
+    // 동일 예외로 떨어져 정규식만으론 구분이 불가능하다. 사용자 메시지는 키 재등록 안내로
+    // 자연스럽게 두되, 운영이 데이터 손상 가능성을 놓치지 않도록 보고는 켠다.
+    report: true,
   },
   PROVIDER_UNAUTHORIZED: {
     httpStatus: 401,

--- a/apps/web/src/shared/lib/crypto/encrypt.test.ts
+++ b/apps/web/src/shared/lib/crypto/encrypt.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CryptoError, decrypt, encrypt } from './encrypt';
+
+// 32 바이트(=64 hex 자리) 더미 키. 테스트 안에서만 사용.
+const VALID_KEY = 'a'.repeat(64);
+
+describe('crypto encrypt/decrypt', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.GITHUB_TOKEN_ENCRYPTION_KEY;
+    process.env.GITHUB_TOKEN_ENCRYPTION_KEY = VALID_KEY;
+  });
+
+  afterEach(() => {
+    if (originalKey === undefined) {
+      delete process.env.GITHUB_TOKEN_ENCRYPTION_KEY;
+    } else {
+      process.env.GITHUB_TOKEN_ENCRYPTION_KEY = originalKey;
+    }
+  });
+
+  describe('round-trip', () => {
+    it('일반 문자열 round-trip', () => {
+      const plain = 'hello, 안녕 🌱';
+      expect(decrypt(encrypt(plain))).toBe(plain);
+    });
+
+    it('빈 문자열 round-trip (AES-GCM 은 0 byte ciphertext 가 정상)', () => {
+      // 사전 길이 검증이 등호를 포함하면 이 케이스가 MALFORMED 로 잘못 거부된다.
+      expect(decrypt(encrypt(''))).toBe('');
+    });
+  });
+
+  describe('getEncryptionKey 검증', () => {
+    it('KEY env 누락 시 KEY_NOT_SET 으로 거부', () => {
+      delete process.env.GITHUB_TOKEN_ENCRYPTION_KEY;
+      expect(() => encrypt('x')).toThrow(CryptoError);
+      try {
+        encrypt('x');
+      } catch (e) {
+        expect((e as CryptoError).code).toBe('KEY_NOT_SET');
+      }
+    });
+
+    it('hex 형식이 아니거나 길이가 다른 키는 KEY_INVALID 로 거부 (비-hex 문자 뒤섞임 포함)', () => {
+      // 64자 길이지만 마지막 두 글자가 비-hex 인 키. 이전 검증(Buffer 길이만)은 통과했지만 정규식 검증은 거부.
+      process.env.GITHUB_TOKEN_ENCRYPTION_KEY = `${'a'.repeat(62)}zz`;
+      try {
+        encrypt('x');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(CryptoError);
+        expect((e as CryptoError).code).toBe('KEY_INVALID');
+      }
+    });
+
+    it('길이만 짧은 키도 KEY_INVALID', () => {
+      process.env.GITHUB_TOKEN_ENCRYPTION_KEY = 'abcd';
+      try {
+        encrypt('x');
+        throw new Error('expected throw');
+      } catch (e) {
+        expect((e as CryptoError).code).toBe('KEY_INVALID');
+      }
+    });
+  });
+
+  describe('decrypt 사전 검증', () => {
+    it('iv+tag 보다 짧은 buffer 는 MALFORMED', () => {
+      const tooShort = Buffer.alloc(20).toString('base64'); // 28 byte 미만
+      try {
+        decrypt(tooShort);
+        throw new Error('expected throw');
+      } catch (e) {
+        expect((e as CryptoError).code).toBe('MALFORMED');
+      }
+    });
+  });
+});

--- a/apps/web/src/shared/lib/crypto/encrypt.ts
+++ b/apps/web/src/shared/lib/crypto/encrypt.ts
@@ -31,14 +31,15 @@ function getEncryptionKey(): Buffer {
   if (!key) {
     throw new CryptoError('KEY_NOT_SET', 'GITHUB_TOKEN_ENCRYPTION_KEY is not set');
   }
-  const buf = Buffer.from(key, 'hex');
-  if (buf.length !== KEY_LENGTH) {
+  // Buffer.from(key, 'hex') 는 첫 비-hex 문자에서 디코드를 멈추고 앞부분만 반환하므로,
+  // 길이만 검증하면 64자리 hex 뒤에 오타가 붙은 키도 통과할 수 있다. 형식 자체를 먼저 본다.
+  if (!/^[0-9a-fA-F]+$/.test(key) || key.length !== KEY_LENGTH * 2) {
     throw new CryptoError(
       'KEY_INVALID',
-      `GITHUB_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH}-byte hex (got ${buf.length} bytes)`
+      `GITHUB_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH * 2} hex characters (got ${key.length} characters)`
     );
   }
-  return buf;
+  return Buffer.from(key, 'hex');
 }
 
 export function encrypt(plaintext: string): string {
@@ -58,12 +59,13 @@ export function decrypt(ciphertext: string): string {
   const key = getEncryptionKey();
   const buf = Buffer.from(ciphertext, 'base64');
 
-  // 사전 길이 검증: iv + tag + 최소 1byte ciphertext 가 안 되면 데이터가 잘린 것.
-  // 이 경우 GCM 인증 실패와 구분이 안 되는 catch 통합 분류를 피해 명시적으로 MALFORMED.
-  if (buf.length <= IV_LENGTH + TAG_LENGTH) {
+  // 사전 길이 검증: iv + tag 도 채우지 못하면 데이터가 잘린 것.
+  // AES-GCM 은 패딩 없는 스트림 암호라 빈 plaintext 도 28바이트(iv+tag) 정상 ciphertext 를 만들므로,
+  // 등호를 포함하면 정상 케이스(encrypt('')) 까지 거부하는 회귀가 생긴다.
+  if (buf.length < IV_LENGTH + TAG_LENGTH) {
     throw new CryptoError(
       'MALFORMED',
-      `ciphertext too short (${buf.length} bytes, expected > ${IV_LENGTH + TAG_LENGTH})`
+      `ciphertext too short (${buf.length} bytes, expected >= ${IV_LENGTH + TAG_LENGTH})`
     );
   }
 

--- a/apps/web/src/shared/lib/crypto/encrypt.ts
+++ b/apps/web/src/shared/lib/crypto/encrypt.ts
@@ -7,13 +7,14 @@ const KEY_LENGTH = 32; // aes-256 → 32 bytes
 
 /**
  * 암복호화 실패를 호출부가 식별할 수 있게 타입으로 구분한다.
- * - KEY_NOT_SET / KEY_INVALID: 서버 환경(키) 설정 문제 — 운영 대응 필요
- * - AUTH_FAILED: 저장 시점과 다른 키로 복호화 시도(키 로테이션/환경 불일치 등)
+ * - KEY_NOT_SET / KEY_INVALID: 서버 환경(키) 설정 문제 (운영 대응 필요)
+ * - AUTH_FAILED: 저장 시점과 다른 키로 복호화 시도 (키 로테이션/환경 불일치 등 사용자 환경)
+ * - MALFORMED: 저장된 ciphertext 자체가 손상 (잘린 buffer, 잘못된 IV 길이 등 데이터 무결성 문제, 운영 대응 필요)
  *
  * `Error` 서브클래스이며 `message` 는 기존과 동일하게 유지하므로,
  * 일반 `catch (error)` 로 받던 기존 호출부(github 토큰/웹훅)는 무영향.
  */
-export type CryptoErrorCode = 'KEY_NOT_SET' | 'KEY_INVALID' | 'AUTH_FAILED';
+export type CryptoErrorCode = 'KEY_NOT_SET' | 'KEY_INVALID' | 'AUTH_FAILED' | 'MALFORMED';
 
 export class CryptoError extends Error {
   readonly code: CryptoErrorCode;
@@ -57,6 +58,15 @@ export function decrypt(ciphertext: string): string {
   const key = getEncryptionKey();
   const buf = Buffer.from(ciphertext, 'base64');
 
+  // 사전 길이 검증: iv + tag + 최소 1byte ciphertext 가 안 되면 데이터가 잘린 것.
+  // 이 경우 GCM 인증 실패와 구분이 안 되는 catch 통합 분류를 피해 명시적으로 MALFORMED.
+  if (buf.length <= IV_LENGTH + TAG_LENGTH) {
+    throw new CryptoError(
+      'MALFORMED',
+      `ciphertext too short (${buf.length} bytes, expected > ${IV_LENGTH + TAG_LENGTH})`
+    );
+  }
+
   const iv = buf.subarray(0, IV_LENGTH);
   const tag = buf.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
   const encrypted = buf.subarray(IV_LENGTH + TAG_LENGTH);
@@ -69,12 +79,13 @@ export function decrypt(ciphertext: string): string {
     decrypted = Buffer.concat([decrypted, decipher.final()]);
     return decrypted.toString('utf8');
   } catch (error) {
-    // GCM 인증 태그 검증 실패 등: 저장 시점과 다른 키로 복호화한 경우.
-    // 원본 메시지를 보존해 기존 일반 catch 호출부 동작을 바꾸지 않는다.
-    throw new CryptoError(
-      'AUTH_FAILED',
-      error instanceof Error ? error.message : 'decryption failed',
-      { cause: error }
+    // GCM 인증 태그 검증 실패와 그 외 데이터 손상 오류를 분리한다.
+    // 인증 실패(키 불일치/로테이션)는 사용자 환경 이슈로 키 재등록 안내,
+    // 그 외(잘린 ciphertext 등 cipher 내부 구조 손상)는 데이터 무결성 문제로 운영 알림.
+    const message = error instanceof Error ? error.message : 'decryption failed';
+    const isAuthFailure = /unable to authenticate|authentication|auth tag|bad decrypt/i.test(
+      message
     );
+    throw new CryptoError(isAuthFailure ? 'AUTH_FAILED' : 'MALFORMED', message, { cause: error });
   }
 }


### PR DESCRIPTION
## 개요

AI 테스트케이스 초안 생성이 실패할 때 원인이 무엇이든 전부 불투명한 500과 "생성에 실패했습니다"로만 떨어져, 사용자도 운영도 원인을 알 수 없던 문제를 해결합니다.

## 원인

키 복호화 호출에 예외 처리가 없었고, 상위 에러 분기가 에러 메시지 문자열 매칭에 의존했습니다. 그 결과 암호화 키 환경설정 누락, 저장 키 복호화 불가, AI 제공자의 인증/모델/한도/일시장애 응답, 응답 파싱 실패가 전부 같은 500으로 붕괴됐습니다.

## 변경 사항

- 복호화 계층의 실패를 원인별로 구분되는 형태로 바꾸고, 기존 메시지를 그대로 유지해 다른 호출 경로에는 영향이 없도록 했습니다.
- AI 초안 생성 흐름의 실패를 의미 단위로 분류하는 도메인 에러 체계를 도입했습니다. 키 환경설정 문제, 키 재등록 필요, 제공자 인증 실패, 모델 설정 오류, 요청 한도, 제공자 일시 장애, 응답 해석 불가를 각각 적절한 상태코드와 사용자 안내 메시지로 응답합니다.
- 복호화된 키 조회에 예외 처리를 더해, 복호화 실패를 의미 있는 도메인 에러로 승격합니다.
- 생성 라우트의 제공자 호출·응답 파싱·전역 처리부를 문자열 매칭 분기에서 분류 기반으로 교체했습니다. 사용자 환경 문제는 모니터링 노이즈를 피하고, 예상 밖 결함만 보고합니다.
- 에러 분류와 복호화 실패 경로에 대한 단위 테스트를 추가했습니다.

## 검증

- 추가한 단위 테스트와 기존 설정 관련 테스트가 모두 통과합니다(무회귀 확인).
- 참고: 생성 케이스 저장 카운트 테스트 1건이 실패하는데, 이는 본 변경과 무관한 선행 결함으로 vitest 복구 핫픽스(#110/#111)에서 이미 드러나 별도 추적 대상입니다.


Closes #102
