### PR TITLE
fix(#121): 마일스톤 생성과 체크리스트→TC 변환의 NOT NULL 회귀 보강

### DIFF
--- a/apps/web/src/entities/checklist/api/server-actions.ts
+++ b/apps/web/src/entities/checklist/api/server-actions.ts
@@ -1,16 +1,19 @@
 'use server';
 
-import * as Sentry from '@sentry/nextjs';
-import { getDatabase, checklists, checklistItems } from '@testea/db';
-import { and, asc, count, eq, inArray, sql } from 'drizzle-orm';
 import type { ActionResult } from '@/shared/types';
+import * as Sentry from '@sentry/nextjs';
+import { checklistItems, checklists, getDatabase } from '@testea/db';
+import { and, asc, count, eq, inArray, sql } from 'drizzle-orm';
+
+import { AddChecklistItemSchema, CreateChecklistSchema } from '../model/schema';
 import type { ChecklistWithItems, ChecklistWithProgress } from '../model/types';
-import { CreateChecklistSchema, AddChecklistItemSchema } from '../model/schema';
 
 // --- 생성 ---
-export const createChecklist = async (
-  input: { projectId: string; title: string; items: { content: string }[] },
-): Promise<ActionResult<{ id: string }>> => {
+export const createChecklist = async (input: {
+  projectId: string;
+  title: string;
+  items: { content: string }[];
+}): Promise<ActionResult<{ id: string }>> => {
   try {
     const parsed = CreateChecklistSchema.safeParse(input);
     if (!parsed.success) {
@@ -31,7 +34,7 @@ export const createChecklist = async (
           checklist_id: checklist.id,
           content: item.content,
           sort_order: idx * 1000,
-        })),
+        }))
       );
     }
 
@@ -44,7 +47,7 @@ export const createChecklist = async (
 
 // --- 목록 조회 ---
 export const getChecklistsByProjectId = async (
-  projectId: string,
+  projectId: string
 ): Promise<ActionResult<ChecklistWithProgress[]>> => {
   try {
     const db = getDatabase();
@@ -64,12 +67,7 @@ export const getChecklistsByProjectId = async (
       })
       .from(checklists)
       .leftJoin(checklistItems, eq(checklistItems.checklist_id, checklists.id))
-      .where(
-        and(
-          eq(checklists.project_id, projectId),
-          eq(checklists.lifecycle_status, 'ACTIVE'),
-        ),
-      )
+      .where(and(eq(checklists.project_id, projectId), eq(checklists.lifecycle_status, 'ACTIVE')))
       .groupBy(checklists.id)
       .orderBy(checklists.updated_at);
 
@@ -89,22 +87,21 @@ export const getChecklistsByProjectId = async (
     return { success: true, data };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'getChecklistsByProjectId' } });
-    return { success: false, errors: { _checklist: ['체크리스트 목록을 불러오는 데 실패했습니다.'] } };
+    return {
+      success: false,
+      errors: { _checklist: ['체크리스트 목록을 불러오는 데 실패했습니다.'] },
+    };
   }
 };
 
 // --- 상세 조회 ---
 export const getChecklistById = async (
-  checklistId: string,
+  checklistId: string
 ): Promise<ActionResult<ChecklistWithItems>> => {
   try {
     const db = getDatabase();
 
-    const [row] = await db
-      .select()
-      .from(checklists)
-      .where(eq(checklists.id, checklistId))
-      .limit(1);
+    const [row] = await db.select().from(checklists).where(eq(checklists.id, checklistId)).limit(1);
 
     if (!row) {
       return { success: false, errors: { _checklist: ['체크리스트를 찾을 수 없습니다.'] } };
@@ -146,7 +143,7 @@ export const getChecklistById = async (
 // --- 항목 체크/언체크 ---
 export const toggleChecklistItem = async (
   itemId: string,
-  isChecked: boolean,
+  isChecked: boolean
 ): Promise<ActionResult<{ checklistStatus: string }>> => {
   try {
     const db = getDatabase();
@@ -202,10 +199,7 @@ export const toggleChecklistItem = async (
       updateData.started_at = new Date();
     }
 
-    await db
-      .update(checklists)
-      .set(updateData)
-      .where(eq(checklists.id, updated.checklist_id));
+    await db.update(checklists).set(updateData).where(eq(checklists.id, updated.checklist_id));
 
     return { success: true, data: { checklistStatus: newStatus } };
   } catch (error) {
@@ -215,9 +209,10 @@ export const toggleChecklistItem = async (
 };
 
 // --- 항목 추가 ---
-export const addChecklistItem = async (
-  input: { checklistId: string; content: string },
-): Promise<ActionResult<{ id: string }>> => {
+export const addChecklistItem = async (input: {
+  checklistId: string;
+  content: string;
+}): Promise<ActionResult<{ id: string }>> => {
   try {
     const parsed = AddChecklistItemSchema.safeParse(input);
     if (!parsed.success) {
@@ -245,12 +240,7 @@ export const addChecklistItem = async (
     await db
       .update(checklists)
       .set({ status: 'open', completed_at: null, updated_at: new Date() })
-      .where(
-        and(
-          eq(checklists.id, parsed.data.checklistId),
-          eq(checklists.status, 'completed'),
-        ),
-      );
+      .where(and(eq(checklists.id, parsed.data.checklistId), eq(checklists.status, 'completed')));
 
     return { success: true, data: { id: item.id } };
   } catch (error) {
@@ -260,9 +250,7 @@ export const addChecklistItem = async (
 };
 
 // --- 항목 삭제 ---
-export const deleteChecklistItem = async (
-  itemId: string,
-): Promise<ActionResult<null>> => {
+export const deleteChecklistItem = async (itemId: string): Promise<ActionResult<null>> => {
   try {
     const db = getDatabase();
     await db.delete(checklistItems).where(eq(checklistItems.id, itemId));
@@ -274,9 +262,7 @@ export const deleteChecklistItem = async (
 };
 
 // --- 체크리스트 삭제 (소프트) ---
-export const archiveChecklist = async (
-  checklistId: string,
-): Promise<ActionResult<null>> => {
+export const archiveChecklist = async (checklistId: string): Promise<ActionResult<null>> => {
   try {
     const db = getDatabase();
     await db
@@ -298,7 +284,7 @@ export const archiveChecklist = async (
 // --- 항목 순서 변경 ---
 export const reorderChecklistItems = async (
   checklistId: string,
-  orderedIds: string[],
+  orderedIds: string[]
 ): Promise<ActionResult<null>> => {
   try {
     const db = getDatabase();
@@ -308,13 +294,8 @@ export const reorderChecklistItems = async (
         db
           .update(checklistItems)
           .set({ sort_order: idx * 1000 })
-          .where(
-            and(
-              eq(checklistItems.id, id),
-              eq(checklistItems.checklist_id, checklistId),
-            ),
-          ),
-      ),
+          .where(and(eq(checklistItems.id, id), eq(checklistItems.checklist_id, checklistId)))
+      )
     );
 
     return { success: true, data: null };
@@ -329,7 +310,7 @@ export const convertChecklistToTestCases = async (
   checklistId: string,
   itemIds: string[],
   projectId: string,
-  suiteId?: string,
+  suiteId?: string
 ): Promise<ActionResult<{ count: number }>> => {
   try {
     const db = getDatabase();
@@ -337,12 +318,7 @@ export const convertChecklistToTestCases = async (
     const items = await db
       .select()
       .from(checklistItems)
-      .where(
-        and(
-          eq(checklistItems.checklist_id, checklistId),
-          inArray(checklistItems.id, itemIds),
-        ),
-      )
+      .where(and(eq(checklistItems.checklist_id, checklistId), inArray(checklistItems.id, itemIds)))
       .orderBy(asc(checklistItems.sort_order));
 
     if (items.length === 0) {
@@ -359,6 +335,7 @@ export const convertChecklistToTestCases = async (
       .where(eq(testCases.project_id, projectId));
 
     let nextDisplayId = (maxDisplayId?.max ?? 0) + 1;
+    const now = new Date();
 
     await db.insert(testCases).values(
       items.map((item) => ({
@@ -368,7 +345,11 @@ export const convertChecklistToTestCases = async (
         test_suite_id: suiteId ?? null,
         display_id: nextDisplayId++,
         sort_order: 0,
-      })),
+        // DB 컬럼에 DEFAULT now() 가 없어 drizzle 의 DEFAULT 키워드만으로는
+        // NOT NULL 제약에서 막힌다. 값을 명시한다.
+        created_at: now,
+        updated_at: now,
+      }))
     );
 
     return { success: true, data: { count: items.length } };

--- a/apps/web/src/features/milestones-create/model/server-action.ts
+++ b/apps/web/src/features/milestones-create/model/server-action.ts
@@ -1,12 +1,13 @@
 'use server';
-import * as Sentry from '@sentry/nextjs';
-import { CreateMilestoneSchema } from '../../../entities/milestone';
-import { getDatabase, milestones } from '@testea/db';
-import { z } from 'zod';
-import { v7 as uuidv7 } from 'uuid';
-import { requireProjectAccess } from '../../../access/lib/require-access';
 import { checkStorageLimit } from '@/shared/lib/storage/check-storage-limit';
 import type { FlatErrors } from '@/shared/types';
+import * as Sentry from '@sentry/nextjs';
+import { getDatabase, milestones } from '@testea/db';
+import { v7 as uuidv7 } from 'uuid';
+import { z } from 'zod';
+
+import { requireProjectAccess } from '../../../access/lib/require-access';
+import { CreateMilestoneSchema } from '../../../entities/milestone';
 
 type CreateMilestoneInput = z.infer<typeof CreateMilestoneSchema>;
 
@@ -33,6 +34,7 @@ export const createMilestoneAction = async (input: CreateMilestoneInput) => {
 
   try {
     const db = getDatabase();
+    const now = new Date();
     const [newMilestone] = await db
       .insert(milestones)
       .values({
@@ -42,6 +44,10 @@ export const createMilestoneAction = async (input: CreateMilestoneInput) => {
         description: validation.data.description,
         start_date: validation.data.startDate?.toISOString(),
         end_date: validation.data.endDate?.toISOString(),
+        // DB 컬럼에 DEFAULT now() 가 없어 drizzle 의 DEFAULT 키워드만으로는
+        // NOT NULL 제약에서 막힌다. 값을 명시한다.
+        created_at: now,
+        updated_at: now,
       })
       .returning();
     return { success: true, milestone: newMilestone };


### PR DESCRIPTION
## 변경 사항

- 마일스톤 생성과 체크리스트 항목을 테스트 케이스로 변환하는 두 흐름에서, 저장 시점에 생성/수정 시각을 명시적으로 채워 보내도록 보강합니다.
- 두 곳 모두 보내지 않은 상태였고, 트랜잭션이 통째 롤백되어 사용자에게는 일반적인 실패 메시지만 노출되는 잠재 결함이었습니다.

## 배경

- PR #114 에서 AI 생성 케이스 일괄 저장이 동일한 패턴으로 실패하던 회귀를 잡았습니다. 같은 결함이 다른 위치에 더 남아있는지 점검했고, 이번에 두 곳을 추가로 확인했습니다.
- 단일 케이스 생성, 케이스 복제, 케이스 가져오기, 단일 마일스톤 생성 경로는 이미 같은 패턴으로 시각을 채워 보내고 있어 영향이 없었습니다. 이번 PR은 누락된 두 위치만 그 컨벤션에 맞추는 방어 보강입니다.

## 영향 / 후속 메모

- 보다 근본적인 정합성 회복(스키마 선언과 실제 DB 컬럼의 기본값 사이 불일치 해소)은 마이그레이션 단독 PR로 분리하는 것이 안전하다고 판단되어, 이번에도 포함하지 않습니다.
- 마일스톤 생성 경로가 도메인 모델 측과 사용자 행동 측에 둘 다 살아 있는 점이 관찰되었습니다. 통합 여부는 별 정리 거리로 남겨둡니다.

## 테스트 계획

- [ ] 로컬에서 마일스톤 생성 시 정상 저장과 목록 즉시 반영 확인
- [ ] 체크리스트에서 항목 선택 후 테스트 케이스로 변환 시 정상 저장과 케이스 리스트 즉시 반영 확인
- [ ] 기존에 안전했던 단일 케이스 생성, 케이스 가져오기 등 회귀 없는지 가벼운 확인


Closes #121
