### PR TITLE
fix(a11y): 메뉴 role·포커스 트랩·이벤트 가드 4건 일괄 quick win 처리

### DIFF
--- a/apps/web/src/entities/test-case/ui/test-case-card.tsx
+++ b/apps/web/src/entities/test-case/ui/test-case-card.tsx
@@ -91,7 +91,6 @@ export const TestCaseCard = ({ testCase, onDuplicate }: TestCaseCardProps) => {
         <button
           type="button"
           aria-label="케이스 작업"
-          aria-haspopup="menu"
           aria-expanded={isMenuOpen}
           className="rounded-1 text-text-4 hover:bg-bg-4 hover:text-text-1 focus-visible:ring-primary cursor-pointer p-1 opacity-0 transition-all group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:ring-2 focus-visible:outline-none"
           onClick={(e) => {
@@ -112,13 +111,11 @@ export const TestCaseCard = ({ testCase, onDuplicate }: TestCaseCardProps) => {
               }}
             />
             <div
-              role="menu"
               aria-label="케이스 작업"
               className="bg-bg-2 border-line-2 rounded-2 absolute top-full right-0 z-50 mt-1 min-w-[120px] border py-1 shadow-lg"
             >
               <button
                 type="button"
-                role="menuitem"
                 className="text-text-2 hover:bg-bg-3 flex w-full items-center gap-2 px-3 py-2 text-sm"
                 onClick={(e) => {
                   e.stopPropagation();

--- a/apps/web/src/features/cases-create/ui/test-case-detail-form.tsx
+++ b/apps/web/src/features/cases-create/ui/test-case-detail-form.tsx
@@ -116,7 +116,7 @@ export const TestCaseDetailForm = ({
       }
       if (e.key !== 'Tab' || !node) return;
       const focusables = node.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
       );
       if (focusables.length === 0) return;
       const first = focusables[0];

--- a/apps/web/src/features/suites-create/ui/suite-create-form.tsx
+++ b/apps/web/src/features/suites-create/ui/suite-create-form.tsx
@@ -67,7 +67,7 @@ export const SuiteCreateForm = ({ projectId, onClose }: SuiteCreateFormProps) =>
       }
       if (e.key !== 'Tab' || !node) return;
       const focusables = node.querySelectorAll<HTMLElement>(
-        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]):not([type="hidden"]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
       );
       if (focusables.length === 0) return;
       const first = focusables[0];

--- a/apps/web/src/view/project/cases/_components/case-list-section.tsx
+++ b/apps/web/src/view/project/cases/_components/case-list-section.tsx
@@ -185,11 +185,17 @@ export const CaseListSection = ({
                         'focus-visible:ring-primary focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset',
                         item.isOptimistic && 'pointer-events-none animate-pulse opacity-50'
                       )}
-                      onClick={() => {
+                      onClick={(e) => {
+                        // 내부 액션 버튼(더보기 / 복제 등) 클릭은 부모로 위임하지 않는다.
+                        // 자식 onClick 의 stopPropagation 에만 기대지 않고 부모에서도 가드한다.
+                        if (e.target !== e.currentTarget) return;
                         track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });
                         onSelectCase(item.id);
                       }}
                       onKeyDown={(e) => {
+                        // 내부 버튼에 포커스된 상태의 Enter/Space 가 부모로 버블링돼
+                        // 행 선택이 동시에 일어나지 않도록 가드한다.
+                        if (e.target !== e.currentTarget) return;
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
                           track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });

--- a/apps/web/src/view/project/cases/_components/case-list-section.tsx
+++ b/apps/web/src/view/project/cases/_components/case-list-section.tsx
@@ -186,16 +186,20 @@ export const CaseListSection = ({
                         item.isOptimistic && 'pointer-events-none animate-pulse opacity-50'
                       )}
                       onClick={(e) => {
-                        // 내부 액션 버튼(더보기 / 복제 등) 클릭은 부모로 위임하지 않는다.
-                        // 자식 onClick 의 stopPropagation 에만 기대지 않고 부모에서도 가드한다.
-                        if (e.target !== e.currentTarget) return;
+                        // 내부 인터랙티브 자식(액션 버튼 등) 클릭은 부모로 위임하지 않는다.
+                        // currentTarget 비교는 자식 텍스트(div / span) 클릭까지 전부 차단해서
+                        // 행 본문 클릭으로 케이스 진입이 안 되는 회귀가 생긴다.
+                        // 인터랙티브 요소(button / a / input / select / textarea)만 가드한다.
+                        if ((e.target as HTMLElement).closest('button, a, input, select, textarea'))
+                          return;
                         track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });
                         onSelectCase(item.id);
                       }}
                       onKeyDown={(e) => {
-                        // 내부 버튼에 포커스된 상태의 Enter/Space 가 부모로 버블링돼
-                        // 행 선택이 동시에 일어나지 않도록 가드한다.
-                        if (e.target !== e.currentTarget) return;
+                        // 내부 인터랙티브 자식에 포커스된 상태의 Enter/Space 가
+                        // 부모로 버블링돼 행 선택이 동시에 일어나지 않도록 가드한다.
+                        if ((e.target as HTMLElement).closest('button, a, input, select, textarea'))
+                          return;
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault();
                           track(TESTCASE_EVENTS.ITEM_CLICK, { case_id: item.id });

--- a/apps/web/src/view/project/cases/_components/more-actions-menu.tsx
+++ b/apps/web/src/view/project/cases/_components/more-actions-menu.tsx
@@ -43,7 +43,6 @@ export const MoreActionsMenu = ({ onAiGenerate, onImport, onExport }: MoreAction
       <button
         type="button"
         aria-label="더 보기"
-        aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
         className={cn(
@@ -56,7 +55,6 @@ export const MoreActionsMenu = ({ onAiGenerate, onImport, onExport }: MoreAction
 
       {open && (
         <div
-          role="menu"
           aria-label="더 보기"
           className="rounded-2 border-line-2 bg-bg-2 absolute top-full right-0 z-50 mt-1 min-w-[160px] border py-1 shadow-lg"
         >
@@ -64,7 +62,6 @@ export const MoreActionsMenu = ({ onAiGenerate, onImport, onExport }: MoreAction
             <button
               key={key}
               type="button"
-              role="menuitem"
               onClick={() => {
                 handlers[key]();
                 setOpen(false);


### PR DESCRIPTION
Closed: #97
Closed: #98
Closed: #99
Closed: #100

## 작업 유형
- [x] fix — 버그 수정

## 요약

a11y 관련 4건의 결함을 한 묶음으로 quick win 정리합니다. 모두 시맨틱 선언과 실제 구현이 어긋나거나 키보드 동선이 끊기는 사례라, 큰 리팩터 대신 시맨틱 정합을 맞추는 방향으로 손봤습니다.

## 배경 / 동기

스크린리더가 `role="menu"`·`role="menuitem"` 을 만나면 화살표·ESC·포커스 이동 같은 키보드 모델이 동작한다고 사용자에게 안내합니다. 그런데 본 코드는 그 동선을 구현하지 않은 채 role 만 선언해 두어, role 을 안 쓴 경우보다 오히려 접근성이 떨어지는 상태였습니다. 모달 포커스 트랩에서도 hidden input 까지 tabbable 후보로 잡혀 Shift+Tab 래핑이 깨지는 결함이 있었고, 케이스 행을 `role="button"` 으로 감싼 구조에서는 내부 액션 버튼의 키보드 이벤트가 부모로 버블링되어 의도와 다른 액션이 동시에 실행되고 있었습니다.

메뉴 패턴을 완전 구현하는 길도 있었지만 항목 수가 1~3개 수준이라 시맨틱 실익보다 도입 비용이 큰 상황이라, 본 PR 에서는 quick win 으로 시맨틱 정합을 맞추는 쪽으로 통일합니다.

- 관련 이슈: #97, #98, #99, #100

## 변경 사항

- 테스트 케이스 카드의 호버 메뉴에서 menu·menuitem 역할 선언을 제거하고 단순 버튼 그룹으로 정리했습니다. 트리거 버튼의 `aria-haspopup="menu"` 도 함께 빼서 정합을 맞췄습니다.
- 케이스 목록 상단의 더 보기 드롭다운도 동일하게 menu·menuitem 역할과 트리거의 `aria-haspopup="menu"` 를 제거했습니다.
- 테스트 케이스 작성 모달과 스위트 생성 모달의 포커스 트랩 selector 에서 hidden input 을 제외해 Shift+Tab 래핑이 끊기지 않도록 보강했습니다 (두 폼 동일 패턴).
- 케이스 행의 onClick / onKeyDown 핸들러에 `e.target !== e.currentTarget` 가드를 추가해 내부 액션 버튼의 클릭·Enter·Space 이벤트가 부모 행 선택으로 함께 실행되지 않게 했습니다.

## 스크린샷 / 데모

UI 변경 사항 없음 (시맨틱·이벤트 모델 정정).

| Before | After |
| --- | --- |
| 해당 없음 | 해당 없음 |

## 테스트 방법

1. 테스트 케이스 카드의 호버 메뉴에서 더 보기 버튼을 누르면 단순 버튼 그룹으로 동작하는지 확인합니다.
2. 케이스 목록 상단의 더 보기 드롭다운(AI 생성 / 가져오기 / 내보내기) 도 동일하게 단순 버튼 그룹으로 동작하는지 확인합니다.
3. 테스트 케이스 작성 모달과 스위트 생성 모달에서 첫 입력 필드에서 Shift+Tab 을 눌렀을 때 모달 끝 요소로 정상 래핑되는지 확인합니다.
4. 케이스 목록에서 행의 내부 액션 버튼(더 보기 / 복제)에 포커스를 둔 뒤 Enter / Space 를 누르면 행 선택이 함께 실행되지 않는지 확인합니다.

## 영향 범위 / 주의사항

- 시맨틱 역할 선언과 이벤트 가드만 손대고 화면·동작 흐름은 그대로 유지합니다.
- 메뉴 패턴(화살표 / ESC / 포커스 이동) 자체는 향후 항목 수가 늘어나거나 재방문이 필요할 때 별도 작업으로 검토합니다.

## 체크리스트

- [x] 기존 기능에 회귀가 없는지 확인 (시맨틱 정정 + 가드 추가뿐, 동작 변경 없음)
- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음
