### PR TITLE
fix: 테스트 케이스 툴바 더보기 버튼 크기 정렬

### DIFF
--- a/apps/web/src/view/project/cases/_components/more-actions-menu.tsx
+++ b/apps/web/src/view/project/cases/_components/more-actions-menu.tsx
@@ -47,7 +47,7 @@ export const MoreActionsMenu = ({
   };
 
   return (
-    <div ref={ref} className="relative">
+    <div ref={ref} className="relative self-stretch">
       <button
         type="button"
         aria-label="더 보기"
@@ -55,7 +55,7 @@ export const MoreActionsMenu = ({
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
         className={cn(
-          'typo-body2-heading rounded-2 border-line-2 bg-bg-2 text-text-2 hover:bg-bg-3 flex cursor-pointer items-center justify-center border px-2.5 py-2 transition-colors',
+          'typo-body2-heading rounded-2 border-line-2 bg-bg-2 text-text-2 hover:bg-bg-3 flex aspect-square h-full cursor-pointer items-center justify-center border transition-colors',
           open && 'bg-bg-3'
         )}
       >


### PR DESCRIPTION
@
## 변경 사항

- 테스트 케이스 페이지 툴바에서 정렬 셀렉트 오른쪽 더보기 버튼이 정렬 셀렉트·검색 입력보다 낮게 표시되던 문제를 수정했다.
- 더보기 버튼이 같은 줄의 다른 컨트롤 높이에 자동으로 맞춰지도록 하고, 가로·세로를 같게 만들어 정사각형 아이콘 버튼으로 정렬했다.

## 원인

- 정렬 셀렉트와 검색 입력은 텍스트를 담아 줄 높이만큼 커지는 반면, 더보기 버튼은 아이콘만 담고 동일한 세로 여백을 써서 그만큼 더 낮게 렌더링됐다.

## 확인

- prettier 검사 통과
- 더보기 버튼이 정렬 셀렉트와 같은 높이로 맞고 정사각형으로 보이는지 dev 화면에서 확인 필요
@