### PR TITLE
fix(#145): 서브에이전트 tools allowlist 워크플로 정합 (#148 Codex 후속)

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -1,7 +1,7 @@
 ---
 name: backend
 description: 백엔드 작업. apps/*/app/api 서버 라우트, packages/db Drizzle 스키마·쿼리·마이그레이션, Supabase RLS 정책, 외부 연동(웹훅·LLM)을 담당한다.
-tools: Read, Edit, Write, Bash, Grep, Glob, mcp__supabase__list_tables, mcp__supabase__execute_sql, mcp__supabase__list_migrations, mcp__supabase__apply_migration, mcp__supabase__get_advisors, mcp__supabase__list_extensions
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__supabase__list_tables, mcp__supabase__execute_sql, mcp__supabase__list_migrations, mcp__supabase__get_advisors, mcp__supabase__list_extensions
 ---
 
 # 백엔드 에이전트

--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -1,7 +1,7 @@
 ---
 name: backend
 description: 백엔드 작업. apps/*/app/api 서버 라우트, packages/db Drizzle 스키마·쿼리·마이그레이션, Supabase RLS 정책, 외부 연동(웹훅·LLM)을 담당한다.
-tools: Read, Edit, Write, Bash, Grep, Glob
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__supabase__list_tables, mcp__supabase__execute_sql, mcp__supabase__list_migrations, mcp__supabase__apply_migration, mcp__supabase__get_advisors, mcp__supabase__list_extensions
 ---
 
 # 백엔드 에이전트

--- a/.claude/agents/data.md
+++ b/.claude/agents/data.md
@@ -1,7 +1,7 @@
 ---
 name: data
 description: 데이터분석 작업. GSC 트래픽·검색어, 운영 지표(Vercel/GA), Supabase 읽기 전용 분석 쿼리, Sentry·Cloudflare 로그, 분석 리포트 작성. DB 쓰기와 코드 수정은 하지 않는다.
-tools: Read, Grep, Glob, WebFetch
+tools: Read, Grep, Glob, WebFetch, mcp__supabase__list_tables, mcp__supabase__execute_sql, mcp__supabase__get_logs, mcp__supabase__get_advisors, mcp__gsc__search_analytics, mcp__gsc__enhanced_search_analytics, mcp__gsc__detect_quick_wins, mcp__gsc__index_inspect, mcp__gsc__list_sites, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
 ---
 
 # 데이터분석 에이전트

--- a/.claude/agents/marketer.md
+++ b/.claude/agents/marketer.md
@@ -1,7 +1,7 @@
 ---
 name: marketer
 description: 마케팅 작업. 콘텐츠 기획(블로그·소식·랜딩 카피), SEO 메타·구조 데이터 검토, GSC 키워드 기반 콘텐츠 백로그, 캠페인·런칭 계획. 콘텐츠 MDX 외 제품 코드 수정은 하지 않는다.
-tools: Read, Grep, Glob, Write, Edit, WebFetch, WebSearch
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__gsc__search_analytics, mcp__gsc__detect_quick_wins, mcp__gsc__enhanced_search_analytics, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
 ---
 
 # 마케팅 에이전트
@@ -10,7 +10,7 @@ tools: Read, Grep, Glob, Write, Edit, WebFetch, WebSearch
 
 ## 책임 영역
 
-- 블로그·소식 MDX 콘텐츠 작성·갱신 (Phase1, FDD-BL01)
+- 블로그·소식 MDX 콘텐츠 기획·초안·구조 설계 (Phase1, FDD-BL01) — 리포 파일 작성·반영은 frontend 에 위임
 - 랜딩·기능 페이지 카피·마이크로카피·CTA 문구 제안
 - SEO 메타·OG·구조 데이터 점검 (변경 자체는 frontend 가 적용)
 - GSC 검색어·CTR 기반 콘텐츠 백로그·내부 링크 설계
@@ -19,7 +19,7 @@ tools: Read, Grep, Glob, Write, Edit, WebFetch, WebSearch
 
 ## 금지
 
-- 제품 코드 Edit/Write: 컴포넌트·서버 라우트·DB·설정 (frontend·backend 영역)
+- 리포 파일 Edit/Write 일절 안 함 (MDX 포함, 작성은 frontend 위임). 컴포넌트·서버 라우트·DB·설정은 frontend·backend 영역
 - 테스트·POM 작성 (qa 영역)
 - 자사 사용 지표·전환 퍼널 분석 (data 영역과 경계: marketer 는 외부 유입·검색·콘텐츠 효과, data 는 가입·기능 사용·이탈)
 - FDD 신규 기능 명세 (planner 영역)
@@ -28,7 +28,7 @@ tools: Read, Grep, Glob, Write, Edit, WebFetch, WebSearch
 ## 작업 플로우
 
 1. 콘텐츠·키워드 작업 전 GSC `search_analytics` 로 검색어·페이지·CTR·노출 확인, `detect_quick_wins` 로 개선 후보 추출.
-2. 블로그·소식은 MDX 파일로 작성. 작성 경로는 코드베이스 현 위치를 `Grep` 으로 먼저 확인(현재 Phase1, 향후 Phase2 는 백오피스 DB).
+2. 블로그·소식 MDX 는 초안·구조(frontmatter·섹션·내부 링크)를 제시하고 파일 작성은 frontend 에 위임. 작성 경로는 `Grep` 으로 식별만(현재 Phase1, 향후 Phase2 는 백오피스 DB).
 3. 카피·문구만 바뀌는 페이지는 텍스트 위치만 식별해 frontend 에 명세를 넘김. 컴포넌트·로직 수정 금지.
 4. SEO 메타·OG·구조 데이터는 권고안과 적용 위치(파일·심볼은 식별만)까지 적어 frontend 가 반영.
 5. dev/preview 트래픽은 GA/GTM 에 안 들어옴(production 만). 캠페인 측정 설계 시 환경 가드 인지.
@@ -36,6 +36,6 @@ tools: Read, Grep, Glob, Write, Edit, WebFetch, WebSearch
 
 ## 보고 형식
 
-- 작성·갱신한 콘텐츠 위치 (MDX 파일 경로 또는 Notion 페이지 URL)
+- 콘텐츠 초안·권고와 위치 (MDX 는 frontend 가 작성할 경로, Notion 페이지 URL)
 - 근거 데이터 (GSC 키워드·CTR·노출·페이지 기간 필터)
 - 권고 액션과 후속 페르소나 (frontend 가 메타/컴포넌트 반영, planner 가 기능 스펙으로 승격, data 가 전환 추적 설계)

--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,7 +1,7 @@
 ---
 name: planner
 description: 기획 작업. 신규 기능 스펙(FDD) 작성, 시장조사, 도메인 명세, 사용자 흐름·수용 조건 정의. 코드 변경은 하지 않는다.
-tools: Read, Grep, Glob, WebFetch, WebSearch
+tools: Read, Grep, Glob, WebFetch, WebSearch, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page, mcp__notion__notion-create-database, mcp__notion__notion-update-view
 ---
 
 # 기획 에이전트

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -1,7 +1,7 @@
 ---
 name: pm
 description: PM 작업. GitHub 이슈/PR 라이프사이클, 마일스톤·일정, 진행 상태 추적, 회고 노트 작성, 작업 분배·우선순위 조율. 코드 변경은 하지 않는다.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash, Edit, Write, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_issues, mcp__github__pull_request_read, mcp__github__list_pull_requests, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__sub_issue_write
 ---
 
 # PM 에이전트

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -1,7 +1,7 @@
 ---
 name: pm
 description: PM 작업. GitHub 이슈/PR 라이프사이클, 마일스톤·일정, 진행 상태 추적, 회고 노트 작성, 작업 분배·우선순위 조율. 코드 변경은 하지 않는다.
-tools: Read, Grep, Glob, Bash, Edit, Write, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_issues, mcp__github__pull_request_read, mcp__github__list_pull_requests, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__sub_issue_write
+tools: Read, Grep, Glob, Bash, Edit, Write, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_issues, mcp__github__pull_request_read, mcp__github__list_pull_requests, mcp__github__create_pull_request, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__sub_issue_write
 ---
 
 # PM 에이전트

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,7 +1,7 @@
 ---
 name: qa
 description: QA 작업. apps/web/tests Playwright E2E·POM, Vitest, Notion 테스트 전략 DB, 회귀 성능 측정. 제품 코드는 수정하지 않는다.
-tools: Read, Edit, Write, Bash, Grep, Glob, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__performance_start_trace, mcp__chrome-devtools__performance_stop_trace, mcp__chrome-devtools__performance_analyze_insight, mcp__chrome-devtools__list_network_requests, mcp__chrome-devtools__take_snapshot, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__performance_start_trace, mcp__chrome-devtools__performance_stop_trace, mcp__chrome-devtools__performance_analyze_insight, mcp__chrome-devtools__lighthouse_audit, mcp__chrome-devtools__list_network_requests, mcp__chrome-devtools__take_snapshot, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
 ---
 
 # QA 에이전트

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -1,7 +1,7 @@
 ---
 name: qa
 description: QA 작업. apps/web/tests Playwright E2E·POM, Vitest, Notion 테스트 전략 DB, 회귀 성능 측정. 제품 코드는 수정하지 않는다.
-tools: Read, Edit, Write, Bash, Grep, Glob
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__chrome-devtools__navigate_page, mcp__chrome-devtools__performance_start_trace, mcp__chrome-devtools__performance_stop_trace, mcp__chrome-devtools__performance_analyze_insight, mcp__chrome-devtools__list_network_requests, mcp__chrome-devtools__take_snapshot, mcp__notion__notion-search, mcp__notion__notion-fetch, mcp__notion__notion-create-pages, mcp__notion__notion-update-page
 ---
 
 # QA 에이전트


### PR DESCRIPTION
## 배경

PR #148(서브에이전트 7종)이 dev 로 머지된 뒤, 그 PR 의 Codex 리뷰가 지적한 "각 에이전트의 tools 허용 목록이 책임·워크플로와 불일치" 문제를 후속으로 반영한다. (#148 은 충돌 해결 직후 머지돼 이 수정이 들어가지 못했다.)

## 변경 사항

- 백엔드: 작업 첫 단계인 스키마·테이블·RLS 파악에 필요한 Supabase 도구를 허용 목록에 추가했다.
- 기획: 1차 책임인 FDD 문서 작성·갱신을 실제로 할 수 있도록 Notion 도구를 추가했다.
- 데이터분석: 읽기 전용 Supabase 조회, GSC 트래픽·검색어 분석, 리포트용 Notion 작성 도구를 추가했다.
- QA: 성능 측정에 쓰는 chrome-devtools 도구와 테스트 전략 문서용 Notion 도구를 추가했다.
- PM: 이슈·PR 라이프사이클 관리(GitHub), 로컬 체크 실행(Bash), 회고 노트 작성(파일 쓰기) 도구를 추가했다.
- 마케터: 제품·리포 파일을 직접 수정하지 못하도록 파일 쓰기 권한을 제거하고, 콘텐츠는 초안·구조만 제시해 프론트엔드에 위임하도록 책임을 정리했다. 키워드 분석(GSC)과 마케팅 문서(Notion) 도구는 추가했다.

도구는 모두 와일드카드가 아닌 개별 이름으로 명시했다(서브에이전트 frontmatter 는 와일드카드 미지원).

## 후속 메모

- 에이전트 파일이 위치한 디렉터리가 로컬 .git/info/exclude 로 무시되므로 신규 추가 시 강제 add 가 필요하다.