### PR TITLE
perf(#160): 대시보드·테스트 실행 목록 서버 라운드트립 축소

### DIFF
--- a/apps/web/app/projects/[slug]/dashboard-content.tsx
+++ b/apps/web/app/projects/[slug]/dashboard-content.tsx
@@ -42,18 +42,9 @@ export async function DashboardData({ slug }: { slug: string }) {
         queryClient.prefetchQuery(dashboardQueryOptions.storageInfo(projectId)),
       ]);
 
-      // 마일스톤 prefetch: testRuns 결과에서 최적 runId 선택
-      const testRunsData = queryClient.getQueryData(testRunsQueryOptions(projectId).queryKey);
-      if (testRunsData?.success && testRunsData.data.length > 0) {
-        const runs = testRunsData.data;
-        const bestRun =
-          runs.find((r: { status: string }) => r.status === 'IN_PROGRESS') ||
-          runs.find((r: { status: string }) => r.status === 'NOT_STARTED') ||
-          runs[0];
-        if (bestRun) {
-          await queryClient.prefetchQuery(dashboardQueryOptions.milestones(projectId, bestRun.id));
-        }
-      }
+      // 마일스톤(wave 3)은 서버에서 prefetch하지 않는다. testRuns 결과(bestRun) 의존으로
+      // 직렬 wave가 하나 더 붙어 콘텐츠 출현을 지연시켰고, 간트 차트는 ssr:false 클라 전용이라
+      // 서버 prefetch 이득도 거의 없다. 클라이언트가 testRuns 캐시에서 기본 run을 골라 직접 조회한다.
     }
   } catch {
     // prefetch 실패 시 클라이언트에서 재시도

--- a/apps/web/src/features/runs/api/get-test-runs.ts
+++ b/apps/web/src/features/runs/api/get-test-runs.ts
@@ -4,7 +4,6 @@ import type { FetchedTestRun } from '@/entities/test-run';
 import { ActionResult } from '@/shared/types';
 import * as Sentry from '@sentry/nextjs';
 import {
-  TestRunStatus,
   getDatabase,
   milestones,
   testCaseRuns,
@@ -31,44 +30,41 @@ export async function getTestRunsByProjectId(
     }
 
     const runIds = runs.map((r) => r.id);
-
-    // 2. 테스트 실행-스위트 연결 조회 (논리 삭제 제외)
-    const runSuiteRows = await db
-      .select()
-      .from(testRunSuites)
-      .where(and(inArray(testRunSuites.test_run_id, runIds), isNull(testRunSuites.excluded_at)));
-
-    // 3. 스위트 이름 조회
-    const suiteIds = [
-      ...new Set(runSuiteRows.map((rs) => rs.test_suite_id).filter(Boolean)),
-    ] as string[];
-    const suiteRows =
-      suiteIds.length > 0
-        ? await db
-            .select({ id: testSuites.id, name: testSuites.name })
-            .from(testSuites)
-            .where(inArray(testSuites.id, suiteIds))
-        : [];
-    const suiteMap = new Map(suiteRows.map((s) => [s.id, s.name]));
-
-    // 4. 마일스톤 이름 조회 (ACTIVE만)
     const milestoneIds = [...new Set(runs.map((r) => r.milestone_id).filter(Boolean))] as string[];
-    const milestoneRows =
+
+    // 독립 쿼리 3개를 병렬 실행 (직렬 5쿼리 → runs 이후 2 라운드트립).
+    // 스위트 이름은 별도 조회 대신 JOIN으로 합쳐 라운드트립 1회 추가 제거.
+    const [runSuiteRows, milestoneRows, allCaseRuns] = await Promise.all([
+      // 실행-스위트 연결 + 스위트 이름 (논리 삭제 제외)
+      db
+        .select({
+          test_run_id: testRunSuites.test_run_id,
+          test_suite_id: testRunSuites.test_suite_id,
+          suiteName: testSuites.name,
+        })
+        .from(testRunSuites)
+        .innerJoin(testSuites, eq(testSuites.id, testRunSuites.test_suite_id))
+        .where(and(inArray(testRunSuites.test_run_id, runIds), isNull(testRunSuites.excluded_at))),
+
+      // 마일스톤 이름 (ACTIVE만)
       milestoneIds.length > 0
-        ? await db
+        ? db
             .select({ id: milestones.id, name: milestones.name })
             .from(milestones)
             .where(
               and(inArray(milestones.id, milestoneIds), eq(milestones.lifecycle_status, 'ACTIVE'))
             )
-        : [];
-    const milestoneMap = new Map(milestoneRows.map((m) => [m.id, m.name]));
+        : Promise.resolve([] as { id: string; name: string }[]),
 
-    // 5. 테스트 케이스 실행 결과 조회 (논리 삭제 제외)
-    const allCaseRuns = await db
-      .select()
-      .from(testCaseRuns)
-      .where(and(inArray(testCaseRuns.test_run_id, runIds), isNull(testCaseRuns.excluded_at)));
+      // 테스트 케이스 실행 결과 (논리 삭제 제외)
+      db
+        .select()
+        .from(testCaseRuns)
+        .where(and(inArray(testCaseRuns.test_run_id, runIds), isNull(testCaseRuns.excluded_at))),
+    ]);
+
+    const suiteMap = new Map(runSuiteRows.map((rs) => [rs.test_suite_id, rs.suiteName] as const));
+    const milestoneMap = new Map(milestoneRows.map((m) => [m.id, m.name]));
 
     // 실행별 케이스 실행 그룹핑
     const caseRunsByRunId = new Map<string, typeof allCaseRuns>();


### PR DESCRIPTION
## 변경 사항

- 테스트 실행 목록을 불러올 때 순차로 돌던 데이터 조회를 한 번에 병렬로 묶고, 스위트 이름을 함께 가져오도록 합쳐 서버 왕복 횟수를 줄였습니다. 대시보드와 테스트 실행 목록이 함께 빨라집니다.
- 대시보드가 마일스톤 데이터까지 서버에서 모두 기다린 뒤 화면을 내보내던 것을, 마일스톤은 첫 화면이 표시된 뒤 따로 불러오도록 바꿔 진입·전환이 훨씬 빨라졌습니다.

## 배경

페이지 전환이 느리다는 체감을 측정한 결과 대시보드 진입과 전환이 단독 병목이었고, 원인은 원격 DB로의 직렬 왕복이 누적된 것이었습니다. 쿼리 실행 자체나 데이터량 문제는 아니었습니다.

## 측정 (로컬 production + 원격 DB)

- 대시보드 진입(새로고침): 약 3~4초 → 약 0.8초
- 다른 메뉴에서 대시보드로 전환 시 내용 표시: 약 2.6~3초 → 약 0.4초

## 검증

- 타입체크·prettier 통과, 변경 파일 lint 클린
- 테스트 실행 목록과 대시보드(차트·마일스톤) 정상 표시 확인, 회귀 없음

Closes #160