### PR TITLE
chore(#146): .tmp/ 임시 분석 산출물 디렉터리 ignore 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist
 .DS_Store
 *.pem
 *.log
+.tmp/
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
Closes #146

## 변경 사항
- 분석/스크립트 산출물을 모으는 .tmp/ 디렉터리를 git ignore 대상으로 추가

## Test plan
- [ ] git status 에서 .tmp/ untracked 표시가 더 이상 나오지 않는지 확인