### PR TITLE
fix: 시나리오 관리 후속 버그 수정·중복 방지 인덱스 (#164 후속)

### DIFF
--- a/apps/web/src/entities/requirement-analysis/api/server-actions.ts
+++ b/apps/web/src/entities/requirement-analysis/api/server-actions.ts
@@ -99,30 +99,31 @@ export const saveRequirementAnalysis = async (input: {
       const analysisId = analysisRow.id;
 
       // 생성된 모든 시나리오를 1급 엔티티(test_scenarios)로 영속화한다.
-      // 입력 순서대로 insert → returning 도 같은 순서이므로 인덱스로 행 id 를 매핑한다.
+      // id 를 미리 생성해 명시적으로 넣음으로써, INSERT ... RETURNING 의 행 순서에 의존하지
+      // 않고 인덱스→id 매핑을 보장한다(PostgreSQL 은 RETURNING 순서를 보장하지 않음).
       const [maxScenarioSort] = await tx
         .select({ max: sql<number>`COALESCE(MAX(${testScenarios.sort_order}), 0)` })
         .from(testScenarios)
         .where(eq(testScenarios.project_id, projectId));
       let nextScenarioSort = (maxScenarioSort?.max ?? 0) + 1;
 
-      const insertedScenarios = await tx
-        .insert(testScenarios)
-        .values(
-          scenarios.map((scenario) => ({
-            project_id: projectId,
-            requirement_analysis_id: analysisId,
-            name: scenario.name,
-            description: scenario.description || null,
-            type: scenario.type,
-            related_requirement_ids: scenario.relatedRequirementIds ?? [],
-            status: 'DRAFT' as const,
-            sort_order: nextScenarioSort++,
-            created_at: now,
-            updated_at: now,
-          }))
-        )
-        .returning({ id: testScenarios.id });
+      const scenarioIds = scenarios.map(() => crypto.randomUUID());
+
+      await tx.insert(testScenarios).values(
+        scenarios.map((scenario, idx) => ({
+          id: scenarioIds[idx],
+          project_id: projectId,
+          requirement_analysis_id: analysisId,
+          name: scenario.name,
+          description: scenario.description || null,
+          type: scenario.type,
+          related_requirement_ids: scenario.relatedRequirementIds ?? [],
+          status: 'DRAFT' as const,
+          sort_order: nextScenarioSort++,
+          created_at: now,
+          updated_at: now,
+        }))
+      );
 
       // 선택한 시나리오는 하위호환을 위해 즉시 스위트로도 변환하고, 출처 시나리오를 잇는다.
       if (selectedIndices.length > 0) {
@@ -140,7 +141,7 @@ export const saveRequirementAnalysis = async (input: {
             name: scenarios[i].name,
             description: scenarios[i].description || null,
             requirement_analysis_id: analysisId,
-            test_scenario_id: insertedScenarios[i].id,
+            test_scenario_id: scenarioIds[i],
             sort_order: nextSuiteSort++,
             lifecycle_status: 'ACTIVE' as const,
             created_at: now,
@@ -151,7 +152,7 @@ export const saveRequirementAnalysis = async (input: {
 
       return {
         analysisId,
-        scenarioCount: insertedScenarios.length,
+        scenarioCount: scenarioIds.length,
         suiteCount: selectedIndices.length,
       };
     });
@@ -184,6 +185,10 @@ export const createFeature = async (input: {
     if (!(await requireProjectAccess(projectId))) {
       return { success: false, errors: { _ai: ['프로젝트 접근 권한이 없습니다.'] } };
     }
+
+    // saveRequirementAnalysis·스위트 생성 경로와 동일하게 용량 한도를 먼저 가드한다.
+    const storageError = await checkStorageLimit(projectId);
+    if (storageError) return storageError;
 
     const document: RequirementAnalysisDocument = {
       title,

--- a/apps/web/src/entities/test-scenario/api/server-actions.ts
+++ b/apps/web/src/entities/test-scenario/api/server-actions.ts
@@ -480,6 +480,23 @@ export const generateSuiteFromScenario = async (
 
     if (!scenario) return invalidInput('대상 시나리오를 찾을 수 없습니다.');
 
+    // 멱등: 이미 이 시나리오에서 파생된 ACTIVE 스위트가 있으면 중복 생성하지 않고 기존 것을 반환.
+    const [existingSuite] = await db
+      .select({ id: testSuites.id })
+      .from(testSuites)
+      .where(
+        and(eq(testSuites.test_scenario_id, scenario.id), eq(testSuites.lifecycle_status, 'ACTIVE'))
+      )
+      .limit(1);
+
+    if (existingSuite) {
+      return {
+        success: true,
+        data: { suiteId: existingSuite.id },
+        message: '이미 이 시나리오에서 생성한 스위트가 있습니다.',
+      };
+    }
+
     const suiteId = await db.transaction(async (tx) => {
       const [maxSort] = await tx
         .select({ max: sql<number>`COALESCE(MAX(${testSuites.sort_order}), 0)` })
@@ -503,7 +520,11 @@ export const generateSuiteFromScenario = async (
       return newSuiteId;
     });
 
-    return { success: true, data: { suiteId } };
+    return {
+      success: true,
+      data: { suiteId },
+      message: '시나리오에서 스위트를 생성했습니다.',
+    };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'generateSuiteFromScenario' } });
     return { success: false, errors: { _scenario: ['스위트 생성에 실패했습니다.'] } };

--- a/apps/web/src/entities/test-scenario/api/server-actions.ts
+++ b/apps/web/src/entities/test-scenario/api/server-actions.ts
@@ -480,45 +480,74 @@ export const generateSuiteFromScenario = async (
 
     if (!scenario) return invalidInput('대상 시나리오를 찾을 수 없습니다.');
 
-    // 멱등: 이미 이 시나리오에서 파생된 ACTIVE 스위트가 있으면 중복 생성하지 않고 기존 것을 반환.
-    const [existingSuite] = await db
-      .select({ id: testSuites.id })
-      .from(testSuites)
-      .where(
-        and(eq(testSuites.test_scenario_id, scenario.id), eq(testSuites.lifecycle_status, 'ACTIVE'))
-      )
-      .limit(1);
+    // 이 시나리오에서 파생된 ACTIVE 스위트 1건 조회(멱등 처리용).
+    const findExistingActiveSuiteId = async (): Promise<string | undefined> => {
+      const [row] = await db
+        .select({ id: testSuites.id })
+        .from(testSuites)
+        .where(
+          and(
+            eq(testSuites.test_scenario_id, scenario.id),
+            eq(testSuites.lifecycle_status, 'ACTIVE')
+          )
+        )
+        .limit(1);
+      return row?.id;
+    };
 
-    if (existingSuite) {
+    // 멱등: 이미 파생된 ACTIVE 스위트가 있으면 중복 생성하지 않고 기존 것을 반환.
+    const existingId = await findExistingActiveSuiteId();
+    if (existingId) {
       return {
         success: true,
-        data: { suiteId: existingSuite.id },
+        data: { suiteId: existingId },
         message: '이미 이 시나리오에서 생성한 스위트가 있습니다.',
       };
     }
 
-    const suiteId = await db.transaction(async (tx) => {
-      const [maxSort] = await tx
-        .select({ max: sql<number>`COALESCE(MAX(${testSuites.sort_order}), 0)` })
-        .from(testSuites)
-        .where(eq(testSuites.project_id, projectId));
+    let suiteId: string;
+    try {
+      suiteId = await db.transaction(async (tx) => {
+        const [maxSort] = await tx
+          .select({ max: sql<number>`COALESCE(MAX(${testSuites.sort_order}), 0)` })
+          .from(testSuites)
+          .where(eq(testSuites.project_id, projectId));
 
-      const newSuiteId = crypto.randomUUID();
-      const now = new Date();
-      await tx.insert(testSuites).values({
-        id: newSuiteId,
-        project_id: projectId,
-        name: scenario.name,
-        description: scenario.description || null,
-        requirement_analysis_id: scenario.requirement_analysis_id,
-        test_scenario_id: scenario.id,
-        sort_order: (maxSort?.max ?? 0) + 1,
-        lifecycle_status: 'ACTIVE' as const,
-        created_at: now,
-        updated_at: now,
+        const newSuiteId = crypto.randomUUID();
+        const now = new Date();
+        await tx.insert(testSuites).values({
+          id: newSuiteId,
+          project_id: projectId,
+          name: scenario.name,
+          description: scenario.description || null,
+          requirement_analysis_id: scenario.requirement_analysis_id,
+          test_scenario_id: scenario.id,
+          sort_order: (maxSort?.max ?? 0) + 1,
+          lifecycle_status: 'ACTIVE' as const,
+          created_at: now,
+          updated_at: now,
+        });
+        return newSuiteId;
       });
-      return newSuiteId;
-    });
+    } catch (error) {
+      // 동시 호출(TOCTOU)로 유니크 인덱스(test_suites_active_scenario_unq) 위반 시,
+      // 먼저 만들어진 스위트를 재조회해 멱등하게 반환한다.
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? (error as { code?: string }).code
+          : undefined;
+      if (code === '23505') {
+        const racedId = await findExistingActiveSuiteId();
+        if (racedId) {
+          return {
+            success: true,
+            data: { suiteId: racedId },
+            message: '이미 이 시나리오에서 생성한 스위트가 있습니다.',
+          };
+        }
+      }
+      throw error;
+    }
 
     return {
       success: true,

--- a/apps/web/src/entities/test-suite/api/server-actions.ts
+++ b/apps/web/src/entities/test-suite/api/server-actions.ts
@@ -537,6 +537,8 @@ export const getTestSuitesWithStats = async ({
         archivedAt: row.archived_at ?? null,
         lifecycleStatus: row.lifecycle_status,
         tag: { label: '기본', tone: 'neutral' as const },
+        requirementAnalysisId: row.requirement_analysis_id ?? null,
+        testScenarioId: row.test_scenario_id ?? null,
         includedPaths,
         caseCount,
         linkedMilestone,

--- a/apps/web/src/entities/test-suite/model/types.ts
+++ b/apps/web/src/entities/test-suite/model/types.ts
@@ -21,6 +21,11 @@ export type TestSuiteCard = TestSuite & {
     tone: SuiteTagTone;
   };
 
+  /** 출처: 요구사항(기능) 분석서에서 파생된 스위트면 분석서 ID, 아니면 null */
+  requirementAnalysisId?: string | null;
+  /** 출처: 특정 시나리오에서 파생된 스위트면 시나리오 ID, 아니면 null */
+  testScenarioId?: string | null;
+
   includedPaths: string[];
   caseCount: number;
 

--- a/apps/web/src/features/ai-generate-scenarios/lib/llm-client.ts
+++ b/apps/web/src/features/ai-generate-scenarios/lib/llm-client.ts
@@ -5,9 +5,13 @@ import { AiError } from '@/entities/ai-config/model/ai-error';
  * 시나리오 생성 라우트에서 재사용하기 위해 한곳으로 모은 것. (기존 두 라우트는 자체 사본 유지)
  */
 
+/** LLM 호출 전체 타임아웃. 응답이 지연·중단돼도 요청이 무한 대기하지 않도록 한다. */
+const LLM_TIMEOUT_MS = 120_000;
+
 async function callOpenAI(apiKey: string, model: string, systemPrompt: string, userPrompt: string) {
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
+    signal: AbortSignal.timeout(LLM_TIMEOUT_MS),
     headers: {
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
@@ -40,6 +44,7 @@ async function callAnthropic(
 ) {
   const res = await fetch('https://api.anthropic.com/v1/messages', {
     method: 'POST',
+    signal: AbortSignal.timeout(LLM_TIMEOUT_MS),
     headers: {
       'x-api-key': apiKey,
       'Content-Type': 'application/json',
@@ -69,6 +74,7 @@ async function callGemini(apiKey: string, model: string, systemPrompt: string, u
     `https://generativelanguage.googleapis.com/v1beta/models/${modelId}:generateContent?key=${apiKey}`,
     {
       method: 'POST',
+      signal: AbortSignal.timeout(LLM_TIMEOUT_MS),
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         system_instruction: { parts: [{ text: systemPrompt }] },

--- a/apps/web/src/features/command-palette/ui/command-palette.tsx
+++ b/apps/web/src/features/command-palette/ui/command-palette.tsx
@@ -5,8 +5,8 @@ import ReactDOM from 'react-dom';
 
 import { useParams, useRouter } from 'next/navigation';
 
-import { dashboardQueryKeys } from '@/features/dashboard';
-import { useQueryClient } from '@tanstack/react-query';
+import { projectIdQueryOptions } from '@/entities/project';
+import { useQuery } from '@tanstack/react-query';
 import { FileText, Flag, FolderOpen, Play } from 'lucide-react';
 
 import { useCommandNavigation } from '../hooks/use-command-navigation';
@@ -33,16 +33,15 @@ export const CommandPalette = () => {
   const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const params = useParams();
-  const queryClient = useQueryClient();
 
   const projectSlug = params.slug as string;
 
-  // dashboard 캐시에서 projectId 가져오기
-  const statsData = queryClient.getQueryData<{
-    success: boolean;
-    data: { project: { id: string } };
-  }>(dashboardQueryKeys.stats(projectSlug));
-  const projectId = statsData?.success ? statsData.data.project.id : undefined;
+  // 어느 프로젝트 페이지에서든 채워지는 projectId 캐시 사용(없으면 fetch). 대시보드 방문 여부와 무관.
+  const { data: projectIdData } = useQuery({
+    ...projectIdQueryOptions(projectSlug),
+    enabled: !!projectSlug,
+  });
+  const projectId = projectIdData?.success ? projectIdData.data.id : undefined;
 
   const searchResults = useCommandSearch(
     query.startsWith('>') ? '' : query,

--- a/apps/web/src/features/trash/api/trash-actions.ts
+++ b/apps/web/src/features/trash/api/trash-actions.ts
@@ -278,6 +278,40 @@ export const restoreItem = async (
         };
       }
       case 'suite': {
+        // 시나리오 파생 스위트는 한 시나리오당 ACTIVE 1건만 허용(유니크 인덱스).
+        // 삭제 후 같은 시나리오로 새 스위트를 만든 상태에서 옛 스위트를 복원하면 제약 위반이
+        // 나므로, 충돌이 있으면 23505 크래시 대신 명확한 안내로 막는다.
+        const [target] = await db
+          .select({ scenarioId: testSuites.test_scenario_id })
+          .from(testSuites)
+          .where(and(eq(testSuites.id, targetId), eq(testSuites.lifecycle_status, 'DELETED')))
+          .limit(1);
+        if (!target) {
+          return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
+        }
+        if (target.scenarioId) {
+          const [conflict] = await db
+            .select({ id: testSuites.id })
+            .from(testSuites)
+            .where(
+              and(
+                eq(testSuites.test_scenario_id, target.scenarioId),
+                eq(testSuites.lifecycle_status, 'ACTIVE')
+              )
+            )
+            .limit(1);
+          if (conflict) {
+            return {
+              success: false,
+              errors: {
+                _trash: [
+                  '같은 시나리오에서 생성된 활성 스위트가 이미 있어 복원할 수 없습니다. 기존 스위트를 삭제한 뒤 다시 시도해주세요.',
+                ],
+              },
+            };
+          }
+        }
+
         const [restored] = await db
           .update(testSuites)
           .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })

--- a/apps/web/src/view/project/cases/test-cases-view.tsx
+++ b/apps/web/src/view/project/cases/test-cases-view.tsx
@@ -54,6 +54,13 @@ export const TestCasesView = () => {
   const [selectedSuiteId, setSelectedSuiteId] = useState<string>('all');
   const [currentPage, setCurrentPage] = useState(1);
 
+  // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
+  const [hydrated, setHydrated] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   const slug = params.slug as string;
 
   // 검색어 debounce
@@ -162,8 +169,8 @@ export const TestCasesView = () => {
         ? '미분류'
         : suiteMap.get(selectedSuiteId) || '테스트 케이스';
 
-  // Loading
-  if (isLoadingProject || (isLoadingCases && !testCasesData)) {
+  // Loading (hydration 전에는 서버와 동일하게 스켈레톤 유지)
+  if (!hydrated || isLoadingProject || (isLoadingCases && !testCasesData)) {
     return <CasesLoadingSkeleton />;
   }
 

--- a/apps/web/src/view/project/scenarios/_components/scenario-row.tsx
+++ b/apps/web/src/view/project/scenarios/_components/scenario-row.tsx
@@ -74,10 +74,15 @@ export const ScenarioRow = ({
 
         <button
           type="button"
-          aria-label="시나리오에서 스위트 생성"
-          title="스위트 생성"
+          aria-label={
+            scenario.derivedSuiteCount > 0 ? '이미 스위트 생성됨' : '시나리오에서 스위트 생성'
+          }
+          title={scenario.derivedSuiteCount > 0 ? '이미 스위트 생성됨' : '스위트 생성'}
           onClick={() => onGenerateSuite(scenario)}
-          className="text-text-4 hover:text-text-1 hover:bg-bg-3 rounded-2 flex h-7 w-7 items-center justify-center transition-colors"
+          className={cn(
+            'hover:text-text-1 hover:bg-bg-3 rounded-2 flex h-7 w-7 items-center justify-center transition-colors',
+            scenario.derivedSuiteCount > 0 ? 'text-system-green' : 'text-text-4'
+          )}
         >
           <FolderPlus className="h-4 w-4" aria-hidden="true" />
         </button>

--- a/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
+++ b/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
@@ -199,7 +199,7 @@ export const ScenarioFeatureDetailView = () => {
     onMutate: (id) => setPendingId(id),
     onSuccess: (result) => {
       if (result.success) {
-        toast.success('시나리오에서 스위트를 생성했습니다.');
+        toast.success(result.message ?? '시나리오에서 스위트를 생성했습니다.');
         queryClient.invalidateQueries({ queryKey: ['scenarios'] });
         queryClient.invalidateQueries({ queryKey: ['testSuites'] });
       } else {

--- a/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
+++ b/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
@@ -73,7 +73,11 @@ export const ScenarioFeatureDetailView = () => {
     [isManual, featureId]
   );
 
-  const { data: scenariosData, isLoading: isLoadingScenarios } = useQuery({
+  const {
+    data: scenariosData,
+    isLoading: isLoadingScenarios,
+    isError: isScenariosError,
+  } = useQuery({
     ...scenariosQueryOptions(projectId!, filter),
     enabled: !!projectId,
   });
@@ -235,6 +239,11 @@ export const ScenarioFeatureDetailView = () => {
   }
 
   if (!projectIdData?.success) return <ProjectErrorFallback />;
+
+  // 시나리오 조회 실패를 "데이터 없음"으로 위장하지 않고 에러 폴백으로 표시.
+  if (isScenariosError || (scenariosData && !scenariosData.success)) {
+    return <ProjectErrorFallback />;
+  }
 
   return (
     <MainContainer className="mx-auto grid h-screen w-full max-w-[1200px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-4 overflow-hidden px-10 py-8">

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -36,7 +36,11 @@ export const ScenarioFeaturesView = () => {
   );
   const projectId = projectIdData?.success ? projectIdData.data.id : undefined;
 
-  const { data: featuresData, isLoading: isLoadingFeatures } = useQuery({
+  const {
+    data: featuresData,
+    isLoading: isLoadingFeatures,
+    isError: isFeaturesError,
+  } = useQuery({
     ...scenarioFeaturesQueryOptions(projectId!),
     enabled: !!projectId,
   });
@@ -69,6 +73,11 @@ export const ScenarioFeaturesView = () => {
   }
 
   if (!projectIdData?.success) return <ProjectErrorFallback />;
+
+  // 기능 목록 조회 실패를 "기능 없음"으로 위장하지 않고 에러 폴백으로 표시.
+  if (isFeaturesError || (featuresData && !featuresData.success)) {
+    return <ProjectErrorFallback />;
+  }
 
   return (
     <MainContainer className="mx-auto grid h-screen w-full max-w-[1200px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-4 overflow-hidden px-10 py-8">

--- a/apps/web/src/view/project/settings/_components/general-settings-section.tsx
+++ b/apps/web/src/view/project/settings/_components/general-settings-section.tsx
@@ -103,7 +103,7 @@ export const GeneralSettingsSection = ({
               <span className="typo-label-heading text-text-2">{label}</span>
             </div>
             <DsFormField.Root error={errors[key]} className="flex-1 !flex-row !items-center !gap-3">
-              <DsFormField.Control>
+              <DsFormField.Control asChild>
                 <DsInput {...register(key)} placeholder={placeholder} />
               </DsFormField.Control>
               <DsFormField.Message>{errors[key]?.message}</DsFormField.Message>

--- a/apps/web/src/view/project/settings/_components/security-section.tsx
+++ b/apps/web/src/view/project/settings/_components/security-section.tsx
@@ -102,7 +102,7 @@ export const SecuritySection = ({ projectId }: { projectId: string }) => {
               <DsFormField.Label className="typo-label-heading text-text-2">
                 현재 비밀번호
               </DsFormField.Label>
-              <DsFormField.Control>
+              <DsFormField.Control asChild>
                 <DsInput
                   {...register('currentPassword')}
                   type="password"
@@ -120,7 +120,7 @@ export const SecuritySection = ({ projectId }: { projectId: string }) => {
               <DsFormField.Label className="typo-label-heading text-text-2">
                 새 비밀번호
               </DsFormField.Label>
-              <DsFormField.Control>
+              <DsFormField.Control asChild>
                 <DsInput
                   {...register('newPassword')}
                   type="password"
@@ -135,7 +135,7 @@ export const SecuritySection = ({ projectId }: { projectId: string }) => {
               <DsFormField.Label className="typo-label-heading text-text-2">
                 새 비밀번호 확인
               </DsFormField.Label>
-              <DsFormField.Control>
+              <DsFormField.Control asChild>
                 <DsInput
                   {...register('confirmPassword')}
                   type="password"

--- a/apps/web/src/view/project/suites/test-suites-view.tsx
+++ b/apps/web/src/view/project/suites/test-suites-view.tsx
@@ -59,9 +59,11 @@ export const TestSuitesView = () => {
       );
     }
 
-    // 타입 필터링 (향후 tag 기반 필터링 확장 가능)
-    if (filterType !== '전체') {
-      result = result.filter((suite) => suite.tag.label === filterType);
+    // 출처 기반 필터링: 기능별 = 요구사항 분석서 파생, 시나리오 = 시나리오 파생
+    if (filterType === '기능별') {
+      result = result.filter((suite) => suite.requirementAnalysisId != null);
+    } else if (filterType === '시나리오') {
+      result = result.filter((suite) => suite.testScenarioId != null);
     }
 
     return result;

--- a/apps/web/src/widgets/project/ui/chart-legend.tsx
+++ b/apps/web/src/widgets/project/ui/chart-legend.tsx
@@ -28,11 +28,10 @@ export const ChartLegend = ({ data, total }: ChartLegendProps) => {
             />
             <div className="flex flex-col gap-0.5">
               <span className="typo-body2-heading text-text-1">
-                {String(percentage).padStart(2, '0')}% {item.label}
+                {percentage}% {item.label}
               </span>
               <span className="typo-label-normal text-text-3">
-                <span className="text-primary">{String(item.value).padStart(3, '0')}</span>
-                개의 케이스
+                <span className="text-primary">{item.value}</span>개의 케이스
               </span>
             </div>
           </div>

--- a/apps/web/src/widgets/project/ui/kpi-cards.tsx
+++ b/apps/web/src/widgets/project/ui/kpi-cards.tsx
@@ -76,7 +76,10 @@ const KPICard = ({
 };
 
 export const KPICards = React.memo(({ data, projectTotalCases }: KPICardsProps) => {
+  // 프로젝트 전체 케이스 수(헤더·Total Cases 카드 공통 기준). run 선택 여부와 무관.
   const displayTotal = projectTotalCases ?? data.totalCases;
+  const hasProjectCases = displayTotal > 0;
+  // 선택된 실행 기준 지표(Pass Rate·Critical·Untested 빈 상태 판단용).
   const total = data.totalCases;
   const hasData = total > 0;
 
@@ -105,11 +108,11 @@ export const KPICards = React.memo(({ data, projectTotalCases }: KPICardsProps) 
         {/* Total Cases */}
         <KPICard
           label="Total Cases"
-          value={data.totalCases}
+          value={displayTotal}
           icon={<FileText className="h-4 w-4" />}
           decorativeIcon={<FileText className="h-[135px] w-[135px]" strokeWidth={1} />}
-          variant={hasData ? 'default' : 'muted'}
-          isEmpty={!hasData}
+          variant={hasProjectCases ? 'default' : 'muted'}
+          isEmpty={!hasProjectCases}
           isHighlighted
         />
 

--- a/packages/db/drizzle/0011_redundant_shen.sql
+++ b/packages/db/drizzle/0011_redundant_shen.sql
@@ -1,0 +1,17 @@
+-- 기존 중복 정리: 한 시나리오에서 파생된 ACTIVE 스위트가 2건 이상이면(과거 중복 생성 버그 잔재)
+-- 가장 오래된 1건만 ACTIVE로 남기고 나머지는 보관(DELETED) 처리한다.
+-- 보관 처리이므로 휴지통에서 복구 가능하며, 아래 유니크 인덱스 생성이 기존 데이터로 실패하는 것을 방지한다.
+UPDATE "test_suites" AS t
+SET "lifecycle_status" = 'DELETED', "archived_at" = now(), "updated_at" = now()
+WHERE t."test_scenario_id" IS NOT NULL
+  AND t."lifecycle_status" = 'ACTIVE'
+  AND t."id" <> (
+    SELECT s."id"
+    FROM "test_suites" AS s
+    WHERE s."test_scenario_id" = t."test_scenario_id"
+      AND s."lifecycle_status" = 'ACTIVE'
+    ORDER BY s."created_at" ASC, s."id" ASC
+    LIMIT 1
+  );
+--> statement-breakpoint
+CREATE UNIQUE INDEX "test_suites_active_scenario_unq" ON "test_suites" USING btree ("test_scenario_id") WHERE "test_suites"."lifecycle_status" = 'ACTIVE' AND "test_suites"."test_scenario_id" IS NOT NULL;

--- a/packages/db/drizzle/meta/0011_snapshot.json
+++ b/packages/db/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,2744 @@
+{
+  "id": "9cf7aec2-ea19-4e5d-b1f0-4e35435c122b",
+  "prevId": "7675dd86-c476-4f4e-8546-c51b1cb33562",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_scenario_id": {
+          "name": "test_scenario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "test_suites_active_scenario_unq": {
+          "name": "test_suites_active_scenario_unq",
+          "columns": [
+            {
+              "expression": "test_scenario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"test_suites\".\"lifecycle_status\" = 'ACTIVE' AND \"test_suites\".\"test_scenario_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suites_test_scenario_id_test_scenarios_id_fk": {
+          "name": "test_suites_test_scenario_id_test_scenarios_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "test_scenarios",
+          "columnsFrom": [
+            "test_scenario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_key": {
+          "name": "case_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[10]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_test_suite_id_test_suites_id_fk": {
+          "name": "test_cases_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_cases_section_id_test_suite_sections_id_fk": {
+          "name": "test_cases_section_id_test_suite_sections_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suite_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_cases_project_id_name_unique": {
+          "name": "test_cases_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        },
+        "test_cases_project_id_display_id_unique": {
+          "name": "test_cases_project_id_display_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "display_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_STARTED'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_ai_summary": {
+          "name": "share_ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_milestone_id_milestones_id_fk": {
+          "name": "test_runs_milestone_id_milestones_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_runs_share_token_unique": {
+          "name": "test_runs_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_project_id_projects_id_fk": {
+          "name": "milestones_project_id_projects_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_runs": {
+      "name": "test_case_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'adhoc'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_source": {
+          "name": "result_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "automation_meta": {
+          "name": "automation_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_runs_test_run_id_test_runs_id_fk": {
+          "name": "test_case_runs_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_runs_test_case_id_test_cases_id_fk": {
+          "name": "test_case_runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_case_runs_result_source_check": {
+          "name": "test_case_runs_result_source_check",
+          "value": "\"test_case_runs\".\"result_source\" in ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_run_milestones": {
+      "name": "test_run_milestones",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_milestones_test_run_id_test_runs_id_fk": {
+          "name": "test_run_milestones_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_milestones_milestone_id_milestones_id_fk": {
+          "name": "test_run_milestones_milestone_id_milestones_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_milestones_test_run_id_milestone_id_pk": {
+          "name": "test_run_milestones_test_run_id_milestone_id_pk",
+          "columns": [
+            "test_run_id",
+            "milestone_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_run_suites": {
+      "name": "test_run_suites",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_suites_test_run_id_test_runs_id_fk": {
+          "name": "test_run_suites_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_suites_test_suite_id_test_suites_id_fk": {
+          "name": "test_run_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_suites_test_run_id_test_suite_id_pk": {
+          "name": "test_run_suites_test_run_id_test_suite_id_pk",
+          "columns": [
+            "test_run_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suite_test_cases": {
+      "name": "suite_test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suite_test_cases_suite_id_test_suites_id_fk": {
+          "name": "suite_test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suite_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "suite_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_cases": {
+      "name": "milestone_test_cases",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_cases_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_cases_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "milestone_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_cases_milestone_id_test_case_id_pk": {
+          "name": "milestone_test_cases_milestone_id_test_case_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_case_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_suites": {
+      "name": "milestone_test_suites",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_suites_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_suites_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_suites_test_suite_id_test_suites_id_fk": {
+          "name": "milestone_test_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_suites_milestone_id_test_suite_id_pk": {
+          "name": "milestone_test_suites_milestone_id_test_suite_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_preferences": {
+      "name": "project_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_preferences_project_id_projects_id_fk": {
+          "name": "project_preferences_project_id_projects_id_fk",
+          "tableFrom": "project_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_preferences_project_id_key_unique": {
+          "name": "project_preferences_project_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_project_id_projects_id_fk": {
+          "name": "audit_logs_project_id_projects_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_attachments": {
+      "name": "test_case_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_attachments_test_case_id_test_cases_id_fk": {
+          "name": "test_case_attachments_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_attachments_project_id_projects_id_fk": {
+          "name": "test_case_attachments_project_id_projects_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_templates": {
+      "name": "test_case_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_steps": {
+          "name": "test_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_templates_project_id_projects_id_fk": {
+          "name": "test_case_templates_project_id_projects_id_fk",
+          "tableFrom": "test_case_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_templates_project_id_name_unique": {
+          "name": "test_case_templates_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_versions": {
+      "name": "test_case_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_versions_test_case_id_test_cases_id_fk": {
+          "name": "test_case_versions_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_versions",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_versions_test_case_id_version_number_unique": {
+          "name": "test_case_versions_test_case_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_case_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suite_sections": {
+      "name": "test_suite_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suite_sections_suite_id_test_suites_id_fk": {
+          "name": "test_suite_sections_suite_id_test_suites_id_fk",
+          "tableFrom": "test_suite_sections",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_sections_suite_id_name_unique": {
+          "name": "test_suite_sections_suite_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suite_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklists_project_id_projects_id_fk": {
+          "name": "checklists_project_id_projects_id_fk",
+          "tableFrom": "checklists",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_checklist_id_checklists_id_fk": {
+          "name": "checklist_items_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_connections_project_id_projects_id_fk": {
+          "name": "github_connections_project_id_projects_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_project_id_unique": {
+          "name": "github_connections_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_external_links": {
+      "name": "test_case_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tc_ext_links_case": {
+          "name": "idx_tc_ext_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tc_ext_links_external": {
+          "name": "idx_tc_ext_links_external",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_case_external_links_test_case_id_test_cases_id_fk": {
+          "name": "test_case_external_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_external_links",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ai_configs": {
+      "name": "project_ai_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_ai_configs_project_id_projects_id_fk": {
+          "name": "project_ai_configs_project_id_projects_id_fk",
+          "tableFrom": "project_ai_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_ai_configs_project_id_unique": {
+          "name": "project_ai_configs_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generated_count": {
+          "name": "generated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_size_bytes": {
+          "name": "attached_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_page_count": {
+          "name": "attached_file_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_project_id_projects_id_fk": {
+          "name": "ai_usage_logs_project_id_projects_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_logs_attached_file_type_check": {
+          "name": "ai_usage_logs_attached_file_type_check",
+          "value": "\"ai_usage_logs\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_active_idx": {
+          "name": "announcements_active_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_category_idx": {
+          "name": "announcements_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reads": {
+      "name": "notification_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_reads_user_idx": {
+          "name": "notification_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_reads_announcement_idx": {
+          "name": "notification_reads_announcement_idx",
+          "columns": [
+            {
+              "expression": "announcement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reads_announcement_id_announcements_id_fk": {
+          "name": "notification_reads_announcement_id_announcements_id_fk",
+          "tableFrom": "notification_reads",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reads_user_announcement_unq": {
+          "name": "notification_reads_user_announcement_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "announcement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_tokens": {
+      "name": "project_automation_tokens",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_tokens_token_hash_unq": {
+          "name": "project_automation_tokens_token_hash_unq",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_tokens_project_id_projects_id_fk": {
+          "name": "project_automation_tokens_project_id_projects_id_fk",
+          "tableFrom": "project_automation_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_requirement_analyses": {
+      "name": "ai_requirement_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_input": {
+          "name": "source_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko'"
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_requirement_analyses_project_id_projects_id_fk": {
+          "name": "ai_requirement_analyses_project_id_projects_id_fk",
+          "tableFrom": "ai_requirement_analyses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_requirement_analyses_attached_file_type_check": {
+          "name": "ai_requirement_analyses_attached_file_type_check",
+          "value": "\"ai_requirement_analyses\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_scenarios": {
+      "name": "test_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "related_requirement_ids": {
+          "name": "related_requirement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_scenarios_project_id_projects_id_fk": {
+          "name": "test_scenarios_project_id_projects_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_scenarios_type_check": {
+          "name": "test_scenarios_type_check",
+          "value": "\"test_scenarios\".\"type\" in ('positive', 'negative', 'edge_case')"
+        },
+        "test_scenarios_status_check": {
+          "name": "test_scenarios_status_check",
+          "value": "\"test_scenarios\".\"status\" in ('DRAFT', 'REVIEW', 'CONFIRMED')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780150290899,
       "tag": "0010_first_marten_broadcloak",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1780165371948,
+      "tag": "0011_redundant_shen",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/test-suites.ts
+++ b/packages/db/src/schema/test-suites.ts
@@ -1,29 +1,42 @@
-import { integer, pgTable, text, timestamp, uuid, varchar } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { integer, pgTable, text, timestamp, uniqueIndex, uuid, varchar } from 'drizzle-orm/pg-core';
 
 import { aiRequirementAnalyses } from './ai-requirement-analyses';
 import { LifecycleStatus, projects } from './projects';
 import { testScenarios } from './test-scenarios';
 
-export const testSuites = pgTable('test_suites', {
-  id: uuid('id').primaryKey(),
-  project_id: uuid('project_id').references(() => projects.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  description: varchar('description'),
-  /** AI 요구사항 분석에서 시나리오로 생성된 스위트의 출처. 일반 스위트는 NULL. */
-  requirement_analysis_id: uuid('requirement_analysis_id').references(
-    () => aiRequirementAnalyses.id,
-    { onDelete: 'set null' }
-  ),
-  /** 이 스위트가 파생된 시나리오. 시나리오에서 만들지 않은 스위트는 NULL. */
-  test_scenario_id: uuid('test_scenario_id').references(() => testScenarios.id, {
-    onDelete: 'set null',
-  }),
-  sort_order: integer('sort_order'),
-  created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-  updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
-  archived_at: timestamp('archived_at', { withTimezone: true }),
-  lifecycle_status: varchar('lifecycle_status', { length: 20 })
-    .$type<LifecycleStatus>()
-    .default('ACTIVE')
-    .notNull(),
-});
+export const testSuites = pgTable(
+  'test_suites',
+  {
+    id: uuid('id').primaryKey(),
+    project_id: uuid('project_id').references(() => projects.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: varchar('description'),
+    /** AI 요구사항 분석에서 시나리오로 생성된 스위트의 출처. 일반 스위트는 NULL. */
+    requirement_analysis_id: uuid('requirement_analysis_id').references(
+      () => aiRequirementAnalyses.id,
+      { onDelete: 'set null' }
+    ),
+    /** 이 스위트가 파생된 시나리오. 시나리오에서 만들지 않은 스위트는 NULL. */
+    test_scenario_id: uuid('test_scenario_id').references(() => testScenarios.id, {
+      onDelete: 'set null',
+    }),
+    sort_order: integer('sort_order'),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+    archived_at: timestamp('archived_at', { withTimezone: true }),
+    lifecycle_status: varchar('lifecycle_status', { length: 20 })
+      .$type<LifecycleStatus>()
+      .default('ACTIVE')
+      .notNull(),
+  },
+  (t) => ({
+    /**
+     * 한 시나리오당 ACTIVE 스위트는 1건만. 시나리오→스위트 파생의 중복 생성을 DB 레벨에서 차단.
+     * 보관(DELETED) 스위트와 시나리오 출처가 없는(NULL) 스위트는 제약 대상에서 제외.
+     */
+    activeScenarioUnq: uniqueIndex('test_suites_active_scenario_unq')
+      .on(t.test_scenario_id)
+      .where(sql`${t.lifecycle_status} = 'ACTIVE' AND ${t.test_scenario_id} IS NOT NULL`),
+  })
+);


### PR DESCRIPTION
## 개요

요구사항 기반 시나리오 관리 기능(#164)이 dev에 머지된 뒤, 탐색적 테스트와 코드리뷰로 발견한 버그를 수정합니다. 기능 본체가 아니라 그 위의 수정·보강만 담은 PR입니다.

## 변경 사항

- 스위트 목록의 "기능별"·"시나리오" 필터가 항상 빈 결과를 보이던 문제를 고쳤습니다. 이제 스위트의 실제 출처를 기준으로 걸러집니다.
- 시나리오에서 스위트 생성 시 같은 스위트가 중복 생성되던 문제를 고쳤습니다. 한 시나리오당 하나만 만들어지고 안내·버튼 상태로 구분하며, 애플리케이션과 데이터베이스 양쪽에서 중복을 막고 동시 요청·휴지통 복원 충돌도 안전하게 처리합니다.
- 대시보드 상단의 전체 케이스 수와 카드 숫자가 다르게 보이던 문제를 프로젝트 전체 기준으로 일치시켰습니다.
- 테스트 현황 범례 숫자의 불필요한 0 채움 표기를 자연스러운 숫자로 정리했습니다.
- 프로젝트 설정의 일반 설정과 비밀번호 변경 폼에서 현재 값이 채워지지 않고 입력이 저장되지 않던 문제를 고쳤습니다. 비밀번호 입력칸이 일반 텍스트로 노출되던 것도 함께 바로잡았습니다.
- 커맨드 팔레트 검색이 대시보드를 거치지 않고 들어온 페이지에서 아무 결과도 찾지 못하던 문제를 고쳤습니다.
- 테스트 케이스 페이지를 직접 열 때 발생하던 서버·클라이언트 렌더 불일치를 제거했습니다.
- 요구사항 분석 저장 시 행 순서 의존을 제거하고, 기능 생성에 저장 용량 한도 가드를 추가하고, LLM 호출에 타임아웃을 추가하고, 시나리오·기능 목록 조회 실패 시 에러를 표시하도록 했습니다.

## 검증

- 각 수정을 로컬에서 브라우저로 직접 재현·확인했습니다.
- 변경 파일은 프로젝트 포매터·타입 체크를 통과합니다.
- 데이터베이스 마이그레이션은 개발 환경 실제 데이터에 트랜잭션으로 적용한 뒤 롤백해 정상 동작을 확인했습니다.

## 참고 / 배포 시 주의

- 데이터베이스 마이그레이션이 포함됩니다(중복 방지 인덱스). 배포 시 과거에 중복 생성된 활성 스위트가 있으면 가장 먼저 만든 하나만 남기고 나머지는 휴지통으로 옮겨집니다(복구 가능). 새 테이블이 아닌 기존 테이블의 인덱스라 접근 정책 변경은 없습니다.
- 기능(#164) 도입 시 기존 요구사항 분석서의 시나리오를 새 테이블로 옮기는 백필이 없어, 배포 전부터 분석서가 있던 사용자는 과거 시나리오가 비어 보일 수 있습니다. 이 PR 범위 밖이며, 기존 데이터 유무에 따라 별도 백필 마이그레이션이 필요할 수 있습니다.