### PR TITLE
feat(i18n): 국제화 2단계 - 가이드 영어 번역·로케일 OG·언어 스위처

### DIFF
--- a/apps/web/app/[locale]/docs/page.tsx
+++ b/apps/web/app/[locale]/docs/page.tsx
@@ -19,6 +19,7 @@ type DocTab =
   | 'milestones';
 
 interface DocsPageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{
     tab?: DocTab;
   }>;
@@ -33,12 +34,18 @@ const docFiles: Record<DocTab, string> = {
   milestones: 'milestones.md',
 };
 
-async function getMarkdownContent(filename: string): Promise<string> {
-  const filePath = join(process.cwd(), 'content', 'docs', filename);
+async function getMarkdownContent(filename: string, locale: string): Promise<string> {
+  // ko 는 content/docs/, 그 외 로케일은 content/docs/<locale>/. 번역본이 없으면 ko 로 폴백.
+  const localizedPath =
+    locale === 'ko'
+      ? join(process.cwd(), 'content', 'docs', filename)
+      : join(process.cwd(), 'content', 'docs', locale, filename);
   try {
-    const content = await readFile(filePath, 'utf-8');
-    return content;
+    return await readFile(localizedPath, 'utf-8');
   } catch {
+    if (locale !== 'ko') {
+      return getMarkdownContent(filename, 'ko');
+    }
     return '# 문서를 찾을 수 없습니다\n\n요청한 문서가 존재하지 않습니다.';
   }
 }
@@ -56,19 +63,20 @@ function extractHeadings(markdown: string): DocHeading[] {
   return headings;
 }
 
-async function getAllContents(): Promise<Record<DocTab, string>> {
+async function getAllContents(locale: string): Promise<Record<DocTab, string>> {
   const entries = await Promise.all(
     Object.entries(docFiles).map(async ([key, filename]) => {
-      const content = await getMarkdownContent(filename);
+      const content = await getMarkdownContent(filename, locale);
       return [key, content] as [DocTab, string];
     })
   );
   return Object.fromEntries(entries) as Record<DocTab, string>;
 }
 
-export default async function DocsPage({ searchParams }: DocsPageProps) {
+export default async function DocsPage({ params, searchParams }: DocsPageProps) {
+  const { locale } = await params;
   const { tab } = await searchParams;
-  const contents = await getAllContents();
+  const contents = await getAllContents(locale);
 
   const validTab = tab && tab in docFiles ? tab : 'getting-started';
 

--- a/apps/web/app/[locale]/legal/page.tsx
+++ b/apps/web/app/[locale]/legal/page.tsx
@@ -12,15 +12,27 @@ import { join } from 'path';
 type TabType = 'privacy' | 'terms';
 
 interface LegalPageProps {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<{
     tab?: TabType;
   }>;
 }
 
-async function getMarkdownContent(filename: string): Promise<string> {
-  const filePath = join(process.cwd(), 'content', 'legal', filename);
-  const content = await readFile(filePath, 'utf-8');
-  return content;
+async function getMarkdownContent(filename: string, locale: string): Promise<string> {
+  // ko 는 content/legal/, 그 외 로케일은 content/legal/<locale>/. 번역본이 없으면 ko 로 폴백.
+  // (법적 고지 영어판은 법무 검토 후 추가 예정 → 현재 en 은 ko 로 폴백)
+  const localizedPath =
+    locale === 'ko'
+      ? join(process.cwd(), 'content', 'legal', filename)
+      : join(process.cwd(), 'content', 'legal', locale, filename);
+  try {
+    return await readFile(localizedPath, 'utf-8');
+  } catch {
+    if (locale !== 'ko') {
+      return getMarkdownContent(filename, 'ko');
+    }
+    throw new Error(`legal content not found: ${filename}`);
+  }
 }
 
 function extractHeadings(markdown: string): LegalHeading[] {
@@ -36,12 +48,13 @@ function extractHeadings(markdown: string): LegalHeading[] {
   return headings;
 }
 
-export default async function LegalPage({ searchParams }: LegalPageProps) {
+export default async function LegalPage({ params, searchParams }: LegalPageProps) {
+  const { locale } = await params;
   const { tab } = await searchParams;
 
   const [privacyContent, termsContent] = await Promise.all([
-    getMarkdownContent('privacy.md'),
-    getMarkdownContent('terms.md'),
+    getMarkdownContent('privacy.md', locale),
+    getMarkdownContent('terms.md', locale),
   ]);
 
   const renderedContents: Record<TabType, ReactNode> = {

--- a/apps/web/app/[locale]/og-render.tsx
+++ b/apps/web/app/[locale]/og-render.tsx
@@ -1,0 +1,114 @@
+import { ImageResponse } from 'next/og';
+
+/**
+ * 마케팅 로케일 OG/Twitter 이미지 공유 렌더. opengraph-image.tsx·twitter-image.tsx 가
+ * 각자 정적 config(runtime/size/...)를 export 하고, 렌더만 이 함수로 위임한다.
+ * (라우트 파일은 config 를 re-export 할 수 없어 모듈로 분리)
+ */
+export const ogSize = {
+  width: 1200,
+  height: 630,
+};
+
+const COPY: Record<string, { tagline: string; description: string }> = {
+  ko: {
+    tagline: '테스트 케이스 작성, 단 5분이면 끝!',
+    description: '효율적인 테스트 케이스 관리와 협업을 위한 플랫폼',
+  },
+  en: {
+    tagline: 'Write test cases in just 5 minutes.',
+    description: 'A platform for efficient test case management and collaboration',
+  },
+};
+
+export function renderOgImage(locale: string): ImageResponse {
+  const copy = COPY[locale] ?? COPY.ko;
+
+  return new ImageResponse(
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#0a0a0a',
+        backgroundImage: 'linear-gradient(135deg, #0a0a0a 0%, #1a1a2e 100%)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundImage: `linear-gradient(to right, rgba(11, 181, 127, 0.05) 1px, transparent 1px),
+                              linear-gradient(to bottom, rgba(11, 181, 127, 0.05) 1px, transparent 1px)`,
+          backgroundSize: '60px 60px',
+        }}
+      />
+
+      <div
+        style={{
+          position: 'absolute',
+          top: -100,
+          right: -100,
+          width: 400,
+          height: 400,
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(11, 181, 127, 0.3) 0%, transparent 70%)',
+        }}
+      />
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 24,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
+          <div
+            style={{
+              width: 64,
+              height: 64,
+              borderRadius: 16,
+              backgroundColor: '#0BB57F',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <span style={{ fontSize: 36, color: '#fff', fontWeight: 700 }}>T</span>
+          </div>
+          <span style={{ fontSize: 72, fontWeight: 700, color: '#ffffff', letterSpacing: -2 }}>
+            Testea
+          </span>
+        </div>
+
+        <span style={{ fontSize: 32, color: '#0BB57F', fontWeight: 600 }}>{copy.tagline}</span>
+
+        <span style={{ fontSize: 24, color: '#a0a0a0', marginTop: 8 }}>{copy.description}</span>
+      </div>
+
+      <div
+        style={{
+          position: 'absolute',
+          bottom: 40,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+        }}
+      >
+        <span style={{ fontSize: 20, color: '#666' }}>gettestea.com</span>
+      </div>
+    </div>,
+    {
+      ...ogSize,
+    }
+  );
+}

--- a/apps/web/app/[locale]/opengraph-image.tsx
+++ b/apps/web/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,11 @@
+import { ogSize, renderOgImage } from './og-render';
+
+export const runtime = 'edge';
+export const alt = 'Testea - Test management platform';
+export const size = ogSize;
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return renderOgImage(locale);
+}

--- a/apps/web/app/[locale]/twitter-image.tsx
+++ b/apps/web/app/[locale]/twitter-image.tsx
@@ -1,0 +1,11 @@
+import { ogSize, renderOgImage } from './og-render';
+
+export const runtime = 'edge';
+export const alt = 'Testea - Test management platform';
+export const size = ogSize;
+export const contentType = 'image/png';
+
+export default async function Image({ params }: { params: Promise<{ locale: string }> }) {
+  const { locale } = await params;
+  return renderOgImage(locale);
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -88,14 +88,8 @@ export const metadata: Metadata = {
     type: 'website',
     locale: 'ko_KR',
     siteName: '테스티아(Testea)',
-    images: [
-      {
-        url: '/opengraph-image',
-        width: 1200,
-        height: 630,
-        alt: 'Testea - 테스트 관리 플랫폼',
-      },
-    ],
+    // images 는 명시하지 않는다. Next 의 파일 컨벤션(opengraph-image)이 라우트 세그먼트별로
+    // 자동 매핑돼, [locale] 마케팅은 로케일별 OG, 루트(제품/공유)는 기본 OG 를 쓴다.
   },
   twitter: {
     card: 'summary_large_image',
@@ -103,7 +97,7 @@ export const metadata: Metadata = {
     description:
       '요구사항 기반 AI 테스트 시나리오·케이스 생성, 실행, 결과 추적을 한 곳에서. 무료 QA 도구 테스티아.',
     creator: '@testea',
-    images: ['/opengraph-image'],
+    // images 미지정: twitter-image 파일 컨벤션이 라우트별로 자동 매핑된다.
   },
   robots: {
     index: allowIndexing,

--- a/apps/web/content/docs/en/dashboard.md
+++ b/apps/web/content/docs/en/dashboard.md
@@ -1,0 +1,195 @@
+# Dashboard
+
+This guide explains how to use the dashboard to grasp your project's test status at a glance and start working quickly.
+
+---
+
+## What is the Dashboard?
+
+The dashboard is the first screen you see when you access a project. It summarizes test progress, project information, recent activity, and more, and serves as a starting point for jumping quickly to the main features.
+
+### Key Roles
+
+- **Test status summary**: Check key metrics at a glance with KPI cards
+- **Visual analysis**: Understand test status distribution and milestone progress with charts
+- **Quick access**: Create or view test cases, suites, and runs directly
+- **Project management**: Check project information such as storage usage and recent activity
+
+---
+
+## KPI Cards
+
+Cards summarizing key metrics are shown at the top of the dashboard.
+
+| Card            | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| **Total Cases** | Total number of test cases registered in the project |
+| **Test Suites** | Number of test suites created                        |
+| **Pass Rate**   | Percentage of executed tests that passed             |
+| **Key Issues**  | Number of failed (Fail) + blocked (Blocked) cases    |
+| **Not Run**     | Number of test cases not yet run                     |
+
+### How Pass Rate Is Calculated
+
+```
+Pass Rate = Pass / (Pass + Fail + Blocked) × 100
+```
+
+- If no tests have been run, it is shown as `N/A`
+
+### Pass Rate Color Criteria
+
+| Pass Rate   | Color  | Meaning         |
+| ----------- | ------ | --------------- |
+| 80% or more | Green  | Good            |
+| 50-79%      | Orange | Needs attention |
+| Below 50%   | Red    | At risk         |
+| No data     | Gray   | Not run         |
+
+---
+
+## Project Information Card
+
+The middle of the dashboard has a card area showing project-related information.
+
+### Project Information
+
+- Displays the project name
+- Copies the project URL to the clipboard with the **Copy Link** button
+- Displays the project creation date
+
+### Storage Capacity
+
+- Displays current usage / maximum capacity
+- Visualizes usage with a progress bar
+
+| Usage       | Color  | Meaning        |
+| ----------- | ------ | -------------- |
+| Below 80%   | Green  | Plenty of room |
+| 80-94%      | Orange | Caution        |
+| 95% or more | Red    | Out of space   |
+
+### Recent Activity
+
+Shows activity recently performed in the project in chronological order.
+
+- Displays up to 7 items
+- Records activity such as test case creation, suite creation, and test run completion
+- Displays relative time (for example, "5 minutes ago", "1 hour ago")
+
+---
+
+## Test Status Chart
+
+Visualizes test run results with a pie chart.
+
+### Items Displayed
+
+| Status      | Color  | Description          |
+| ----------- | ------ | -------------------- |
+| **Passed**  | Green  | Test passed          |
+| **Failed**  | Red    | Test failed          |
+| **Blocked** | Orange | Cannot run (blocked) |
+| **Not Run** | Gray   | Not run              |
+
+### Chart Information
+
+- Displays the count and percentage for each status
+- **Completion rate**: Percentage of tests run
+  - `Completion rate = (Pass + Fail + Blocked) / Total × 100`
+- Displays a badge with the total number of tests
+
+### Selecting a Test Run
+
+From the dropdown at the top of the chart, you can select a specific test run to view only that run's results.
+
+- An In Progress run is selected first
+- The run name, case count, and completion rate are shown together
+
+> **Note**: If there are no test runs, a **"Start a Test Run"** button is shown instead of the chart.
+
+---
+
+## Milestone Gantt Chart
+
+Shows the schedule and progress of milestones and their suites on a timeline.
+
+### Chart Composition
+
+- **Milestone row**: A top-level item showing overall progress
+- **Suite row**: Shown indented under the milestone
+- **Progress bar**: The test completion percentage for each item
+
+### Navigating the Timeline
+
+- Displays 6 weeks at a time
+- Move between periods with the **Previous/Next** buttons
+- **Today marker**: A vertical line shown on the current date
+- Displays weekly gridlines
+
+### Test Run Filter
+
+- Selecting a specific test run from the dropdown displays milestone data based on that run
+- You can collapse or expand a milestone row to show/hide its suites
+
+---
+
+## Test Cases Section
+
+The bottom of the dashboard briefly shows recent test cases.
+
+### Displayed Information
+
+- Preview of up to 5 cases
+- Displays the case key, name, and creation date
+- Move to the full case list with the **"View All"** link
+- Create a new case with the **"Add"** button
+
+> **Note**: If there are no cases, a **"Create a Test Case"** button is shown.
+
+---
+
+## Test Suites Section
+
+The bottom of the dashboard briefly shows recent test suites.
+
+### Displayed Information
+
+- Preview of up to 5 suites
+- Displays the suite name, description, and number of included cases
+- Move to the full suite list with the **"View All"** link
+- Create a new suite with the **"Add"** button
+
+> **Note**: If there are no suites, a **"Create a Test Suite"** button is shown.
+
+---
+
+## Onboarding Tour
+
+If you are using the dashboard for the first time, you can start a guided tour by clicking the **"Onboarding"** button. The tour walks through each area of the dashboard in order.
+
+---
+
+## Quick Action Guide
+
+These are the main actions you can perform directly from the dashboard.
+
+| Action                | How                                                     |
+| --------------------- | ------------------------------------------------------- |
+| Create a test case    | Click the **"Add"** button in the cases section         |
+| Create a test suite   | Click the **"Add"** button in the suites section        |
+| Start a test run      | Click **"Start a Test Run"** in the test status area    |
+| Share the project URL | Click the **Copy Link** icon in the project information |
+| View all cases        | Click **"View All"** in the cases section               |
+| View all suites       | Click **"View All"** in the suites section              |
+
+---
+
+## Next Steps
+
+Once you have checked your project status on the dashboard, refer to the following guides.
+
+- [Test Case Management](/docs?tab=test-cases)
+- [Test Suite Management](/docs?tab=test-suites)
+- [Test Runs](/docs?tab=test-runs)
+- [Milestone Management](/docs?tab=milestones)

--- a/apps/web/content/docs/en/getting-started.md
+++ b/apps/web/content/docs/en/getting-started.md
@@ -1,0 +1,85 @@
+# Getting Started
+
+Welcome to Testea. This guide is for those using the service for the first time.
+
+---
+
+## What is Testea?
+
+Testea is a test management platform that lets you efficiently manage test cases and track execution results.
+
+### Key Features
+
+- **Dashboard**: Grasp your test status at a glance
+- **Test Cases**: Author test cases and manage their status
+- **Test Suites**: Group test cases together
+- **Test Runs**: Run tests and record results
+- **Milestones**: Manage schedule-based test plans
+- **CSV Export**: Export test cases to a CSV file
+
+---
+
+## Creating a Project
+
+### Step 1: Visit the Homepage
+
+On the service homepage, click the **"Start for Free"** button.
+
+### Step 2: Enter Project Information
+
+| Field        | Required | Description                                           |
+| ------------ | -------- | ----------------------------------------------------- |
+| Project name | ✓        | 1-50 characters, the name that identifies the project |
+| Identifier   | ✓        | 8-16 characters, the project access password          |
+| Description  |          | A brief description of the project                    |
+| Owner name   |          | Name of the project administrator                     |
+
+### Step 3: Project Creation Complete
+
+Click the create button to create the project and move to the dashboard.
+
+> **Important**: The identifier is stored hashed, so it cannot be recovered if lost. Keep it in a safe place.
+
+---
+
+## Accessing a Project
+
+### Entering the Identifier
+
+1. Go to the project URL. (`/projects/[project-name]`)
+2. The identifier entry screen appears.
+3. Enter the identifier you set when creating the project.
+4. Click the **"Access"** button.
+
+### Access Token
+
+- On successful authentication, an access token valid for 24 hours is issued.
+- When the token expires, you must enter the identifier again.
+- If you clear your browser cookies, re-authentication is required.
+
+### Access Restrictions
+
+- If you enter the identifier incorrectly 5 times in a row, access is blocked for 15 minutes.
+- After the block is lifted, you can try again.
+
+---
+
+## Provided Specifications
+
+The following specifications are provided per project.
+
+| Item             | Quota |
+| ---------------- | ----- |
+| Storage capacity | 20MB  |
+
+---
+
+## Next Steps
+
+Once you have created a project, refer to the following guides.
+
+- [Dashboard](/docs?tab=dashboard)
+- [Test Case Management](/docs?tab=test-cases)
+- [Test Suite Management](/docs?tab=test-suites)
+- [Test Runs](/docs?tab=test-runs)
+- [Milestone Management](/docs?tab=milestones)

--- a/apps/web/content/docs/en/milestones.md
+++ b/apps/web/content/docs/en/milestones.md
@@ -1,0 +1,124 @@
+# Milestone Management
+
+This guide explains how to plan and manage tests on a schedule basis.
+
+---
+
+## What is a Milestone?
+
+A milestone is a unit that defines the test goals to be achieved during a specific period. You can build test plans aligned with sprints, releases, or specific events.
+
+### Usage Examples
+
+- **Sprint**: Sprint 1, Sprint 2, Sprint 3
+- **Release**: v1.0 Release, v2.0 Release
+- **Event**: QA Sign-off, UAT, Production Deploy
+
+---
+
+## Milestone List
+
+Click the **"Milestones"** menu in the project sidebar to view the full list of milestones.
+
+### List Information
+
+| Item     | Description                   |
+| -------- | ----------------------------- |
+| Name     | Milestone name                |
+| Period   | Start date - end date         |
+| Status   | Planned, In Progress, Done    |
+| Progress | Percentage of completed tests |
+
+---
+
+## Creating a Milestone
+
+### Quick Creation
+
+1. Click **"Create Milestone"** in the **"Quick Start"** section of the dashboard
+2. Or click the **"+ New Milestone"** button in the milestone list
+
+### Input Fields
+
+| Field       | Required | Description                                     |
+| ----------- | -------- | ----------------------------------------------- |
+| Name        | ✓        | 1-50 characters, the milestone name             |
+| Description |          | Up to 500 characters, the milestone description |
+| Start date  |          | Milestone start date                            |
+| End date    |          | Milestone end date                              |
+
+---
+
+## Milestone Status
+
+| Status          | Description              |
+| --------------- | ------------------------ |
+| **Planned**     | Planned, not yet started |
+| **In Progress** | In progress              |
+| **Done**        | Complete                 |
+
+---
+
+## Milestone Detail
+
+Click a milestone to go to its detail screen.
+
+### Detail Screen Composition
+
+- **Header**: Milestone name, period, status
+- **Description**: A description of the milestone
+- **Progress**: Visualized with a progress bar
+- **Test suites**: The list of suites linked to the milestone
+- **Test cases**: The list of cases included in the milestone
+
+---
+
+## Adding Suites/Cases to a Milestone
+
+You can add test suites and individual cases to a milestone.
+
+### Adding a Suite
+
+1. Click the **"Add Suite"** button on the milestone detail screen
+2. Select the suite to add
+3. All cases included in the selected suite are linked to the milestone
+
+### Adding a Case
+
+1. Click the **"Add Case"** button on the milestone detail screen
+2. Select the cases to add individually
+
+> **Note**: When you add a suite, it is managed as a suite unit, and you can check progress per suite under the milestone in the Gantt chart on the [Dashboard](/docs?tab=dashboard).
+
+---
+
+## Creating a Test Run from a Milestone
+
+When you click the **"Create Test Run"** button on the milestone detail screen:
+
+1. A new test run is created
+2. The test cases included in the milestone are selected automatically
+3. You are taken to the test run screen
+
+---
+
+## Editing a Milestone
+
+1. Click the milestone you want to edit in the milestone list
+2. Edit the name, description, and period on the detail screen
+3. Click the **"Save"** button
+
+---
+
+## Deleting a Milestone
+
+1. Click the **"Delete"** button on the milestone detail screen
+2. Confirm the deletion in the confirmation dialog
+
+> **Note**: Deleting a milestone does not delete the linked test cases and suites.
+
+---
+
+## Usage Limit
+
+During the beta period, you can create up to **10** milestones per project.

--- a/apps/web/content/docs/en/test-cases.md
+++ b/apps/web/content/docs/en/test-cases.md
@@ -1,0 +1,130 @@
+# Test Case Management
+
+This guide explains how to author and manage test cases.
+
+---
+
+## What is a Test Case?
+
+A test case is a unit of testing for verifying a specific feature or scenario. Each test case includes preconditions, test steps, and expected results.
+
+---
+
+## Test Case List
+
+Click the **"Test Cases"** menu in the project sidebar to view the full list of test cases.
+
+### List Information
+
+| Item     | Description                                                        |
+| -------- | ------------------------------------------------------------------ |
+| Case key | An automatically generated unique identifier (for example, TC-001) |
+| Name     | Test case name                                                     |
+| Status   | Untested, Pass, Fail, Blocked                                      |
+| Tags     | Tags for classification                                            |
+| Modified | Date and time of last modification                                 |
+
+### Filtering and Search
+
+- **Search**: Search by case name
+- **Status filter**: Show only cases with a specific status
+- **Tag filter**: Show only cases with a specific tag
+- **Suite filter**: Show only cases included in a specific suite
+  - **"Unassigned"**: Show only cases not assigned to a suite
+
+### Sort Options
+
+| Option            | Description                              |
+| ----------------- | ---------------------------------------- |
+| Recently modified | Show recently modified cases first       |
+| Oldest modified   | Show least recently modified cases first |
+| Recently created  | Show recently created cases first        |
+| Oldest created    | Show least recently created cases first  |
+| Title ascending   | Sort in alphabetical (ABC) order         |
+| Title descending  | Sort in reverse order                    |
+
+### Pagination
+
+- Shows 30 items by default
+- Click the **"Load More"** button to load additional cases
+
+---
+
+## Creating a Test Case
+
+### Quick Creation
+
+1. Click **"Create Test Case"** in the **"Quick Start"** section of the dashboard
+2. Or click the **"+ New Case"** button in the test case list
+
+### Input Fields
+
+| Field           | Required | Description                                              |
+| --------------- | -------- | -------------------------------------------------------- |
+| Name            | ✓        | 1-200 characters, the test case title                    |
+| Test type       |          | Type of test (functional, regression, integration, etc.) |
+| Tags            |          | Up to 10, tags for classification                        |
+| Preconditions   |          | Conditions required before running the test              |
+| Test steps      |          | The procedure for performing the test                    |
+| Expected result |          | The expected outcome when the test succeeds              |
+
+> **Note**: The case key (for example, TC-001) is assigned automatically on creation.
+
+---
+
+## Test Case Status
+
+| Status       | Description          | Color  |
+| ------------ | -------------------- | ------ |
+| **Untested** | Not yet run          | Gray   |
+| **Pass**     | Test passed          | Green  |
+| **Fail**     | Test failed          | Red    |
+| **Blocked**  | Cannot run (blocked) | Orange |
+
+> **Note**: A test case's status is updated automatically when you enter a result in a [Test Run](/docs?tab=test-runs).
+
+---
+
+## Editing a Test Case
+
+1. Click the case you want to edit in the case list
+2. Edit the content in the side panel or detail screen
+3. Click the **"Save"** button
+
+---
+
+## Deleting a Test Case
+
+1. Click the **"Delete"** button on the case detail screen
+2. Confirm the deletion in the confirmation dialog
+
+> **Caution**: A deleted test case cannot be recovered. Be sure to confirm before deleting.
+
+---
+
+## CSV Export
+
+You can export the test case list to a CSV file.
+
+### How to Export
+
+1. Click the **"Export"** button on the test case list screen
+2. The CSV file is downloaded automatically
+
+### Included Information
+
+| Item            | Description                         |
+| --------------- | ----------------------------------- |
+| Case key        | Unique identifier                   |
+| Title           | Test case name                      |
+| Test type       | Type of test                        |
+| Tags            | Classification tags                 |
+| Preconditions   | Conditions required before the test |
+| Test steps      | The procedure                       |
+| Expected result | Expected outcome                    |
+| Status          | Current test status                 |
+| Suite           | Name of the suite it belongs to     |
+| Created         | Case creation date                  |
+| Modified        | Date of last modification           |
+
+> **Note**: The currently applied filter and sort order are reflected in the export. CSV files containing Korean text are saved in UTF-8 BOM format so they can be opened directly in Excel.

--- a/apps/web/content/docs/en/test-runs.md
+++ b/apps/web/content/docs/en/test-runs.md
@@ -1,0 +1,147 @@
+# Test Runs
+
+This guide explains how to run tests and record results.
+
+---
+
+## What is a Test Run?
+
+A test run is a session for running test cases at a specific point in time and recording the results. Each run is managed independently, and the run history lets you understand quality trends.
+
+### Usage Examples
+
+- **Sprint test**: Run a regression test before the sprint ends
+- **Release verification**: Run tests on key features before deployment
+- **Daily check**: Run a smoke test every day
+
+---
+
+## Test Run List
+
+Click the **"Test Runs"** menu in the project sidebar to view the full list of runs.
+
+### List Information
+
+| Item        | Description                                                     |
+| ----------- | --------------------------------------------------------------- |
+| Name        | Test run name                                                   |
+| Source type | Basis for creating the run (suite, milestone, manual selection) |
+| Case count  | Number of included test cases                                   |
+| Progress    | Percentage of completed cases                                   |
+| Status      | Not Started, In Progress, Completed                             |
+| Updated     | Time of last update                                             |
+
+### Sort Options
+
+- **Recently Updated**: By most recent update
+- **Created Date**: By creation date
+- **Name**: By name
+
+---
+
+## Creating a Test Run
+
+### How to Create
+
+1. Click **"Test Runs"** in the sidebar
+2. Click the **"+ New Run"** button
+3. Enter the run information
+
+### Input Fields
+
+| Field       | Required | Description                             |
+| ----------- | -------- | --------------------------------------- |
+| Name        | ✓        | At least 1 character, the test run name |
+| Description |          | A description of the run                |
+| Test cases  | ✓        | Select the cases to run                 |
+
+### Selecting Cases by Source Type
+
+There are three ways to select cases when creating a test run.
+
+| Source type            | Description                                     |
+| ---------------------- | ----------------------------------------------- |
+| **Select a suite**     | Run the cases included in a specific test suite |
+| **Select a milestone** | Run the cases linked to a milestone             |
+| **Manual selection**   | Select the cases you want individually          |
+
+### Creating Directly from a Milestone
+
+When you click the **"Create Test Run"** button on a [Milestone](/docs?tab=milestones) detail screen, a run is created with that milestone's cases selected automatically.
+
+---
+
+## Test Run Status
+
+| Status          | Description                  |
+| --------------- | ---------------------------- |
+| **Not Started** | Run created, not yet started |
+| **In Progress** | Tests in progress            |
+| **Completed**   | All tests complete           |
+
+---
+
+## Running Tests
+
+### Run Detail Screen
+
+1. Click the item you want to run in the run list
+2. Go to the run detail screen
+
+### Entering Results per Case
+
+Enter a result for each test case:
+
+| Result       | Shortcut | Description                 |
+| ------------ | -------- | --------------------------- |
+| **Pass**     | `P`      | Test passed                 |
+| **Fail**     | `F`      | Test failed                 |
+| **Blocked**  | `B`      | Cannot run                  |
+| **Untested** | `U`      | Revert to the not-run state |
+
+### Adding Comments
+
+- You can add a comment to each case's result
+- Record the failure reason, bug links, reproduction steps, and so on
+- When you enter a result, the execution time is recorded automatically
+
+---
+
+## Keyboard Shortcuts
+
+On the test run detail screen, you can quickly enter results using only the keyboard.
+
+| Shortcut  | Function                       |
+| --------- | ------------------------------ |
+| `P`       | Change to Pass                 |
+| `F`       | Change to Fail                 |
+| `B`       | Change to Blocked              |
+| `U`       | Change to Untested             |
+| `↑` / `↓` | Move to the previous/next case |
+
+> **Note**: Using shortcuts, you can enter test results quickly without a mouse. With a case selected, pressing a status key applies the result immediately, and you can move to the next case with the arrow keys.
+
+---
+
+## Checking Run Results
+
+### Progress
+
+- Check the overall progress on the run detail screen
+- Displays the number of cases by status
+
+### Statistics
+
+- **Pass Rate**: Percentage of passed cases
+- **Fail Count**: Number of failed cases
+- **Blocked Count**: Number of blocked cases
+
+---
+
+## Checking on the Dashboard
+
+You can also check test run results on the [Dashboard](/docs?tab=dashboard).
+
+- **Test status chart**: Check the status distribution with a pie chart
+- **Milestone Gantt chart**: Check the progress timeline by milestone
+- You can select a specific run in the dashboard charts to switch the results shown

--- a/apps/web/content/docs/en/test-suites.md
+++ b/apps/web/content/docs/en/test-suites.md
@@ -1,0 +1,105 @@
+# Test Suite Management
+
+This guide explains how to manage test cases by grouping them.
+
+---
+
+## What is a Test Suite?
+
+A test suite is a group that brings related test cases together for management. You can classify cases by feature, by module, or by test type.
+
+### Usage Examples
+
+- **By feature**: Login suite, Payment suite, Search suite
+- **By type**: Smoke test, Regression test, Performance test
+- **By priority**: Critical suite, High suite, Low suite
+
+---
+
+## Test Suite List
+
+Click the **"Test Suites"** menu in the project sidebar to view the full list of suites.
+
+### List Information
+
+| Item       | Description                        |
+| ---------- | ---------------------------------- |
+| Name       | Suite name                         |
+| Case count | Number of included test cases      |
+| Status     | Active / archived status           |
+| Modified   | Date and time of last modification |
+
+### Filtering
+
+- **Search**: Search by suite name
+- **Status filter**: All, Active, Archived
+
+---
+
+## Creating a Test Suite
+
+### Quick Creation
+
+1. Click **"Create Test Suite"** in the **"Quick Start"** section of the dashboard
+2. Or click the **"+ New Suite"** button in the suite list
+
+### Input Fields
+
+| Field       | Required | Description                        |
+| ----------- | -------- | ---------------------------------- |
+| Name        | ✓        | 10-200 characters, the suite title |
+| Description |          | A description of the suite         |
+
+> **Note**: The suite name must be at least 10 characters. Use a name that clearly conveys the suite's purpose.
+
+---
+
+## Adding Cases to a Suite
+
+### Method 1: Add from the Suite Detail
+
+1. Go to the suite detail screen
+2. Click the **"Add Case"** button
+3. Select the cases to add
+
+### Method 2: Assign a Suite When Creating a Case
+
+1. Select a suite when creating a test case
+2. The case is automatically added to that suite
+
+> **Note**: Cases not included in a suite can be found in the [Test Case List](/docs?tab=test-cases) using the **"Unassigned"** filter.
+
+---
+
+## Test Suite Detail
+
+Click a suite to go to its detail screen.
+
+### Detail Screen Composition
+
+- **Header**: Suite name, description, edit button
+- **Case list**: The test cases included in the suite
+- **Statistics**: Number of cases by status
+
+---
+
+## Creating a Test Run from a Suite
+
+You can create a [Test Run](/docs?tab=test-runs) directly from the suite detail screen. The test cases included in the suite are selected automatically.
+
+---
+
+## Editing a Test Suite
+
+1. Click the suite you want to edit in the suite list
+2. Edit the name and description on the detail screen
+3. Click the **"Save"** button
+
+---
+
+## Deleting a Test Suite
+
+1. Click the **"Delete"** button on the suite detail screen
+2. Confirm the deletion in the confirmation dialog
+
+> **Note**: Deleting a suite does not delete the test cases it contains. The cases remain in the "Unassigned" state.

--- a/apps/web/src/i18n/messages/en.json
+++ b/apps/web/src/i18n/messages/en.json
@@ -34,7 +34,10 @@
     "docsLinkAria": "Go to docs page",
     "docs": "User guide",
     "searchAria": "Open my project search dialog",
-    "findProject": "Find my project"
+    "findProject": "Find my project",
+    "langSwitcher": "Select language",
+    "langKo": "한국어",
+    "langEn": "English"
   },
   "footer": {
     "ariaInfo": "Site information",

--- a/apps/web/src/i18n/messages/ko.json
+++ b/apps/web/src/i18n/messages/ko.json
@@ -34,7 +34,10 @@
     "docsLinkAria": "문서 페이지로 이동",
     "docs": "이용 가이드",
     "searchAria": "내 프로젝트 검색 모달 열기",
-    "findProject": "내 프로젝트 찾기"
+    "findProject": "내 프로젝트 찾기",
+    "langSwitcher": "언어 선택",
+    "langKo": "한국어",
+    "langEn": "English"
   },
   "footer": {
     "ariaInfo": "사이트 정보",

--- a/apps/web/src/widgets/global-header/global-header.tsx
+++ b/apps/web/src/widgets/global-header/global-header.tsx
@@ -11,6 +11,7 @@ import { LANDING_EVENTS, NAVIGATION_EVENTS, track } from '@/shared/lib/analytics
 import { NotificationBell } from '@/widgets/notification-center';
 
 import { BetaBanner } from './beta-banner';
+import { LanguageSwitcher } from './language-switcher';
 import { useBetaBanner } from './use-beta-banner';
 
 const ProjectSearchModal = dynamic(
@@ -69,6 +70,7 @@ export const GlobalHeader = () => {
             {t('findProject')}
           </button>
           <NotificationBell />
+          <LanguageSwitcher />
         </nav>
       </header>
 

--- a/apps/web/src/widgets/global-header/index.ts
+++ b/apps/web/src/widgets/global-header/index.ts
@@ -1,2 +1,3 @@
 export { GlobalHeader } from '@/widgets/global-header/global-header';
+export { LanguageSwitcher } from '@/widgets/global-header/language-switcher';
 export { useBetaBanner } from '@/widgets/global-header/use-beta-banner';

--- a/apps/web/src/widgets/global-header/language-switcher.tsx
+++ b/apps/web/src/widgets/global-header/language-switcher.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import React from 'react';
+
+import { useLocale, useTranslations } from 'next-intl';
+
+import { usePathname, useRouter } from '@/i18n/navigation';
+import type { Locale } from '@/i18n/routing';
+import { routing } from '@/i18n/routing';
+
+const LOCALE_LABEL_KEY: Record<Locale, 'langKo' | 'langEn'> = {
+  ko: 'langKo',
+  en: 'langEn',
+};
+
+/**
+ * 마케팅 헤더용 언어 전환 스위처.
+ *
+ * 현재 경로(로케일 제거된 pathname)를 유지한 채 로케일만 바꾼다. next-intl navigation
+ * 래퍼의 `useRouter().replace(pathname, { locale })` 패턴을 사용하므로 `/en` 접두 부여/제거가
+ * 자동으로 처리된다. GlobalHeader 는 마케팅 화면(로케일 라우팅 대상)에서만 렌더되므로 안전하다.
+ */
+export const LanguageSwitcher = () => {
+  const t = useTranslations('header');
+  const locale = useLocale() as Locale;
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const switchLocale = (next: Locale) => {
+    if (next === locale) return;
+    router.replace(pathname, { locale: next });
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label={t('langSwitcher')}
+      className="text-body2 text-text-2 flex items-center gap-1"
+    >
+      {routing.locales.map((option, index) => {
+        const isActive = option === locale;
+        return (
+          <React.Fragment key={option}>
+            {index > 0 && (
+              <span aria-hidden className="text-text-2/40">
+                /
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => switchLocale(option)}
+              aria-label={t(LOCALE_LABEL_KEY[option])}
+              aria-current={isActive ? 'true' : undefined}
+              className={`cursor-pointer transition-colors ${
+                isActive ? 'text-primary font-semibold' : 'text-text-2 hover:text-primary'
+              }`}
+            >
+              {t(LOCALE_LABEL_KEY[option])}
+            </button>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};


### PR DESCRIPTION
@
## 배경

국제화 1단계(마케팅 페이지 ko/en)에 이어 영어 사용자 경험을 보강한다. 사용 가이드 본문 영어화, 언어별 공유 이미지, 언어 전환 UI 를 추가한다.

## 변경 사항

- 사용 가이드 본문을 영어로 제공한다. 영어 화면에서 가이드 6개 문서가 영어로 표시되고, 번역본이 없으면 한국어로 안전하게 폴백한다.
- 공유(SNS 미리보기) 이미지를 언어별로 분리해, 영어 페이지는 영어 문구 이미지를, 한국어 페이지는 한국어 문구 이미지를 노출한다.
- 헤더에 언어 전환 버튼(한국어 / English)을 추가했다. 현재 보고 있는 페이지를 유지한 채 언어만 전환한다.

## 범위 밖 (의도적 보류)

- 법적 고지(개인정보 처리방침·이용약관) 영어 번역: 영어판이 법적 구속력을 가지므로 법무 검토 후 별도 추가한다(현재 영어 화면에서 한국어로 폴백). 영어본을 추가하면 자동 적용되도록 로더는 준비돼 있다.
- 제품 화면 국제화: 별도 대형 과제로 분리.
- 언어 전환 버튼은 현재 랜딩 헤더에 노출된다(가이드·법적 고지·팀 페이지는 자체 헤더라 후속 확장 예정).

## 검증

- 영어 가이드 본문 렌더 및 한국어 폴백, 언어별 공유 이미지 노출, 언어 전환 시 경로 유지, 마케팅·제품 회귀 없음을 프로덕션 빌드와 로컬 실행으로 확인했다.
@