### PR TITLE
chore(#124): DB 장애 복구 공지 팝업 비활성화

### DIFF
--- a/apps/web/src/view/lending/lending-cta.tsx
+++ b/apps/web/src/view/lending/lending-cta.tsx
@@ -1,24 +1,27 @@
 'use client';
 
 import React from 'react';
+
 import dynamic from 'next/dynamic';
+
+import { LANDING_EVENTS, track } from '@/shared/lib/analytics';
 import { DSButton } from '@testea/ui';
-import { track, LANDING_EVENTS } from '@/shared/lib/analytics';
 
 const ProjectCreateForm = dynamic(
-  () => import('@/features/projects-create').then(mod => ({ default: mod.ProjectCreateForm })),
-  { ssr: false },
+  () => import('@/features/projects-create').then((mod) => ({ default: mod.ProjectCreateForm })),
+  { ssr: false }
 );
 
 const BetaNoticePopup = dynamic(
-  () => import('@/features/beta-notice').then(mod => ({ default: mod.BetaNoticePopup })),
-  { ssr: false },
+  () => import('@/features/beta-notice').then((mod) => ({ default: mod.BetaNoticePopup })),
+  { ssr: false }
 );
 
-const DbOutageNoticePopup = dynamic(
-  () => import('@/features/db-outage-notice').then(mod => ({ default: mod.DbOutageNoticePopup })),
-  { ssr: false },
-);
+// DB 장애 복구 완료로 공지 비활성화. 향후 동일 공지 필요 시 주석 해제.
+// const DbOutageNoticePopup = dynamic(
+//   () => import('@/features/db-outage-notice').then(mod => ({ default: mod.DbOutageNoticePopup })),
+//   { ssr: false },
+// );
 
 export const LendingCta = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = React.useState(false);
@@ -38,11 +41,9 @@ export const LendingCta = () => {
           무료로 시작하기
         </DSButton>
       </section>
-      {isCreateModalOpen && (
-        <ProjectCreateForm onClick={() => setIsCreateModalOpen(false)} />
-      )}
+      {isCreateModalOpen && <ProjectCreateForm onClick={() => setIsCreateModalOpen(false)} />}
       <BetaNoticePopup />
-      <DbOutageNoticePopup />
+      {/* <DbOutageNoticePopup /> */}
     </>
   );
 };


### PR DESCRIPTION
## 변경 사항

- 랜딩 진입 시 노출되던 DB 장애 안내 공지 팝업을 주석으로 비활성화합니다.

## 배경

- DB 장애가 복구되어 더 이상 동일한 안내가 필요하지 않은 상태입니다.
- 공지 컴포넌트 자체와 동적 로드 정의는 그대로 두었고, 호출하는 위치만 비활성화했습니다. 향후 같은 결의 공지가 필요할 때 한 줄 주석 해제로 즉시 복구할 수 있도록 했습니다.

## 테스트 계획

- [ ] 랜딩 진입 시 안내 공지가 더 이상 자동으로 뜨지 않는지 확인
- [ ] 베타 안내 공지는 그대로 노출되는지 확인 (영향 범위 분리 확인용)


Closes #124
