### PR TITLE
fix(#134): 케이스 상태 드롭다운 portal 처리로 컨테이너 잘림 해결

### DIFF
--- a/apps/web/src/view/project/runs/_components/run-case-list-panel.tsx
+++ b/apps/web/src/view/project/runs/_components/run-case-list-panel.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { type TestCaseRunDetail } from '@/features/runs';
-import { useOutsideClick } from '@testea/lib';
 import { cn } from '@testea/util';
 import {
   CheckCircle2,
@@ -92,8 +92,34 @@ export const RunCaseListPanel = ({
   onInlineStatusChange,
 }: RunCaseListPanelProps) => {
   const [inlineDropdownId, setInlineDropdownId] = useState<string | null>(null);
-  const inlineDropdownRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(inlineDropdownRef, () => setInlineDropdownId(null), !!inlineDropdownId);
+  const [inlineDropdownAnchor, setInlineDropdownAnchor] = useState<{
+    top: number;
+    right: number;
+  } | null>(null);
+  const inlineDropdownTriggerRef = useRef<HTMLDivElement>(null);
+  const inlineDropdownContentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!inlineDropdownId) return;
+    const close = () => {
+      setInlineDropdownId(null);
+      setInlineDropdownAnchor(null);
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (inlineDropdownTriggerRef.current?.contains(target)) return;
+      if (inlineDropdownContentRef.current?.contains(target)) return;
+      close();
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [inlineDropdownId]);
   const hasSelection = bulkSelection.count > 0;
   const allSelected = filteredCases.length > 0 && bulkSelection.count === filteredCases.length;
 
@@ -441,63 +467,86 @@ export const RunCaseListPanel = ({
                             </p>
                           </div>
                         </button>
-                        {/* Inline status dropdown — right side */}
+                        {/* Inline status dropdown (right side) */}
                         <div
-                          className="relative flex-shrink-0"
-                          ref={inlineDropdownId === tc.id ? inlineDropdownRef : undefined}
+                          className="flex-shrink-0"
+                          ref={inlineDropdownId === tc.id ? inlineDropdownTriggerRef : undefined}
                         >
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              setInlineDropdownId((prev) => (prev === tc.id ? null : tc.id));
+                              if (inlineDropdownId === tc.id) {
+                                setInlineDropdownId(null);
+                                setInlineDropdownAnchor(null);
+                                return;
+                              }
+                              const rect = e.currentTarget.getBoundingClientRect();
+                              setInlineDropdownAnchor({
+                                top: rect.bottom + 4,
+                                right: window.innerWidth - rect.right,
+                              });
+                              setInlineDropdownId(tc.id);
                             }}
                             className={cn(
                               'flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors',
                               config.style,
                               STATUS_CONFIG[tc.status].bgStyle
                             )}
-                            title={`상태: ${config.label} — 클릭하여 변경`}
+                            title={`상태: ${config.label} (클릭하여 변경)`}
                           >
                             {config.icon}
                             <ChevronDown className="h-3 w-3" />
                           </button>
-                          {inlineDropdownId === tc.id && (
-                            <div className="bg-bg-2 border-line-2 absolute top-full right-0 z-30 mt-1 w-32 overflow-hidden rounded-lg border shadow-xl">
-                              {(['pass', 'fail', 'blocked', 'untested'] as const).map((s) => (
-                                <button
-                                  key={s}
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onInlineStatusChange(tc.id, s);
-                                    setInlineDropdownId(null);
-                                  }}
-                                  className={cn(
-                                    'flex w-full items-center gap-2 px-3 py-1.5 text-xs transition-colors',
-                                    tc.status === s
-                                      ? cn(
-                                          STATUS_CONFIG[s].bgStyle.split(' ')[0],
-                                          STATUS_CONFIG[s].style
-                                        )
-                                      : 'hover:bg-bg-3'
-                                  )}
-                                >
-                                  <span className={STATUS_CONFIG[s].style}>
-                                    {STATUS_CONFIG[s].icon}
-                                  </span>
-                                  <span
-                                    className={
-                                      tc.status === s ? STATUS_CONFIG[s].style : 'text-text-1'
-                                    }
+                          {inlineDropdownId === tc.id &&
+                            inlineDropdownAnchor &&
+                            typeof document !== 'undefined' &&
+                            createPortal(
+                              <div
+                                ref={inlineDropdownContentRef}
+                                style={{
+                                  position: 'fixed',
+                                  top: inlineDropdownAnchor.top,
+                                  right: inlineDropdownAnchor.right,
+                                }}
+                                className="bg-bg-2 border-line-2 z-50 w-32 overflow-hidden rounded-lg border shadow-xl"
+                              >
+                                {(['pass', 'fail', 'blocked', 'untested'] as const).map((s) => (
+                                  <button
+                                    key={s}
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      onInlineStatusChange(tc.id, s);
+                                      setInlineDropdownId(null);
+                                      setInlineDropdownAnchor(null);
+                                    }}
+                                    className={cn(
+                                      'flex w-full items-center gap-2 px-3 py-1.5 text-xs transition-colors',
+                                      tc.status === s
+                                        ? cn(
+                                            STATUS_CONFIG[s].bgStyle.split(' ')[0],
+                                            STATUS_CONFIG[s].style
+                                          )
+                                        : 'hover:bg-bg-3'
+                                    )}
                                   >
-                                    {STATUS_CONFIG[s].label}
-                                  </span>
-                                  <kbd className="text-text-4 ml-auto text-[10px]">
-                                    {STATUS_CONFIG[s].shortcut}
-                                  </kbd>
-                                </button>
-                              ))}
-                            </div>
-                          )}
+                                    <span className={STATUS_CONFIG[s].style}>
+                                      {STATUS_CONFIG[s].icon}
+                                    </span>
+                                    <span
+                                      className={
+                                        tc.status === s ? STATUS_CONFIG[s].style : 'text-text-1'
+                                      }
+                                    >
+                                      {STATUS_CONFIG[s].label}
+                                    </span>
+                                    <kbd className="text-text-4 ml-auto text-[10px]">
+                                      {STATUS_CONFIG[s].shortcut}
+                                    </kbd>
+                                  </button>
+                                ))}
+                              </div>,
+                              document.body
+                            )}
                         </div>
                         {isSelected && (
                           <ChevronRight className="text-text-3 h-4 w-4 flex-shrink-0" />


### PR DESCRIPTION
@
## 작업 유형

- [x] fix — 버그 수정

## 요약

테스트 런 상세 페이지의 케이스 리스트에서 우측 상태 토글 버튼을 누르면 펼쳐지는 인라인 드롭다운이 부모 컨테이너의 overflow 경계에 잘려서 일부만 보이거나, 리스트 하단 행에서는 거의 가려져 클릭이 불가능하던 문제를 해결합니다.

## 배경 / 동기

- 관련 이슈: #134
- 관련 FDD / 문서:

드롭다운이 자체 구현된 absolute 포지셔닝으로 부모 stacking context 안에 머물고 있었습니다. 케이스 행 자체의 overflow 잘림 + 리스트 스크롤 컨테이너의 세로 overflow 두 경계 모두에 종속되어, 메뉴가 행 아래쪽으로 펼쳐지면 시각적으로 잘리고 하단 행에서는 메뉴가 거의 보이지 않는 회귀가 있었습니다.

## 변경 사항

- 인라인 상태 드롭다운을 React Portal로 document.body 하위에 렌더링하여 부모 overflow 경계의 영향을 완전히 받지 않도록 변경
- 트리거 버튼을 누른 시점에 트리거의 화면상 좌표를 측정하고, 드롭다운은 fixed 포지셔닝으로 해당 좌표 바로 아래에 배치
- 외부 클릭 감지를 트리거 영역과 포털 콘텐츠 영역 두 곳을 함께 검사하도록 직접 핸들링 (기존 단일 ref 기반 유틸로는 포털 영역을 외부로 오인해 클릭 즉시 닫히던 문제 방지)
- 스크롤이나 창 리사이즈가 발생하면 드롭다운을 자동으로 닫아 앵커 좌표가 어긋난 채 떠 있는 시각 버그를 차단
- 더 이상 사용되지 않게 된 외부 클릭 훅 임포트를 제거하고, 포털 처리에 필요한 훅과 헬퍼를 추가

## 스크린샷 / 데모

| Before | After |
| ------ | ----- |
|        |       |

## 테스트 방법

1. 테스트 런 상세 페이지(`/projects/{slug}/runs/{runId}`) 접속
2. 좌측 케이스 리스트에서 임의의 케이스 행 우측 끝 상태 토글 버튼 클릭
3. 드롭다운 네 가지 옵션(Pass / Fail / Blocked / Untested)이 전부 보이는지 확인
4. 케이스 리스트를 아래로 스크롤한 뒤, 화면 하단 가까이 위치한 행에서도 같은 동작이 잘리지 않는지 확인
5. 드롭다운이 열린 상태에서 리스트를 스크롤하면 메뉴가 깔끔하게 닫히는지 확인
6. 다른 곳을 클릭하거나 ESC가 아닌 일반 영역 클릭으로도 드롭다운이 닫히는지 확인

## 영향 범위 / 주의사항

- [x] 위 항목 모두 해당 없음

테스트 런 상세 페이지 케이스 리스트 한 곳에만 국한된 변경입니다. 다른 화면이나 데이터 흐름에는 영향을 주지 않습니다.

## 체크리스트

- [x] 로컬에서 빌드 / 타입 체크 통과 확인
- [ ] 관련 화면을 브라우저에서 직접 동작 확인 (UI 변경 시)
- [ ] 골든 패스 외 엣지 케이스도 확인
- [ ] 기존 기능에 회귀가 없는지 확인
- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음
@