### PR TITLE
fix(#120): AI 생성 케이스 일괄 저장이 NOT NULL 제약에 막히던 회귀 수정

### DIFF
--- a/apps/web/src/entities/ai-config/api/server-actions.ts
+++ b/apps/web/src/entities/ai-config/api/server-actions.ts
@@ -184,6 +184,7 @@ export const saveGeneratedCases = async (input: {
 
     const { projectId, suiteId, cases } = parsed.data;
     const db = getDatabase();
+    const now = new Date();
 
     const count = await db.transaction(async (tx) => {
       // display_id 최대값 조회
@@ -210,6 +211,10 @@ export const saveGeneratedCases = async (input: {
             case_key: `TC-${String(displayId).padStart(3, '0')}`,
             sort_order: 0,
             result_status: 'untested' as const,
+            // DB 컬럼에 DEFAULT now() 가 박혀있지 않아 drizzle 의 DEFAULT 키워드만으로는
+            // NOT NULL 제약에서 막힌다. 단일 케이스 생성과 동일하게 값을 명시한다.
+            created_at: now,
+            updated_at: now,
           };
         })
       );

--- a/apps/web/src/features/ai-generate/ui/ai-generate-modal.tsx
+++ b/apps/web/src/features/ai-generate/ui/ai-generate-modal.tsx
@@ -1,21 +1,21 @@
 'use client';
 
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import { Bot, Loader2, Sparkles, X } from 'lucide-react';
 
 import { aiConfigQueryOptions } from '@/entities/ai-config';
-import { aiUsageQueryOptions } from '@/entities/ai-usage';
 import type { GeneratedTestCase } from '@/entities/ai-config';
 import { saveGeneratedCases } from '@/entities/ai-config/api/server-actions';
+import { aiUsageQueryOptions } from '@/entities/ai-usage';
 import { testSuitesQueryOptions } from '@/widgets';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Dialog } from '@testea/ui';
 import { DSButton } from '@testea/ui';
+import { Bot, Loader2, Sparkles, X } from 'lucide-react';
+import { toast } from 'sonner';
 
+import { AiCasePreviewList } from './ai-case-preview-list';
 import { AiGenerateForm } from './ai-generate-form';
 import { AiGeneratingSpinner } from './ai-generating-spinner';
-import { AiCasePreviewList } from './ai-case-preview-list';
 
 type Props = {
   projectId: string;
@@ -92,6 +92,9 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
         toast.error(msg);
       }
     },
+    onError: (error: Error) => {
+      toast.error(error.message || 'TC 저장 중 오류가 발생했습니다.');
+    },
   });
 
   const toggleAll = () => {
@@ -119,16 +122,20 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
     <Dialog.Root defaultOpen>
       <Dialog.Portal>
         <Dialog.Overlay onClick={step !== 'loading' ? onClose : undefined} />
-        <Dialog.Content className="bg-bg-2 border-line-2 rounded-5 w-full max-w-[720px] max-h-[85vh] border p-0 flex flex-col">
+        <Dialog.Content className="bg-bg-2 border-line-2 rounded-5 flex max-h-[85vh] w-full max-w-[720px] flex-col border p-0">
           {/* 헤더 */}
-          <div className="flex items-center justify-between border-b border-line-2 px-6 py-4">
+          <div className="border-line-2 flex items-center justify-between border-b px-6 py-4">
             <div className="flex items-center gap-3">
               <Dialog.Title className="typo-h2-heading text-text-1">
                 AI 테스트 케이스 생성
               </Dialog.Title>
             </div>
             {step !== 'loading' && (
-              <button type="button" onClick={onClose} className="text-text-4 hover:text-text-2 transition-colors">
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-text-4 hover:text-text-2 transition-colors"
+              >
                 <X className="h-5 w-5" />
               </button>
             )}
@@ -138,8 +145,8 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
           <div className="flex-1 overflow-y-auto p-6">
             {!hasConfig ? (
               <div className="flex flex-col items-center gap-4 py-10 text-center">
-                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
-                  <Bot className="h-7 w-7 text-primary" />
+                <div className="bg-primary/10 flex h-14 w-14 items-center justify-center rounded-full">
+                  <Bot className="text-primary h-7 w-7" />
                 </div>
                 <div className="flex flex-col gap-1">
                   <p className="typo-body1-heading text-text-1">API 키가 필요합니다</p>
@@ -154,28 +161,28 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
             ) : step === 'input' ? (
               <>
                 {usage && (
-                  <div className="mb-4 flex items-center justify-between rounded-lg border border-line-2 bg-bg-3 px-4 py-2.5">
-                    <span className="typo-body2-normal text-text-3">
-                      이번 달 사용량
-                    </span>
-                    <span className={`typo-body2-heading ${isLimitExceeded ? 'text-error' : 'text-text-1'}`}>
+                  <div className="border-line-2 bg-bg-3 mb-4 flex items-center justify-between rounded-lg border px-4 py-2.5">
+                    <span className="typo-body2-normal text-text-3">이번 달 사용량</span>
+                    <span
+                      className={`typo-body2-heading ${isLimitExceeded ? 'text-error' : 'text-text-1'}`}
+                    >
                       {usage.used}/{usage.limit}건
                     </span>
                   </div>
                 )}
                 {isLimitExceeded && (
-                  <div className="mb-4 rounded-lg border border-error/30 bg-error/5 px-4 py-3">
+                  <div className="border-error/30 bg-error/5 mb-4 rounded-lg border px-4 py-3">
                     <p className="typo-body2-normal text-error">
                       이번 달 사용 한도를 초과했습니다. 다음 달에 다시 이용해주세요.
                     </p>
                   </div>
                 )}
-              <AiGenerateForm
-                description={description}
-                onDescriptionChange={setDescription}
-                language={language}
-                onLanguageChange={setLanguage}
-              />
+                <AiGenerateForm
+                  description={description}
+                  onDescriptionChange={setDescription}
+                  language={language}
+                  onLanguageChange={setLanguage}
+                />
               </>
             ) : step === 'loading' ? (
               <AiGeneratingSpinner />
@@ -195,7 +202,7 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
 
           {/* 푸터 */}
           {hasConfig && step !== 'loading' && (
-            <div className="flex items-center justify-between border-t border-line-2 px-6 py-4">
+            <div className="border-line-2 flex items-center justify-between border-t px-6 py-4">
               {step === 'preview' && (
                 <button
                   type="button"
@@ -215,7 +222,11 @@ export const AiGenerateModal = ({ projectId, slug, onClose }: Props) => {
                     variant="solid"
                     size="small"
                     onClick={() => generateMutation.mutate()}
-                    disabled={description.trim().length < 20 || generateMutation.isPending || isLimitExceeded}
+                    disabled={
+                      description.trim().length < 20 ||
+                      generateMutation.isPending ||
+                      isLimitExceeded
+                    }
                   >
                     <span className="flex items-center gap-2">
                       <Sparkles className="h-4 w-4" />


### PR DESCRIPTION
## 변경 사항

- AI로 생성한 테스트 케이스를 일괄 저장할 때 트랜잭션 전체가 롤백되어 한 건도 저장되지 않던 회귀를 수정합니다. 저장 시점에 생성/수정 시각 값을 함께 보내도록 맞췄습니다.
- 저장 단계의 에러 처리 누락도 함께 보완합니다. 서버에서 예외가 발생했을 때 사용자에게 토스트가 노출되지 않던 점을 채워, 어느 경로로 실패해도 메시지가 보이도록 했습니다.

## 배경

- 모달에서 생성 결과를 확인한 뒤 "저장하기"를 눌러도 일관되게 실패 토스트만 떴습니다.
- DB를 직접 들여다보니 해당 프로젝트에 생성 시도된 케이스들이 한 건도 들어가 있지 않았고, 중복/충돌도 아니었습니다.
- 발송된 SQL을 그대로 재현해보니 생성 시각 컬럼이 NOT NULL 제약을 위반하면서 트랜잭션 전체가 롤백되고 있었습니다.
- 같은 테이블에 들어가는 단일 케이스 생성 흐름은 시각 값을 명시적으로 채워 보내고 있어 영향이 없었지만, AI 일괄 저장 경로만 누락된 상태였습니다.

## 영향 / 후속 메모

- 동일한 일괄 insert 패턴을 쓰는 다른 위치(체크리스트 일괄 생성, 케이스 가져오기)도 같은 누락이 의심됩니다. 이번 PR 범위는 AI 저장만 다루고, 나머지는 별도 점검 후 처리합니다.
- 보다 근본적인 정합성 회복(스키마 선언과 실제 컬럼 DEFAULT 사이의 불일치 해소)은 마이그레이션 단독 PR로 분리하는 것이 안전하다고 판단되어, 이번 PR에는 포함하지 않습니다.

## 테스트 계획

- [ ] 로컬에서 AI로 케이스 10건을 생성 후 저장 버튼 클릭, 성공 토스트와 케이스 리스트 즉시 반영 확인
- [ ] 동일 흐름에서 의도적으로 실패를 유도(예: 잘못된 입력)했을 때 에러 토스트가 노출되는지 확인
- [ ] 단일 케이스 생성, 케이스 가져오기 등 기존 흐름이 회귀 없는지 가벼운 회귀 확인


Closes #120
