### PR TITLE
fix: 프로젝트 검색 자동완성이 엔터 검색 후 다시 뜨는 문제 수정

### DIFF
--- a/apps/web/src/features/project-search/ui/project-search-form.tsx
+++ b/apps/web/src/features/project-search/ui/project-search-form.tsx
@@ -146,8 +146,10 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setInputValue(value);
-    // 제출한 검색어와 다른 새 입력일 때만 자동완성을 다시 연다.
-    if (value.trim().length >= 2 && lastSubmittedRef.current !== value.trim()) {
+    // 입력이 바뀌면 "방금 제출" 가드를 해제한다. 그래야 같은 키워드로 되돌아와도
+    // 자동완성이 다시 정상 동작한다(가드는 제출 직후 대기 중인 디바운스에만 적용).
+    lastSubmittedRef.current = null;
+    if (value.trim().length >= 2) {
       setShowAutocomplete(true);
     }
   };

--- a/apps/web/src/features/project-search/ui/project-search-form.tsx
+++ b/apps/web/src/features/project-search/ui/project-search-form.tsx
@@ -21,6 +21,8 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
   const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  // 방금 엔터·검색 버튼으로 제출한 검색어. 이 값에 대해선 자동완성을 다시 열지 않는다.
+  const lastSubmittedRef = useRef<string | null>(null);
 
   // Input state
   const [inputValue, setInputValue] = useState('');
@@ -42,6 +44,9 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
         setShowAutocomplete(false);
         return;
       }
+
+      // 제출 직후 남아 있던 디바운스가 드롭다운을 다시 여는 레이스를 막는다.
+      if (lastSubmittedRef.current === trimmed) return;
 
       setIsAutocompleteLoading(true);
       setShowAutocomplete(true);
@@ -85,6 +90,7 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
           e.preventDefault();
           const trimmed = inputValue.trim();
           if (trimmed.length >= 2) {
+            lastSubmittedRef.current = trimmed;
             setShowAutocomplete(false);
             onSearch(trimmed);
           }
@@ -109,6 +115,7 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
           } else {
             const trimmed = inputValue.trim();
             if (trimmed.length >= 2) {
+              lastSubmittedRef.current = trimmed;
               setShowAutocomplete(false);
               onSearch(trimmed);
             }
@@ -129,6 +136,7 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
     const trimmed = inputValue.trim();
     if (trimmed.length >= 2) {
       track(PROJECT_SEARCH_EVENTS.SUBMIT, { keyword: trimmed });
+      lastSubmittedRef.current = trimmed;
       setShowAutocomplete(false);
       onSearch(trimmed);
     }
@@ -136,8 +144,10 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
 
   // Handle input change
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-    if (e.target.value.trim().length >= 2) {
+    const value = e.target.value;
+    setInputValue(value);
+    // 제출한 검색어와 다른 새 입력일 때만 자동완성을 다시 연다.
+    if (value.trim().length >= 2 && lastSubmittedRef.current !== value.trim()) {
       setShowAutocomplete(true);
     }
   };


### PR DESCRIPTION
## 배경

프로젝트 검색에서 검색어를 입력하면 일치 프로젝트 자동완성 드롭다운이 뜬다. 그런데 엔터(또는 검색 버튼)로 검색을 제출해도 드롭다운이 닫히지 않고 다시 나타나는 경우가 있었다. 제출 시 드롭다운을 닫지만, 타이핑 중 걸려 있던 디바운스 검색이 그 직후 발동하면서 드롭다운을 다시 여는 레이스 때문이다.

## 변경 사항

- 방금 제출한 검색어를 기억해 두고, 그 검색어에 대해서는 자동완성을 다시 열지 않도록 막았다. 제출 직후 남아 있던 디바운스 검색이나 재렌더가 드롭다운을 되살리지 못한다.
- 사용자가 새 글자를 입력해 검색어가 달라지면 자동완성은 정상적으로 다시 동작한다.
- 검색 결과 목록 자체에는 영향이 없다.

## 테스트 계획

- [ ] 검색어 입력 후 엔터 → 자동완성 드롭다운이 다시 뜨지 않는지 확인
- [ ] 검색 버튼 클릭 시에도 동일하게 닫힌 채 유지되는지 확인
- [ ] 제출 후 다시 타이핑하면 자동완성이 정상 동작하는지 확인
- [ ] 자동완성 항목 선택(엔터/클릭) 시 해당 프로젝트 접근 페이지로 이동하는지 확인