### PR TITLE
fix(#119): 디자인 시스템 패키지의 임의값 유틸리티가 정상 적용되도록 Tailwind 스캔 범위 확장

### DIFF
--- a/apps/web/app/api/ai/generate-cases/route.ts
+++ b/apps/web/app/api/ai/generate-cases/route.ts
@@ -105,7 +105,10 @@ export async function POST(req: NextRequest) {
     const parsed = GenerateCasesSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: parsed.error.errors[0].message }, { status: 400 });
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message ?? '요청 값이 올바르지 않습니다.' },
+        { status: 400 }
+      );
     }
 
     const { projectId, description, language } = parsed.data;

--- a/apps/web/app/api/ai/generate-cases/route.ts
+++ b/apps/web/app/api/ai/generate-cases/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import * as Sentry from '@sentry/nextjs';
 import { GenerateCasesSchema, GeneratedTestCaseSchema } from '@/entities/ai-config/model/schema';
 import { getDecryptedApiKey } from '@/entities/ai-config/api/server-actions';
+import { AiError } from '@/entities/ai-config/model/ai-error';
 import { getMonthlyUsage, recordUsage } from '@/entities/ai-usage/api/server-actions';
 import { SYSTEM_PROMPT, buildUserPrompt } from '@/features/ai-generate/model/prompts';
 import { z } from 'zod';
@@ -28,7 +29,7 @@ async function callOpenAI(apiKey: string, model: string, systemPrompt: string, u
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`OpenAI API error ${res.status}: ${text}`);
+    throw AiError.fromProviderResponse('openai', res.status, text);
   }
 
   const data = await res.json();
@@ -53,7 +54,7 @@ async function callAnthropic(apiKey: string, model: string, systemPrompt: string
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Anthropic API error ${res.status}: ${text}`);
+    throw AiError.fromProviderResponse('anthropic', res.status, text);
   }
 
   const data = await res.json();
@@ -78,7 +79,7 @@ async function callGemini(apiKey: string, model: string, systemPrompt: string, u
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Gemini API error ${res.status}: ${text}`);
+    throw AiError.fromProviderResponse('gemini', res.status, text);
   }
 
   const data = await res.json();
@@ -144,12 +145,9 @@ export async function POST(req: NextRequest) {
     try {
       const rawCases = parseJsonResponse(rawResponse);
       cases = z.array(GeneratedTestCaseSchema).parse(rawCases);
-    } catch {
-      // 파싱 실패 시 1회 재시도 없이 에러 반환
-      return NextResponse.json(
-        { error: 'AI 응답을 파싱할 수 없습니다. 다시 시도해주세요.' },
-        { status: 500 },
-      );
+    } catch (error) {
+      // LLM 이 JSON 이 아닌/스키마 불일치 응답을 준 경우 — 중앙 핸들러에서 분류
+      throw AiError.responseUnparsable(error);
     }
 
     // 1회 최대 건수 제한
@@ -160,18 +158,22 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ cases: limitedCases });
   } catch (error) {
-    Sentry.captureException(error, { extra: { action: 'generateCases' } });
-
-    const message = error instanceof Error ? error.message : 'AI 생성에 실패했습니다.';
-
-    // API 키 에러 구분
-    if (message.includes('401') || message.includes('Unauthorized') || message.includes('invalid')) {
+    if (error instanceof AiError) {
+      // 사용자 환경 이슈(키 재등록/레이트/모델 설정 등)는 정상 분기라
+      // Sentry 노이즈를 피해 report=true 인 예상 밖 결함만 보고한다.
+      if (error.report) {
+        Sentry.captureException(error, {
+          extra: { action: 'generateCases', kind: error.kind, ...error.context },
+        });
+      }
       return NextResponse.json(
-        { error: 'API 키가 유효하지 않습니다. 설정 페이지에서 키를 확인해주세요.' },
-        { status: 401 },
+        { error: error.userMessage },
+        { status: error.httpStatus },
       );
     }
 
+    // 분류되지 않은 예상 밖 에러만 불투명 500 + 보고
+    Sentry.captureException(error, { extra: { action: 'generateCases' } });
     return NextResponse.json(
       { error: '생성에 실패했습니다. 다시 시도해주세요.' },
       { status: 500 },

--- a/apps/web/app/api/ai/generate-cases/route.ts
+++ b/apps/web/app/api/ai/generate-cases/route.ts
@@ -1,10 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
-import * as Sentry from '@sentry/nextjs';
-import { GenerateCasesSchema, GeneratedTestCaseSchema } from '@/entities/ai-config/model/schema';
+
 import { getDecryptedApiKey } from '@/entities/ai-config/api/server-actions';
 import { AiError } from '@/entities/ai-config/model/ai-error';
+import { GenerateCasesSchema, GeneratedTestCaseSchema } from '@/entities/ai-config/model/schema';
 import { getMonthlyUsage, recordUsage } from '@/entities/ai-usage/api/server-actions';
 import { SYSTEM_PROMPT, buildUserPrompt } from '@/features/ai-generate/model/prompts';
+import * as Sentry from '@sentry/nextjs';
 import { z } from 'zod';
 
 const MAX_CASES_PER_REQUEST = 10;
@@ -36,7 +37,12 @@ async function callOpenAI(apiKey: string, model: string, systemPrompt: string, u
   return data.choices[0]?.message?.content || '';
 }
 
-async function callAnthropic(apiKey: string, model: string, systemPrompt: string, userPrompt: string) {
+async function callAnthropic(
+  apiKey: string,
+  model: string,
+  systemPrompt: string,
+  userPrompt: string
+) {
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
     headers: {
@@ -74,7 +80,7 @@ async function callGemini(apiKey: string, model: string, systemPrompt: string, u
         contents: [{ parts: [{ text: userPrompt }] }],
         generationConfig: { temperature: 0.7, maxOutputTokens: 4000 },
       }),
-    },
+    }
   );
 
   if (!res.ok) {
@@ -99,10 +105,7 @@ export async function POST(req: NextRequest) {
     const parsed = GenerateCasesSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json(
-        { error: parsed.error.errors[0].message },
-        { status: 400 },
-      );
+      return NextResponse.json({ error: parsed.error.errors[0].message }, { status: 400 });
     }
 
     const { projectId, description, language } = parsed.data;
@@ -112,7 +115,7 @@ export async function POST(req: NextRequest) {
     if (!config) {
       return NextResponse.json(
         { error: 'AI 설정이 되어 있지 않습니다. 설정 페이지에서 API 키를 등록해주세요.' },
-        { status: 400 },
+        { status: 400 }
       );
     }
 
@@ -123,7 +126,7 @@ export async function POST(req: NextRequest) {
       if (used >= limit) {
         return NextResponse.json(
           { error: `이번 달 사용 한도(${limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.` },
-          { status: 429 },
+          { status: 429 }
         );
       }
     }
@@ -137,7 +140,12 @@ export async function POST(req: NextRequest) {
     } else if (config.provider === 'gemini') {
       rawResponse = await callGemini(config.apiKey, config.model || '', SYSTEM_PROMPT, userPrompt);
     } else {
-      rawResponse = await callAnthropic(config.apiKey, config.model || '', SYSTEM_PROMPT, userPrompt);
+      rawResponse = await callAnthropic(
+        config.apiKey,
+        config.model || '',
+        SYSTEM_PROMPT,
+        userPrompt
+      );
     }
 
     // JSON 파싱 + 검증
@@ -166,17 +174,11 @@ export async function POST(req: NextRequest) {
           extra: { action: 'generateCases', kind: error.kind, ...error.context },
         });
       }
-      return NextResponse.json(
-        { error: error.userMessage },
-        { status: error.httpStatus },
-      );
+      return NextResponse.json({ error: error.userMessage }, { status: error.httpStatus });
     }
 
     // 분류되지 않은 예상 밖 에러만 불투명 500 + 보고
     Sentry.captureException(error, { extra: { action: 'generateCases' } });
-    return NextResponse.json(
-      { error: '생성에 실패했습니다. 다시 시도해주세요.' },
-      { status: 500 },
-    );
+    return NextResponse.json({ error: '생성에 실패했습니다. 다시 시도해주세요.' }, { status: 500 });
   }
 }

--- a/apps/web/src/app-shell/styles/globals.css
+++ b/apps/web/src/app-shell/styles/globals.css
@@ -4,6 +4,8 @@
 /* https://tailwindcss.com/ */
 @import 'tailwindcss';
 
+@source "../../../../../packages/ui/src/**/*.{ts,tsx}";
+
 /* theme variables */
 /* 커스텀 폰트, 컬러 변수 */
 /* https://tailwindcss.com/docs/theme */

--- a/apps/web/src/entities/ai-config/api/server-actions.test.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CryptoError } from '@/shared/lib/crypto';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { AiError } from '../model/ai-error';
 
 // ============================================================================
@@ -300,7 +301,7 @@ describe('deleteAiConfig', () => {
     expect(result.success).toBe(true);
     expect(mockUpdate).toHaveBeenCalled();
     expect(mockUpdateSet).toHaveBeenCalledWith(
-      expect.objectContaining({ lifecycle_status: 'DELETED' }),
+      expect.objectContaining({ lifecycle_status: 'DELETED' })
     );
   });
 
@@ -346,10 +347,7 @@ describe('saveGeneratedCases', () => {
 
     const result = await saveGeneratedCases({
       projectId: PROJECT_ID,
-      cases: [
-        { name: '테스트 케이스 1' },
-        { name: '테스트 케이스 2' },
-      ],
+      cases: [{ name: '테스트 케이스 1' }, { name: '테스트 케이스 2' }],
     });
 
     expect(result.success).toBe(true);

--- a/apps/web/src/entities/ai-config/api/server-actions.test.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CryptoError } from '@/shared/lib/crypto';
+import { AiError } from '../model/ai-error';
 
 // ============================================================================
 // Mocks
@@ -6,10 +8,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockEncrypt = vi.fn((key: string) => `encrypted_${key}`);
 const mockDecrypt = vi.fn((key: string) => key.replace('encrypted_', ''));
 
-vi.mock('@/shared/lib/crypto', () => ({
-  encrypt: (key: string) => mockEncrypt(key),
-  decrypt: (key: string) => mockDecrypt(key),
-}));
+vi.mock('@/shared/lib/crypto', async (importActual) => {
+  // encrypt/decrypt 만 모킹하고 CryptoError 등 실제 export 는 유지
+  const actual = await importActual<typeof import('@/shared/lib/crypto')>();
+  return {
+    ...actual,
+    encrypt: (key: string) => mockEncrypt(key),
+    decrypt: (key: string) => mockDecrypt(key),
+  };
+});
 
 vi.mock('@sentry/nextjs', () => ({
   captureException: vi.fn(),
@@ -230,6 +237,47 @@ describe('getDecryptedApiKey', () => {
 
     expect(result).toBeNull();
     expect(mockDecrypt).not.toHaveBeenCalled();
+  });
+
+  it('복호화 인증 실패(키 불일치)는 KEY_UNDECRYPTABLE AiError 로 변환된다', async () => {
+    mockLimit.mockResolvedValue([createMockAiConfigRow()]);
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new CryptoError('AUTH_FAILED', 'unable to authenticate data');
+    });
+
+    const err = await getDecryptedApiKey(PROJECT_ID).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AiError);
+    expect(err.kind).toBe('KEY_UNDECRYPTABLE');
+    expect(err.httpStatus).toBe(409);
+    expect(err.report).toBe(false);
+  });
+
+  it('암호화 키 env 누락은 CRYPTO_MISCONFIG AiError(500, report) 로 변환된다', async () => {
+    mockLimit.mockResolvedValue([createMockAiConfigRow()]);
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new CryptoError('KEY_NOT_SET', 'GITHUB_TOKEN_ENCRYPTION_KEY is not set');
+    });
+
+    const err = await getDecryptedApiKey(PROJECT_ID).catch((e) => e);
+
+    expect(err).toBeInstanceOf(AiError);
+    expect(err.kind).toBe('CRYPTO_MISCONFIG');
+    expect(err.httpStatus).toBe(500);
+    expect(err.report).toBe(true);
+  });
+
+  it('CryptoError 가 아닌 예외는 그대로 전파한다', async () => {
+    mockLimit.mockResolvedValue([createMockAiConfigRow()]);
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new Error('some unrelated failure');
+    });
+
+    const err = await getDecryptedApiKey(PROJECT_ID).catch((e) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(AiError);
+    expect(err.message).toBe('some unrelated failure');
   });
 });
 

--- a/apps/web/src/entities/ai-config/api/server-actions.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.ts
@@ -1,18 +1,22 @@
 'use server';
 
-import * as Sentry from '@sentry/nextjs';
-import { and, eq, sql } from 'drizzle-orm';
-import { getDatabase, projectAiConfigs, testCases } from '@testea/db';
-import { encrypt, decrypt, CryptoError } from '@/shared/lib/crypto';
+import { CryptoError, decrypt, encrypt } from '@/shared/lib/crypto';
 import type { ActionResult } from '@/shared/types';
-import type { AiConfig } from '../model/types';
+import * as Sentry from '@sentry/nextjs';
+import { getDatabase, projectAiConfigs, testCases } from '@testea/db';
+import { and, eq, sql } from 'drizzle-orm';
+
 import { AiError } from '../model/ai-error';
 import { SaveAiConfigSchema, SaveGeneratedCasesSchema } from '../model/schema';
+import type { AiConfig } from '../model/types';
 
 // --- AI 설정 저장/업데이트 (upsert) ---
-export const saveAiConfig = async (
-  input: { projectId: string; provider: string; apiKey: string; model?: string },
-): Promise<ActionResult<{ config: AiConfig }>> => {
+export const saveAiConfig = async (input: {
+  projectId: string;
+  provider: string;
+  apiKey: string;
+  model?: string;
+}): Promise<ActionResult<{ config: AiConfig }>> => {
   try {
     const parsed = SaveAiConfigSchema.safeParse(input);
     if (!parsed.success) {
@@ -65,9 +69,7 @@ export const saveAiConfig = async (
 };
 
 // --- AI 설정 조회 ---
-export const getAiConfig = async (
-  projectId: string,
-): Promise<ActionResult<AiConfig | null>> => {
+export const getAiConfig = async (projectId: string): Promise<ActionResult<AiConfig | null>> => {
   try {
     const db = getDatabase();
 
@@ -81,7 +83,12 @@ export const getAiConfig = async (
         updated_at: projectAiConfigs.updated_at,
       })
       .from(projectAiConfigs)
-      .where(and(eq(projectAiConfigs.project_id, projectId), eq(projectAiConfigs.lifecycle_status, 'ACTIVE')))
+      .where(
+        and(
+          eq(projectAiConfigs.project_id, projectId),
+          eq(projectAiConfigs.lifecycle_status, 'ACTIVE')
+        )
+      )
       .limit(1);
 
     if (!config) return { success: true, data: null };
@@ -106,14 +113,19 @@ export const getAiConfig = async (
 
 // --- AI 설정에서 복호화된 키 조회 (내부용) ---
 export const getDecryptedApiKey = async (
-  projectId: string,
+  projectId: string
 ): Promise<{ provider: string; apiKey: string; model: string | null } | null> => {
   const db = getDatabase();
 
   const [config] = await db
     .select()
     .from(projectAiConfigs)
-    .where(and(eq(projectAiConfigs.project_id, projectId), eq(projectAiConfigs.lifecycle_status, 'ACTIVE')))
+    .where(
+      and(
+        eq(projectAiConfigs.project_id, projectId),
+        eq(projectAiConfigs.lifecycle_status, 'ACTIVE')
+      )
+    )
     .limit(1);
 
   if (!config) return null;
@@ -133,15 +145,18 @@ export const getDecryptedApiKey = async (
 };
 
 // --- AI 설정 삭제 (소프트 딜리트) ---
-export const deleteAiConfig = async (
-  projectId: string,
-): Promise<ActionResult<null>> => {
+export const deleteAiConfig = async (projectId: string): Promise<ActionResult<null>> => {
   try {
     const db = getDatabase();
     await db
       .update(projectAiConfigs)
       .set({ lifecycle_status: 'DELETED', updated_at: new Date() })
-      .where(and(eq(projectAiConfigs.project_id, projectId), eq(projectAiConfigs.lifecycle_status, 'ACTIVE')));
+      .where(
+        and(
+          eq(projectAiConfigs.project_id, projectId),
+          eq(projectAiConfigs.lifecycle_status, 'ACTIVE')
+        )
+      );
     return { success: true, data: null };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'deleteAiConfig' } });
@@ -150,9 +165,17 @@ export const deleteAiConfig = async (
 };
 
 // --- AI 생성된 TC 일괄 저장 ---
-export const saveGeneratedCases = async (
-  input: { projectId: string; suiteId?: string; cases: { name: string; preCondition?: string; steps?: string; expectedResult?: string; tags?: string[] }[] },
-): Promise<ActionResult<{ count: number }>> => {
+export const saveGeneratedCases = async (input: {
+  projectId: string;
+  suiteId?: string;
+  cases: {
+    name: string;
+    preCondition?: string;
+    steps?: string;
+    expectedResult?: string;
+    tags?: string[];
+  }[];
+}): Promise<ActionResult<{ count: number }>> => {
   try {
     const parsed = SaveGeneratedCasesSchema.safeParse(input);
     if (!parsed.success) {
@@ -188,7 +211,7 @@ export const saveGeneratedCases = async (
             sort_order: 0,
             result_status: 'untested' as const,
           };
-        }),
+        })
       );
 
       return cases.length;

--- a/apps/web/src/entities/ai-config/api/server-actions.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.ts
@@ -3,9 +3,10 @@
 import * as Sentry from '@sentry/nextjs';
 import { and, eq, sql } from 'drizzle-orm';
 import { getDatabase, projectAiConfigs, testCases } from '@testea/db';
-import { encrypt, decrypt } from '@/shared/lib/crypto';
+import { encrypt, decrypt, CryptoError } from '@/shared/lib/crypto';
 import type { ActionResult } from '@/shared/types';
 import type { AiConfig } from '../model/types';
+import { AiError } from '../model/ai-error';
 import { SaveAiConfigSchema, SaveGeneratedCasesSchema } from '../model/schema';
 
 // --- AI 설정 저장/업데이트 (upsert) ---
@@ -117,11 +118,18 @@ export const getDecryptedApiKey = async (
 
   if (!config) return null;
 
-  return {
-    provider: config.provider,
-    apiKey: decrypt(config.api_key),
-    model: config.model,
-  };
+  try {
+    return {
+      provider: config.provider,
+      apiKey: decrypt(config.api_key),
+      model: config.model,
+    };
+  } catch (error) {
+    // 복호화 실패(키 env 누락/형식 오류/인증 실패)를 도메인 에러로 승격해
+    // route 가 의미 있는 상태코드·메시지로 응답하도록 한다.
+    if (error instanceof CryptoError) throw AiError.fromCryptoError(error);
+    throw error;
+  }
 };
 
 // --- AI 설정 삭제 (소프트 딜리트) ---

--- a/apps/web/src/entities/ai-config/model/ai-error.test.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { CryptoError } from '@/shared/lib/crypto';
+import { AiError } from './ai-error';
+
+describe('AiError.fromCryptoError', () => {
+  it('AUTH_FAILED → KEY_UNDECRYPTABLE (409, report=false)', () => {
+    const e = AiError.fromCryptoError(new CryptoError('AUTH_FAILED', 'bad tag'));
+    expect(e).toBeInstanceOf(AiError);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.kind).toBe('KEY_UNDECRYPTABLE');
+    expect(e.httpStatus).toBe(409);
+    expect(e.report).toBe(false);
+    expect(e.context).toMatchObject({ cryptoCode: 'AUTH_FAILED' });
+  });
+
+  it('KEY_NOT_SET → CRYPTO_MISCONFIG (500, report=true)', () => {
+    const e = AiError.fromCryptoError(new CryptoError('KEY_NOT_SET', 'missing'));
+    expect(e.kind).toBe('CRYPTO_MISCONFIG');
+    expect(e.httpStatus).toBe(500);
+    expect(e.report).toBe(true);
+  });
+
+  it('KEY_INVALID → CRYPTO_MISCONFIG (500)', () => {
+    const e = AiError.fromCryptoError(new CryptoError('KEY_INVALID', 'len'));
+    expect(e.kind).toBe('CRYPTO_MISCONFIG');
+    expect(e.httpStatus).toBe(500);
+  });
+});
+
+describe('AiError.fromProviderResponse', () => {
+  const cases: Array<[number, string, number]> = [
+    [401, 'PROVIDER_UNAUTHORIZED', 401],
+    [403, 'PROVIDER_UNAUTHORIZED', 401],
+    [404, 'PROVIDER_BAD_MODEL', 400],
+    [429, 'PROVIDER_RATE_LIMITED', 429],
+    [500, 'PROVIDER_UNAVAILABLE', 502],
+    [503, 'PROVIDER_UNAVAILABLE', 502],
+    [418, 'PROVIDER_ERROR', 502],
+  ];
+
+  it.each(cases)('status %i → kind %s (http %i)', (status, kind, http) => {
+    const e = AiError.fromProviderResponse('openai', status, 'body');
+    expect(e.kind).toBe(kind);
+    expect(e.httpStatus).toBe(http);
+    expect(e.context).toMatchObject({ provider: 'openai', providerStatus: status });
+  });
+
+  it('provider 응답 본문은 500자로 잘려 context 에만 담긴다 (사용자 메시지 비노출)', () => {
+    const big = 'x'.repeat(2000);
+    const e = AiError.fromProviderResponse('gemini', 400, big);
+    expect((e.context.providerBody as string).length).toBe(500);
+    expect(e.userMessage).not.toContain('x');
+  });
+
+  it('비정상 상태(418)는 report=true', () => {
+    expect(AiError.fromProviderResponse('anthropic', 418, '').report).toBe(true);
+  });
+
+  it('레이트리밋(429)은 report=false', () => {
+    expect(AiError.fromProviderResponse('anthropic', 429, '').report).toBe(false);
+  });
+});
+
+describe('AiError.responseUnparsable', () => {
+  it('RESPONSE_UNPARSABLE (502, report=true)', () => {
+    const e = AiError.responseUnparsable(new Error('JSON'));
+    expect(e.kind).toBe('RESPONSE_UNPARSABLE');
+    expect(e.httpStatus).toBe(502);
+    expect(e.report).toBe(true);
+  });
+});

--- a/apps/web/src/entities/ai-config/model/ai-error.test.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
 import { CryptoError } from '@/shared/lib/crypto';
+import { describe, expect, it } from 'vitest';
+
 import { AiError } from './ai-error';
 
 describe('AiError.fromCryptoError', () => {

--- a/apps/web/src/entities/ai-config/model/ai-error.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.ts
@@ -1,0 +1,124 @@
+import { CryptoError } from '@/shared/lib/crypto';
+
+/**
+ * AI 초안 생성 흐름의 실패를 의미 단위로 분류한다.
+ *
+ * 기존에는 route 의 전역 catch 가 에러 메시지를 문자열 매칭
+ * (`401`/`Unauthorized`/`invalid`)해 분기했고, 그 외 모든 실패
+ * (복호화 실패·키 env 누락·provider 404/429/5xx·JSON 파싱 실패)가
+ * 하나의 불투명 500 으로 붕괴됐다. AiError 로 원인을 타입화해
+ * 적절한 HTTP 상태/사용자 메시지/Sentry 보고 여부를 결정한다.
+ */
+export type AiErrorKind =
+  | 'CRYPTO_MISCONFIG' // 서버 암호화 키 env 누락/형식 오류 (운영 대응)
+  | 'KEY_UNDECRYPTABLE' // 저장된 키를 현재 키로 복호화 불가 (재등록 필요)
+  | 'PROVIDER_UNAUTHORIZED' // provider 401/403 — API 키 무효
+  | 'PROVIDER_BAD_MODEL' // provider 404 — 모델 설정 오류
+  | 'PROVIDER_RATE_LIMITED' // provider 429
+  | 'PROVIDER_UNAVAILABLE' // provider 5xx
+  | 'PROVIDER_ERROR' // provider 그 외 비-2xx (예상 밖)
+  | 'RESPONSE_UNPARSABLE'; // LLM 응답이 JSON 으로 해석 불가
+
+interface AiErrorSpec {
+  httpStatus: number;
+  /** 클라이언트에 그대로 노출되는 안전한 메시지 (원인 식별 가능) */
+  userMessage: string;
+  /** 예상 밖 결함이라 Sentry 로 알려야 하는지 (사용자 환경 이슈는 false) */
+  report: boolean;
+}
+
+const SPECS: Record<AiErrorKind, AiErrorSpec> = {
+  CRYPTO_MISCONFIG: {
+    httpStatus: 500,
+    userMessage: '서버 키 설정 문제로 AI 기능을 사용할 수 없습니다. 관리자에게 문의해주세요.',
+    report: true,
+  },
+  KEY_UNDECRYPTABLE: {
+    httpStatus: 409,
+    userMessage:
+      '저장된 API 키를 복호화할 수 없습니다. 설정 페이지에서 API 키를 다시 등록해주세요.',
+    report: false,
+  },
+  PROVIDER_UNAUTHORIZED: {
+    httpStatus: 401,
+    userMessage: 'API 키가 유효하지 않습니다. 설정 페이지에서 키를 확인해주세요.',
+    report: false,
+  },
+  PROVIDER_BAD_MODEL: {
+    httpStatus: 400,
+    userMessage: 'AI 모델 설정이 올바르지 않습니다. 설정 페이지에서 모델을 확인해주세요.',
+    report: false,
+  },
+  PROVIDER_RATE_LIMITED: {
+    httpStatus: 429,
+    userMessage:
+      'AI 제공자의 요청 한도에 걸렸습니다. 잠시 후 다시 시도해주세요.',
+    report: false,
+  },
+  PROVIDER_UNAVAILABLE: {
+    httpStatus: 502,
+    userMessage:
+      'AI 제공자가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.',
+    report: false,
+  },
+  PROVIDER_ERROR: {
+    httpStatus: 502,
+    userMessage: 'AI 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+    report: true,
+  },
+  RESPONSE_UNPARSABLE: {
+    httpStatus: 502,
+    userMessage: 'AI 응답을 해석할 수 없습니다. 다시 시도해주세요.',
+    report: true,
+  },
+};
+
+export class AiError extends Error {
+  readonly kind: AiErrorKind;
+  readonly httpStatus: number;
+  readonly userMessage: string;
+  readonly report: boolean;
+  /** Sentry 진단용 부가 정보 — 사용자에게 노출하지 않음 */
+  readonly context: Record<string, unknown>;
+
+  constructor(kind: AiErrorKind, context: Record<string, unknown> = {}, cause?: unknown) {
+    const spec = SPECS[kind];
+    super(`AiError(${kind})`, cause === undefined ? undefined : { cause });
+    this.name = 'AiError';
+    this.kind = kind;
+    this.httpStatus = spec.httpStatus;
+    this.userMessage = spec.userMessage;
+    this.report = spec.report;
+    this.context = context;
+  }
+
+  /** 복호화 계층(CryptoError)을 도메인 에러로 변환 */
+  static fromCryptoError(error: CryptoError): AiError {
+    const kind: AiErrorKind =
+      error.code === 'AUTH_FAILED' ? 'KEY_UNDECRYPTABLE' : 'CRYPTO_MISCONFIG';
+    return new AiError(kind, { cryptoCode: error.code }, error);
+  }
+
+  /** provider 비-2xx 응답을 상태코드 기준으로 분류 */
+  static fromProviderResponse(
+    provider: string,
+    status: number,
+    bodyText: string,
+  ): AiError {
+    let kind: AiErrorKind;
+    if (status === 401 || status === 403) kind = 'PROVIDER_UNAUTHORIZED';
+    else if (status === 404) kind = 'PROVIDER_BAD_MODEL';
+    else if (status === 429) kind = 'PROVIDER_RATE_LIMITED';
+    else if (status >= 500) kind = 'PROVIDER_UNAVAILABLE';
+    else kind = 'PROVIDER_ERROR';
+    return new AiError(kind, {
+      provider,
+      providerStatus: status,
+      providerBody: bodyText.slice(0, 500),
+    });
+  }
+
+  static responseUnparsable(cause?: unknown): AiError {
+    return new AiError('RESPONSE_UNPARSABLE', {}, cause);
+  }
+}

--- a/apps/web/src/entities/ai-config/model/ai-error.ts
+++ b/apps/web/src/entities/ai-config/model/ai-error.ts
@@ -51,14 +51,12 @@ const SPECS: Record<AiErrorKind, AiErrorSpec> = {
   },
   PROVIDER_RATE_LIMITED: {
     httpStatus: 429,
-    userMessage:
-      'AI 제공자의 요청 한도에 걸렸습니다. 잠시 후 다시 시도해주세요.',
+    userMessage: 'AI 제공자의 요청 한도에 걸렸습니다. 잠시 후 다시 시도해주세요.',
     report: false,
   },
   PROVIDER_UNAVAILABLE: {
     httpStatus: 502,
-    userMessage:
-      'AI 제공자가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.',
+    userMessage: 'AI 제공자가 일시적으로 응답하지 않습니다. 잠시 후 다시 시도해주세요.',
     report: false,
   },
   PROVIDER_ERROR: {
@@ -100,11 +98,7 @@ export class AiError extends Error {
   }
 
   /** provider 비-2xx 응답을 상태코드 기준으로 분류 */
-  static fromProviderResponse(
-    provider: string,
-    status: number,
-    bodyText: string,
-  ): AiError {
+  static fromProviderResponse(provider: string, status: number, bodyText: string): AiError {
     let kind: AiErrorKind;
     if (status === 401 || status === 403) kind = 'PROVIDER_UNAUTHORIZED';
     else if (status === 404) kind = 'PROVIDER_BAD_MODEL';

--- a/apps/web/src/shared/lib/crypto/encrypt.ts
+++ b/apps/web/src/shared/lib/crypto/encrypt.ts
@@ -3,11 +3,41 @@ import crypto from 'crypto';
 const ALGORITHM = 'aes-256-gcm';
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
+const KEY_LENGTH = 32; // aes-256 → 32 bytes
+
+/**
+ * 암복호화 실패를 호출부가 식별할 수 있게 타입으로 구분한다.
+ * - KEY_NOT_SET / KEY_INVALID: 서버 환경(키) 설정 문제 — 운영 대응 필요
+ * - AUTH_FAILED: 저장 시점과 다른 키로 복호화 시도(키 로테이션/환경 불일치 등)
+ *
+ * `Error` 서브클래스이며 `message` 는 기존과 동일하게 유지하므로,
+ * 일반 `catch (error)` 로 받던 기존 호출부(github 토큰/웹훅)는 무영향.
+ */
+export type CryptoErrorCode = 'KEY_NOT_SET' | 'KEY_INVALID' | 'AUTH_FAILED';
+
+export class CryptoError extends Error {
+  readonly code: CryptoErrorCode;
+
+  constructor(code: CryptoErrorCode, message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = 'CryptoError';
+    this.code = code;
+  }
+}
 
 function getEncryptionKey(): Buffer {
   const key = process.env.GITHUB_TOKEN_ENCRYPTION_KEY;
-  if (!key) throw new Error('GITHUB_TOKEN_ENCRYPTION_KEY is not set');
-  return Buffer.from(key, 'hex');
+  if (!key) {
+    throw new CryptoError('KEY_NOT_SET', 'GITHUB_TOKEN_ENCRYPTION_KEY is not set');
+  }
+  const buf = Buffer.from(key, 'hex');
+  if (buf.length !== KEY_LENGTH) {
+    throw new CryptoError(
+      'KEY_INVALID',
+      `GITHUB_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH}-byte hex (got ${buf.length} bytes)`,
+    );
+  }
+  return buf;
 }
 
 export function encrypt(plaintext: string): string {
@@ -31,10 +61,20 @@ export function decrypt(ciphertext: string): string {
   const tag = buf.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
   const encrypted = buf.subarray(IV_LENGTH + TAG_LENGTH);
 
-  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(tag);
+  try {
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(tag);
 
-  let decrypted = decipher.update(encrypted);
-  decrypted = Buffer.concat([decrypted, decipher.final()]);
-  return decrypted.toString('utf8');
+    let decrypted = decipher.update(encrypted);
+    decrypted = Buffer.concat([decrypted, decipher.final()]);
+    return decrypted.toString('utf8');
+  } catch (error) {
+    // GCM 인증 태그 검증 실패 등: 저장 시점과 다른 키로 복호화한 경우.
+    // 원본 메시지를 보존해 기존 일반 catch 호출부 동작을 바꾸지 않는다.
+    throw new CryptoError(
+      'AUTH_FAILED',
+      error instanceof Error ? error.message : 'decryption failed',
+      { cause: error },
+    );
+  }
 }

--- a/apps/web/src/shared/lib/crypto/encrypt.ts
+++ b/apps/web/src/shared/lib/crypto/encrypt.ts
@@ -34,7 +34,7 @@ function getEncryptionKey(): Buffer {
   if (buf.length !== KEY_LENGTH) {
     throw new CryptoError(
       'KEY_INVALID',
-      `GITHUB_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH}-byte hex (got ${buf.length} bytes)`,
+      `GITHUB_TOKEN_ENCRYPTION_KEY must be ${KEY_LENGTH}-byte hex (got ${buf.length} bytes)`
     );
   }
   return buf;
@@ -74,7 +74,7 @@ export function decrypt(ciphertext: string): string {
     throw new CryptoError(
       'AUTH_FAILED',
       error instanceof Error ? error.message : 'decryption failed',
-      { cause: error },
+      { cause: error }
     );
   }
 }

--- a/apps/web/src/shared/lib/crypto/index.ts
+++ b/apps/web/src/shared/lib/crypto/index.ts
@@ -1,1 +1,2 @@
-export { encrypt, decrypt } from './encrypt';
+export { encrypt, decrypt, CryptoError } from './encrypt';
+export type { CryptoErrorCode } from './encrypt';


### PR DESCRIPTION
## 변경 사항

- 디자인 시스템 패키지에서만 쓰이는 임의값 유틸리티 클래스가 빠짐없이 컴파일되도록, 호스트 앱의 Tailwind content 스캔 대상에 워크스페이스 디자인 시스템 패키지 소스를 명시적으로 포함시킵니다.
- 그 결과 dev 환경의 인풋 컴포넌트에서 좌우 안쪽 여백과 내부 자식 간격이 적용되어 placeholder가 박스 좌상단에 붙던 시각 회귀가 복구됩니다.

## 배경

- main과 dev의 인풋 관련 디자인 시스템 소스는 byte-identical인데도 dev 환경에서만 placeholder 정렬 회귀가 보였습니다.
- 분석 결과, classList에는 임의값 유틸리티가 분명히 들어있는데 브라우저 computed style은 0으로 떨어지는 상태였습니다. 즉 코드 변경이 아니라 CSS 빌드 파이프라인이 원인이었습니다.
- Tailwind v4 의 자동 content 스캔은 호스트 앱 디렉터리만 기준으로 동작하기 때문에, 워크스페이스 디자인 시스템 패키지의 소스는 자동 포함되지 않습니다. 호스트 앱 다른 컴포넌트에서도 같은 클래스 문자열을 쓰는 경우는 우연히 컴파일이 되어 일부 속성만 살아남고, 패키지에서만 쓰이는 임의값은 전부 누락되는 부분 회귀 양상이 만들어졌습니다.
- transpilePackages 설정은 JavaScript 트랜스파일 처리이므로 Tailwind 스캔과 무관합니다.

## 검증

로컬 개발 서버에서 동일 화면을 다시 띄워 인풋 computed style을 비교 확인했습니다.

| 속성 | 패치 전 | 패치 후 |
| --- | --- | --- |
| 좌우 안쪽 여백 | 0 | 의도한 값 적용 |
| 자식 간격 | 적용 안 됨 | 의도한 값 적용 |
| 높이·flex 정렬 | 정상 | 정상 |

시각적으로도 placeholder가 박스 안쪽으로 들여져 정렬이 정상화됨을 확인했습니다.

## 영향 범위 / 후속

- 동일 패턴이 다른 워크스페이스 패키지로 확장되면 그 시점에 동일 directive 추가가 필요합니다.
- 향후 백오피스 앱이 동일 디자인 시스템을 사용하기 시작하면 그쪽 전역 스타일에도 같은 처리가 필요합니다.

## 테스트 계획

- [ ] 로컬 개발 서버에서 프로젝트 생성 모달의 프로젝트 이름 인풋에 좌우 안쪽 여백·자식 간격이 적용되는지 확인
- [ ] dev 배포 후 같은 인풋에서 placeholder 정렬이 정상화됐는지 확인
- [ ] 디자인 시스템 인풋을 사용하는 다른 화면(검색 모달, 식별번호 입력 등)이 회귀 없는지 둘러보기
- [ ] CSS 번들 크기 변화가 크지 않은지 확인


Closes #119
