### PR TITLE
fix: 시나리오·기능상세·요구사항 페이지 SSR 하이드레이션 미스매치 수정

### DIFF
--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
@@ -29,6 +29,13 @@ export const RequirementsView = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [searchQuery, setSearchQuery] = useState('');
 
+  // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
+  const [hydrated, setHydrated] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   const { data: projectIdData, isLoading: isLoadingProject } = useQuery(
     projectIdQueryOptions(slug)
   );
@@ -49,7 +56,7 @@ export const RequirementsView = () => {
     );
   }, [analysesData, searchQuery]);
 
-  if (isLoadingProject || isLoadingAnalyses) {
+  if (!hydrated || isLoadingProject || isLoadingAnalyses) {
     return (
       <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex flex-col gap-2">

--- a/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
+++ b/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
@@ -62,6 +62,13 @@ export const ScenarioFeatureDetailView = () => {
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+
+  // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
+  const [hydrated, setHydrated] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
 
   const { data: projectIdData, isLoading: isLoadingProject } = useQuery(
     projectIdQueryOptions(slug)
@@ -222,7 +229,7 @@ export const ScenarioFeatureDetailView = () => {
     [deleteMutation]
   );
 
-  if (isLoadingProject || isLoadingScenarios) {
+  if (!hydrated || isLoadingProject || isLoadingScenarios) {
     return (
       <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex flex-col gap-2">

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
@@ -31,6 +31,13 @@ export const ScenarioFeaturesView = () => {
   const { isOpen: isAiOpen, onOpen: onAiOpen, onClose: onAiClose } = useDisclosure();
   const [searchQuery, setSearchQuery] = useState('');
 
+  // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
+  const [hydrated, setHydrated] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
   const { data: projectIdData, isLoading: isLoadingProject } = useQuery(
     projectIdQueryOptions(slug)
   );
@@ -56,7 +63,7 @@ export const ScenarioFeaturesView = () => {
   const hrefFor = (f: ScenarioFeatureListItem) =>
     `/projects/${slug}/scenarios/${f.isManual ? 'manual' : f.id}`;
 
-  if (isLoadingProject || isLoadingFeatures) {
+  if (!hydrated || isLoadingProject || isLoadingFeatures) {
     return (
       <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex flex-col gap-2">


### PR DESCRIPTION
## 개요

시나리오 관리(목록), 기능 상세, 요구사항 생성 페이지를 새로고침하거나 링크로 직접 열 때 서버와 클라이언트 렌더가 어긋나 발생하던 하이드레이션 경고를 없앱니다.

## 현상

세 페이지는 로딩 동안 스켈레톤을, 데이터가 준비되면 실제 화면을 보여줍니다. 직접 진입 시 서버는 스켈레톤을, 클라이언트는 실제 화면을 먼저 그리면서 첫 렌더가 어긋나 콘솔에 하이드레이션 실패 경고가 떴습니다.

## 변경 사항

- 세 페이지가 클라이언트 마운트 전까지 서버와 동일하게 스켈레톤을 그리도록 맞춰, 첫 렌더 불일치를 제거했습니다. 마운트 이후 실제 화면으로 전환됩니다. (대시보드와 테스트 케이스 페이지에서 이미 쓰는 방식과 동일)

## 배경

테스트 케이스 페이지의 동일 증상은 앞선 PR(#165)에서 수정했고, 머지 후 다른 페이지를 점검하다 같은 패턴이 남아 있어 일관되게 처리합니다.

## 검증

- 세 페이지를 직접 로드해 콘솔 하이드레이션 경고가 사라진 것을 확인했습니다.
- 변경 파일은 포매터·타입 체크를 통과합니다. 정적 분기 외 동작 로직 변경은 없습니다.