### PR TITLE
fix(hydration): 드래그 정렬 영역 SSR/CSR 접근성 속성 불일치 해결

### DIFF
--- a/apps/web/src/shared/ui/step-box-editor/step-box-editor.tsx
+++ b/apps/web/src/shared/ui/step-box-editor/step-box-editor.tsx
@@ -122,7 +122,12 @@ export const StepBoxEditor = ({
 
   return (
     <div className={cn('flex w-full flex-col gap-2', className)}>
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <DndContext
+        id={idPrefix}
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
         <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
           {steps.map((step, i) => (
             <StepRow

--- a/apps/web/src/view/project/cases/_components/case-list-section.tsx
+++ b/apps/web/src/view/project/cases/_components/case-list-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useId, useState } from 'react';
 
 import { TestCaseCard, TestCaseCardType, duplicateTestCase } from '@/entities/test-case';
 import { testCaseQueryKeys } from '@/features/cases-list';
@@ -63,6 +63,9 @@ export const CaseListSection = ({
   const isCustomSort = sortOption === 'custom';
 
   // D&D
+  // DndContext 에 안정적인 id 를 주지 않으면 dnd-kit 가 내부 카운터로 접근성 id(DndDescribedBy-N)를
+  // 생성해 SSR/CSR 값이 어긋나며 hydration 불일치가 난다. useId 로 서버·클라이언트 동일 id 를 보장한다.
+  const dndId = useId();
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
     useSensor(KeyboardSensor)
@@ -161,6 +164,7 @@ export const CaseListSection = ({
           </div>
         ) : (
           <DndContext
+            id={dndId}
             sensors={sensors}
             collisionDetection={closestCenter}
             onDragEnd={handleDragEnd}


### PR DESCRIPTION
## 변경 사항

- 테스트 케이스 목록과 테스트 케이스 단계 편집기의 드래그 정렬 영역에서, 서버 렌더링과 클라이언트의 접근성 속성 값이 달라 콘솔에 hydration 불일치 경고가 뜨던 문제를 수정했습니다.
- 드래그 정렬 컨텍스트에 서버·클라이언트가 동일하게 쓰는 안정적인 식별자를 부여해, 접근성 설명 연결 값이 항상 일치하도록 했습니다.

## 참고

- 기능 변화는 없으며 콘솔 경고와 잠재적 접근성 연결 깨짐만 제거하는 수정입니다.

## 테스트 계획

- [ ] 테스트 케이스 목록 페이지 진입 시 콘솔에 hydration 경고가 더 이상 출력되지 않음
- [ ] 케이스 행 드래그 정렬 정상 동작
- [ ] 테스트 케이스 단계 편집기 드래그 정렬 정상 동작