### PR TITLE
fix(#143): apps/web ESLint 안전 위반 11건 해소 및 lint 스크립트 정상화

### DIFF
--- a/apps/web/app/dev/ui/dev-view.tsx
+++ b/apps/web/app/dev/ui/dev-view.tsx
@@ -1,5 +1,3 @@
-interface DevViewProps {}
-
 export const DevView = () => {
   return <div>DevView</div>;
 };

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 
 import Image from 'next/image';
+import Link from 'next/link';
 
 import * as Sentry from '@sentry/nextjs';
 
@@ -44,12 +45,12 @@ export default function Error({ error, reset }: ErrorProps) {
             >
               다시 시도
             </button>
-            <a
+            <Link
               href="/"
               className="rounded-4 border-line-2 text-body2 text-text-1 hover:bg-bg-3 inline-flex w-fit items-center justify-center border px-6 py-3 font-semibold transition-colors"
             >
               홈으로 돌아가기
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -93,6 +93,8 @@ export default function GlobalError({ error, reset }: GlobalErrorProps) {
               >
                 다시 시도
               </button>
+              {/* root error boundary 는 React tree 가 깨진 상태이므로 next/link 대신 anchor 로 강제 새로고침 이동 */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
               <a
                 href="/"
                 style={{

--- a/apps/web/app/projects/[slug]/cases/error.tsx
+++ b/apps/web/app/projects/[slug]/cases/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function CasesError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/app/projects/[slug]/error.tsx
+++ b/apps/web/app/projects/[slug]/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function ProjectError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/app/projects/[slug]/milestones/error.tsx
+++ b/apps/web/app/projects/[slug]/milestones/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function MilestonesError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/app/projects/[slug]/runs/error.tsx
+++ b/apps/web/app/projects/[slug]/runs/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function RunsError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/app/projects/[slug]/settings/error.tsx
+++ b/apps/web/app/projects/[slug]/settings/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function SettingsError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/app/projects/[slug]/suites/error.tsx
+++ b/apps/web/app/projects/[slug]/suites/error.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect } from 'react';
 
+import Link from 'next/link';
+
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 
@@ -32,12 +34,12 @@ export default function SuitesError({ error, reset }: ErrorProps) {
         >
           다시 시도
         </button>
-        <a
+        <Link
           href="/"
           className="rounded-4 border-line-2 text-text-1 hover:bg-bg-3 inline-flex items-center border px-5 py-2.5 text-sm font-semibold transition-colors"
         >
           홈으로 돌아가기
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -17,6 +17,8 @@ const eslintConfig = defineConfig([
     'out/**',
     'build/**',
     'next-env.d.ts',
+    // Storybook 빌드 산출물 (gitignored, 로컬 lint 잡음 제거)
+    'storybook-static/**',
   ]),
 
   // [FSD 공통 규칙] shared는 절대 상위 레이어(비즈니스 로직)를 알면 안 됨

--- a/apps/web/src/features/project-search/ui/project-search-form.tsx
+++ b/apps/web/src/features/project-search/ui/project-search-form.tsx
@@ -71,6 +71,12 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
   // Handle click outside to close autocomplete
   useOutsideClick(containerRef, () => setShowAutocomplete(false));
 
+  // Handle project selection from autocomplete
+  const handleSelectProject = (project: ProjectSearchResult) => {
+    setShowAutocomplete(false);
+    router.push(`/projects/${project.slug}/access`);
+  };
+
   // Handle keyboard navigation
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -116,12 +122,6 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
     },
     [showAutocomplete, suggestions, selectedIndex, inputValue, onSearch]
   );
-
-  // Handle project selection from autocomplete
-  const handleSelectProject = (project: ProjectSearchResult) => {
-    setShowAutocomplete(false);
-    router.push(`/projects/${project.slug}/access`);
-  };
 
   // Handle form submit
   const handleSubmit = (e: React.FormEvent) => {

--- a/apps/web/src/features/project-search/ui/project-search-form.tsx
+++ b/apps/web/src/features/project-search/ui/project-search-form.tsx
@@ -74,7 +74,7 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
   // Handle project selection from autocomplete
   const handleSelectProject = (project: ProjectSearchResult) => {
     setShowAutocomplete(false);
-    router.push(`/projects/${project.slug}/access`);
+    router.push(`/projects/${encodeURIComponent(project.slug)}/access`);
   };
 
   // Handle keyboard navigation

--- a/apps/web/src/features/reorder/ui/drag-handle.tsx
+++ b/apps/web/src/features/reorder/ui/drag-handle.tsx
@@ -6,7 +6,7 @@ import { cn } from '@testea/util';
 import { GripVertical } from 'lucide-react';
 
 interface DragHandleProps {
-  listeners?: Record<string, Function>;
+  listeners?: Record<string, (event: unknown) => void>;
   attributes?: Record<string, unknown>;
   className?: string;
 }


### PR DESCRIPTION
Closes #143

## 변경 사항
- Next 16 에서 제거된 next lint 호출을 ESLint 직접 호출로 교체해 lint 명령이 다시 정상 동작하도록 정리
- Storybook 빌드 산출물이 로컬 lint 결과를 가리던 문제를 ignore 규칙 추가로 해소
- 라우트별 에러 바운더리의 홈 이동 링크를 Next.js Link 컴포넌트로 교체해 클라이언트 라우팅 유지
- 루트 에러 바운더리는 React tree 가 깨진 상태에서 강제 새로고침이 의도이므로 앵커를 유지하고 사유 주석으로 명시
- 드래그 핸들에서 광범위했던 Function 타입을 이벤트 핸들러 시그니처로 좁힘
- 사용처보다 늦게 선언돼 접근 오류 경고를 내던 검색 폼 핸들러를 선언 위치 위로 이동
- 사용되지 않던 빈 인터페이스 정리

## 효과
- apps/web ESLint error 57 에서 46 으로 감소 (안전 룰 4종 완전 소거)
- prettier 동일 명령으로 변경 파일 전체 통과

## 남은 작업 (별도 PR)
- any 32건, useEffect 내 setState 10건, FSD 위반 2건, 메모이제이션 보존 2건 = 46건
- 메인 error 0 도달 후 CI 워크플로에 lint job 추가

## Test plan
- [ ] CI prettier 검사 통과 확인
- [ ] 각 라우트 에러 바운더리에서 "홈으로 돌아가기" 클릭 시 클라이언트 라우팅으로 홈 이동
- [ ] 루트 error 발생 상황에서는 앵커가 강제 새로고침으로 동작
- [ ] 프로젝트 검색 폼의 자동완성 + 키보드 내비게이션 정상