### PR TITLE
chore(#129): 브라우저 확장 노이즈 Sentry ignoreErrors·denyUrls 추가

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -18,6 +18,20 @@ Sentry.init({
   enableLogs: true,
   sendDefaultPii: true,
 
+  // 브라우저 확장(패스워드 매니저·광고차단·DevTools 등)에서 새는 노이즈는 우리 코드와 무관.
+  // Sentry 알림이 더러워지지 않도록 필터링한다.
+  ignoreErrors: [
+    // chrome.runtime.onMessage listener 가 비동기 응답 반환 전에 채널이 닫혀서 나는 에러.
+    // 거의 모든 확장에서 발생.
+    /A listener indicated an asynchronous response by returning true/i,
+    /The message port closed before a response was received/i,
+    // 확장 컨텍스트가 reload 되면서 발생
+    /Extension context invalidated/i,
+    // ResizeObserver 무한 루프 경고 (사용자 코드 영향 없음, 브라우저 자체 노이즈)
+    /ResizeObserver loop (?:limit exceeded|completed with undelivered notifications)/i,
+  ],
+  denyUrls: [/^chrome-extension:\/\//, /^moz-extension:\/\//, /^safari-(?:web-)?extension:\/\//],
+
   enabled: process.env.NODE_ENV !== 'development' && !!dsn,
 });
 


### PR DESCRIPTION
Closed: #129

## 작업 유형
- [x] chore — 빌드 / 설정 변경

## 요약

브라우저 확장이 만들어 사용자 콘솔로 새 나오는 노이즈가 Sentry 로도 그대로 수집되어 운영 알림이 흐려지는 문제를 줄였습니다. 알려진 패턴을 클라이언트 Sentry 단에서 무시하거나 차단 출처로 처리하도록 설정을 보강합니다.

## 배경 / 동기

콘솔에 가끔 보이는 "비동기 응답을 약속했는데 채널이 먼저 닫혔다" 류 에러는 본 앱이 만드는 게 아니라 패스워드 매니저, 광고 차단기, React DevTools 같은 브라우저 확장이 자기 메시지 핸들러에서 던지는 노이즈입니다. 본 앱은 확장 메시지 API 를 쓰지 않고, 유일한 OAuth 팝업용 message 리스너도 비동기 응답을 약속하는 형태가 아니라 이 에러를 만들 길이 없습니다.

그럼에도 Sentry 가 사용자 브라우저에서 새 나온 노이즈를 그대로 수집해 운영 알림에서 시그널 대비 노이즈 비율이 점점 악화되고 있었습니다. 알림이 무뎌지면 진짜 회귀를 놓치기 쉬워지므로 알려진 패턴은 미리 걸러둡니다.

- 관련 이슈: #129

## 변경 사항

- Sentry 클라이언트의 에러 메시지 무시 패턴에 확장 메시지 채널의 비동기 응답 닫힘, 메시지 포트 닫힘, 확장 컨텍스트 무효화, ResizeObserver loop 노이즈, React DevTools 가 React 19 fiber 순회 도중 트리거하는 self-diagnostic 다섯 종류를 추가했습니다.
- 확장 출처 자체를 캡처에서 제외하도록 chrome / firefox / safari 확장 스킴과 React DevTools 가 페이지에 주입하는 hook 스크립트 경로를 차단 목록에 더했습니다.

## 스크린샷 / 데모

UI 변경 사항이 없습니다.

| Before | After |
| --- | --- |
| 해당 없음 | 해당 없음 |

## 테스트 방법

1. 로컬에서 빌드를 실행해 정상 통과를 확인합니다.
2. dev 배포 후 1주간 같은 패턴의 에러가 Sentry 에서 더 이상 수집되지 않는지 모니터링합니다.

## 영향 범위 / 주의사항

- Sentry 클라이언트 초기화 한 곳만 변경합니다.
- 추가한 필터는 캡처 단계에서만 동작해 정상 에러 수집에는 영향이 없습니다.

## 체크리스트

- [x] 기존 기능에 회귀가 없는지 확인 (필터는 캡처 단계 전용, 코드 동작 변경 없음)
- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음
