### PR TITLE
chore(#141): CLAUDE.md 작성 컨벤션 명문화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md (web-mvp-front)
+
+Claude Code 가 이 저장소에서 **코드를 작성**할 때 따르는 컨벤션이다.
+
+- 자동 PR 리뷰 기준: `AGENTS.md` (이 파일과 역할 분리)
+- 개인 출력 규약(언어, em dash, 이모지, 커밋 메시지 등): `~/.claude/CLAUDE.md`
+- 앱별 특화 컨벤션: `apps/web/CLAUDE.md`, `apps/back-office/CLAUDE.md`
+
+## 저장소 구조
+
+- pnpm workspace + Turborepo
+- `apps/web` (사용자 대상), `apps/back-office` (운영 백오피스, `admin.gettestea.com` 별도 배포)
+- `packages/db`, `packages/ui`, `packages/util`, `packages/lib`, `packages/fetch-kit`
+- 배포: prod `gettestea.com`, dev `dev.gettestea.com` (DB 는 Vercel env 분기로 prod 와 preview/dev 분리)
+- 제품명 Testea (테스티아). UI 한국어. 핵심 도메인: 프로젝트, 케이스, 스위트, 마일스톤, 테스트 런.
+
+## 패키지 경계
+
+새 코드를 패키지에 넣기 전: 사용처가 한 앱뿐이면 `apps/*/src/shared/` 에 둔다. 두 앱이 같이 쓰거나 외부 노출 가능성이 있을 때만 패키지로 승격.
+
+- `packages/db`: Drizzle 스키마·쿼리·마이그레이션. 신규 테이블은 **RLS deny anon 정책 동반 필수** (서버/service_role 경유만 허용).
+- `packages/ui`: 디자인 시스템 컴포넌트. workspace React 타입을 의존하면 `@types/react` 를 devDep 으로 박아야 한다 (안 그러면 소비 앱에서 타입 해석 깨짐).
+- `packages/util`: 순수 유틸. React/Next 의존 금지. barrel export 충돌 주의.
+- `packages/lib`: 도메인 로직.
+- `packages/fetch-kit`: 클라이언트/서버 fetch 래퍼.
+
+워크스페이스 패키지 추가/이동 후 타입이 안 잡히면 `tsbuildinfo` stale 의심 (해당 패키지에서 클린 빌드).
+
+## 인증·보안 기본 전제
+
+- 사용자 계정 없음. 프로젝트별 비밀번호(bcrypt 해시)로 진입. 봇 차단은 Cloudflare Turnstile (프로젝트 생성 Step 3 + 접근 폼).
+- 레이트 리밋: 현재 인메모리 Map (5회/15분 락아웃). 운영 스케일 시 Redis 로 교체 예정.
+- 새 API 라우트 (`apps/web/app/api/**`) 는 외부 입력·웹훅·LLM 응답을 신뢰하지 않는다. 입력 검증 + 권한 가드 필수. 프로젝트 접근 가드는 `requireProjectAccess` 패턴.
+- RLS 신규 테이블 deny-all 정책 누락은 보안 회귀. 마이그레이션 PR 에 정책 같이 들어가야 한다.
+
+## 환경 게이팅
+
+- 분석·추적은 운영에서만 동작해야 한다. GA/GTM 은 `NEXT_PUBLIC_GTM_ID` 미주입으로 dev/preview 차단, 추가 가드는 `VERCEL_ENV === 'production'`.
+- Sentry, Cloudflare 비콘은 dev 에서도 활성 (관측 목적).
+- 분석/추적/디버그/실험 코드를 새로 추가할 때 환경 가드 누락 여부 확인.
+
+## 작성 시 자주 밟는 함정
+
+- **Tailwind v4 + cva 오버라이드**: cva 는 `tw-merge` 를 하지 않으므로, 변형 클래스 인스턴스 오버라이드는 v4 후행 important (`px-3!`) 가 필요하다. 선행 `!class` 아님.
+- **Dialog Primitive `style` 전달**: `Overlay`/`Content` 에 `style` 을 넘기면 기본 레이아웃 클래스가 무효화된다. position/top/left/transform 등 기본값을 직접 명시.
+- **자체 absolute 드롭다운**: 행 `overflow-hidden` + 스크롤 컨테이너 두 경계에 잘린다. `createPortal` + `fixed` + 양쪽 ref outside-click 패턴 사용.
+- **클라 훅**: `useState`/`useEffect`/`useRouter` 등 사용 전 파일 최상단 `'use client'` 선언 확인.
+- **Tailwind v4 content scan**: 새 패키지 추가 시 `apps/*/src/app/globals.css` 의 `@source` 등록 누락하면 클래스가 안 적용된다.
+
+## 검증 명령
+
+PR 생성·추가 커밋 push 전, cherry-pick/rebase 직후 모두 아래를 로컬에서 통과시킨다.
+
+- `pnpm format:check` (= `prettier --check`)
+- 변경 패키지에 해당하는 `pnpm -w turbo run lint test`
+- UI 변경은 dev 서버에서 실제 동작 확인 후 보고. 타입체크·테스트 통과 ≠ 기능 정상.
+
+## 테스트
+
+- 단위/통합: Vitest (`apps/*/vitest.config.ts`).
+- E2E: Playwright, 위치 `apps/web/tests/`, 확장자 `*.spec.ts`. `src/` 아래에 두지 않는다.
+- POM·시나리오 규약은 `AGENTS.md` "테스트 아키텍처" 절 참조.
+
+## 문서·기획
+
+- 기능 명세(FDD)는 Notion. 신규 기능 구현 전 FDD 페이지 있는지 확인.
+- 회고/개발 노트는 `docs/노트에 적을거/` (디에듀 톤, 메타박스 금지, 1인칭 흐름).
+- 이슈 문서: `docs/issues/<feature>/` 하위 feature 단위 폴더.

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,45 @@
+# CLAUDE.md (apps/web)
+
+저장소 공통 컨벤션은 루트 `../../CLAUDE.md`. 이 파일은 web 앱 특화.
+
+## 구조
+
+App Router + FSD 혼합.
+
+- `app/`: Next.js 라우트. `app/api/**` 가 서버 라우트.
+- `src/app-shell`: 전역 레이아웃·프로바이더
+- `src/view`: 라우트 단위 view 컴포넌트
+- `src/widgets`: 합성 위젯
+- `src/features`: 기능 단위
+- `src/entities`: 도메인 엔티티
+- `src/shared`: 공용 컴포넌트·훅·유틸 (앱 내부 한정)
+- `src/access`: 프로젝트 비밀번호 진입 화면
+- `src/stories`: Storybook
+- `tests/`: Playwright (`pages/`·`fixtures/`·`scenarios/`)
+
+새 코드 위치를 정할 때: 라우트 한 곳에서만 쓰이면 `view`, 여러 라우트가 쓰면 `widgets`/`features`, 두 앱이 같이 쓸 가능성이 있으면 패키지 승격 검토.
+
+## 컴포넌트
+
+- `@testea/ui` 에 같은 컴포넌트가 있으면 그것을 쓴다. 새로 만들기 전 확인.
+- `DsInput`·`DsCheckbox` 등 cva 기반 컴포넌트의 인스턴스별 클래스 오버라이드는 후행 important (`px-3!`). 루트 CLAUDE.md "Tailwind v4 + cva" 참조.
+- 행 내부 absolute 드롭다운(케이스 상태 등)은 `createPortal` + `fixed` + 양쪽 ref outside-click. 그렇지 않으면 행 `overflow-hidden` 과 스크롤 컨테이너에 잘린다 (#134 회귀).
+
+## 서버 라우트 (`app/api/**`)
+
+- 외부 입력·웹훅·LLM 응답 신뢰 금지. zod 등으로 입력 검증.
+- 프로젝트 접근이 필요한 라우트는 `requireProjectAccess` 통과 후 핸들러 실행.
+- 분석·추적·디버그 코드는 `VERCEL_ENV` 가드 필수.
+- DB 쓰기는 Drizzle. `returning()` 없이 결과에 의존하지 말 것.
+
+## E2E (POM)
+
+- POM 작성·리뷰 기준은 루트 `../../AGENTS.md` "테스트 아키텍처" 절.
+- 스캐폴딩 요청이 **"필드만 정의"** 이면 필드 + 생성자 로케이터만. 메서드 작성 금지.
+- 작성자 라인이 있으면 보존. 명백한 복붙 오타만 정정하고 한 줄로 알린다.
+
+## 성능 측정
+
+- production 모드로 측정: `pnpm build` + `pnpm start`. dev 모드 LCP/CLS 신뢰 금지.
+- chrome-devtools MCP: navigate → trace → lighthouse → network 순서. Lighthouse MCP 는 Performance 카테고리 제외 한계.
+- Turnstile 가 자동화 차단하므로 측정 환경에서는 always-pass 테스트 키(`1x00000000000000000000AA`) 사용.


### PR DESCRIPTION
관련 이슈: #141

## 변경 사항

- 저장소 루트에 작성 에이전트용 컨벤션 문서를 신설했다. 모노레포 구조, 패키지 경계 기준, 인증·RLS 전제, 환경 게이팅, 자주 밟는 함정(Tailwind v4·cva 오버라이드, Dialog Primitive style 전달, 자체 absolute 드롭다운 portal 처리, 클라 훅 use client 누락, content scan 등록 누락), 로컬 검증 명령을 한곳에 모았다.
- web 앱 특화 컨벤션 문서를 신설했다. FSD 레이어 위치, 디자인 시스템 우선 사용, 서버 라우트 보안 가드, E2E POM 스캐폴딩 규약("필드만 정의"는 필드와 생성자 로케이터만 작성), 성능 측정 절차를 명시했다.
- 기존 자동 리뷰 지침 문서와 역할을 분리했다. 작성 컨벤션은 신규 문서, 리뷰 기준은 기존 문서를 그대로 유지한다. 백오피스는 기존 임포트 패턴을 유지한다.

## 배경

코드 작성 시 반복되던 함정과 규약이 개인 메모리에만 누적돼 있어 다른 머신·컨트리뷰터가 활용하지 못하던 문제를 해결한다. 글로벌 출력 규약과 자동 리뷰 기준은 건드리지 않고 저장소 특화 컨벤션 층만 분리한다. 후속 PR에서 자동화 층과 워크플로 층을 이어 붙인다.

## 검증

- 신규 문서 두 건 prettier 검사 통과
- 코드·설정 변경 없음, 문서 신설만
