### PR TITLE
feat(i18n): 제품 화면 국제화 메커니즘 + 공용 라벨 (제품 1단계)

### DIFF
--- a/apps/web/src/features/locale-switcher/actions.ts
+++ b/apps/web/src/features/locale-switcher/actions.ts
@@ -1,0 +1,26 @@
+'use server';
+
+import { hasLocale } from 'next-intl';
+import { cookies } from 'next/headers';
+
+import { LOCALE_COOKIE, routing } from '@/i18n/routing';
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * 제품 화면의 로케일을 쿠키에 저장한다. URL 접두가 없는 제품 영역은 이 쿠키로 언어를 정한다.
+ * 호출 후 클라이언트에서 `router.refresh()` 로 SSR 을 재실행해야 새 로케일이 반영된다.
+ */
+export async function setLocaleCookie(locale: string): Promise<void> {
+  if (!hasLocale(routing.locales, locale)) {
+    return;
+  }
+  const store = await cookies();
+  store.set(LOCALE_COOKIE, locale, {
+    maxAge: ONE_YEAR_SECONDS,
+    path: '/',
+    sameSite: 'lax',
+    httpOnly: false, // 클라이언트에서도 현재 로케일을 읽을 수 있어야 한다 (민감정보 아님).
+    secure: process.env.NODE_ENV === 'production',
+  });
+}

--- a/apps/web/src/features/locale-switcher/index.ts
+++ b/apps/web/src/features/locale-switcher/index.ts
@@ -1,0 +1,2 @@
+export { ProductLanguageSwitcher } from './product-language-switcher';
+export { setLocaleCookie } from './actions';

--- a/apps/web/src/features/locale-switcher/product-language-switcher.tsx
+++ b/apps/web/src/features/locale-switcher/product-language-switcher.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useTransition } from 'react';
+
+import { useLocale, useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+
+import type { Locale } from '@/i18n/routing';
+import { routing } from '@/i18n/routing';
+
+import { setLocaleCookie } from './actions';
+
+const LOCALE_LABEL_KEY: Record<Locale, 'langKo' | 'langEn'> = {
+  ko: 'langKo',
+  en: 'langEn',
+};
+
+/**
+ * 제품 화면용 언어 스위처. URL 접두가 없는 제품 영역은 쿠키로 로케일을 정하므로,
+ * 마케팅 스위처와 달리 라우터 navigation 대신 쿠키 set + `router.refresh()` 로 전환한다.
+ */
+export const ProductLanguageSwitcher = () => {
+  const t = useTranslations('header');
+  const locale = useLocale() as Locale;
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const switchLocale = (next: Locale) => {
+    if (next === locale || isPending) return;
+    startTransition(async () => {
+      await setLocaleCookie(next);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div
+      role="group"
+      aria-label={t('langSwitcher')}
+      className="text-body2 text-text-2 flex items-center gap-1"
+    >
+      {routing.locales.map((option, index) => {
+        const isActive = option === locale;
+        return (
+          <React.Fragment key={option}>
+            {index > 0 && (
+              <span aria-hidden className="text-text-2/40">
+                /
+              </span>
+            )}
+            <button
+              type="button"
+              onClick={() => switchLocale(option)}
+              disabled={isPending}
+              aria-label={t(LOCALE_LABEL_KEY[option])}
+              aria-current={isActive ? 'true' : undefined}
+              className={`cursor-pointer transition-colors disabled:opacity-60 ${
+                isActive ? 'text-primary font-semibold' : 'text-text-2 hover:text-primary'
+              }`}
+            >
+              {t(LOCALE_LABEL_KEY[option])}
+            </button>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/i18n/messages/en.json
+++ b/apps/web/src/i18n/messages/en.json
@@ -1,5 +1,42 @@
 {
   "common": {},
+  "aside": {
+    "sections": {
+      "requirements": "Requirements",
+      "testManagement": "Test Management"
+    },
+    "items": {
+      "requirements": "Requirements",
+      "scenarios": "Scenarios",
+      "cases": "Test Cases",
+      "suites": "Test Suites",
+      "milestones": "Milestones",
+      "runs": "Test Runs",
+      "checklists": "Checklists",
+      "trash": "Trash",
+      "settings": "Settings",
+      "help": "Help"
+    },
+    "dashboardAria": "Go to dashboard",
+    "brand": "Test Tools",
+    "search": "Search",
+    "comingSoon": "This feature is coming soon."
+  },
+  "notifications": {
+    "category": {
+      "feature": "New feature",
+      "maintenance": "Maintenance",
+      "policy": "Policy",
+      "event": "Event",
+      "notice": "Notice"
+    },
+    "severity": {
+      "info": "Info",
+      "warning": "Warning",
+      "critical": "Critical"
+    },
+    "unread": "Unread"
+  },
   "meta": {
     "landing": {
       "title": "Testea - Free QA tool for AI test scenario and case generation",

--- a/apps/web/src/i18n/messages/ko.json
+++ b/apps/web/src/i18n/messages/ko.json
@@ -1,5 +1,42 @@
 {
   "common": {},
+  "aside": {
+    "sections": {
+      "requirements": "요구사항",
+      "testManagement": "테스트 관리"
+    },
+    "items": {
+      "requirements": "요구사항 생성",
+      "scenarios": "시나리오 관리",
+      "cases": "테스트 케이스",
+      "suites": "테스트 스위트",
+      "milestones": "마일스톤",
+      "runs": "테스트 실행",
+      "checklists": "체크리스트",
+      "trash": "휴지통",
+      "settings": "설정",
+      "help": "도움말"
+    },
+    "dashboardAria": "대시보드로 이동",
+    "brand": "테스트 도구",
+    "search": "검색",
+    "comingSoon": "해당 기능은 준비중입니다."
+  },
+  "notifications": {
+    "category": {
+      "feature": "신규 기능",
+      "maintenance": "점검",
+      "policy": "정책",
+      "event": "이벤트",
+      "notice": "공지"
+    },
+    "severity": {
+      "info": "안내",
+      "warning": "주의",
+      "critical": "긴급"
+    },
+    "unread": "미읽음"
+  },
   "meta": {
     "landing": {
       "title": "테스티아(Testea) - AI 테스트 시나리오·케이스 생성 무료 QA 도구",

--- a/apps/web/src/i18n/request.ts
+++ b/apps/web/src/i18n/request.ts
@@ -1,18 +1,24 @@
 import { hasLocale } from 'next-intl';
 import { getRequestConfig } from 'next-intl/server';
+import { cookies } from 'next/headers';
 
-import { routing } from './routing';
+import { LOCALE_COOKIE, routing } from './routing';
 
 /**
  * 요청별 로케일·메시지 해석.
  *
- * [locale] 세그먼트 밖의 라우트(제품 `/projects`, `/share`, `/api` 등)는 유효 로케일이
- * 아니므로 `hasLocale` 가 실패하고 defaultLocale(ko) 로 폴백한다. 따라서 제품 화면은
- * 항상 ko 메시지·`lang="ko"` 로 동작해 회귀가 없다.
+ * 우선순위: (1) URL 세그먼트 로케일(마케팅 `[locale]`) → (2) `NEXT_LOCALE` 쿠키(제품 화면) →
+ * (3) defaultLocale(ko). 마케팅은 URL 접두가 항상 우선이라 쿠키와 충돌하지 않고, [locale]
+ * 밖의 제품(`/projects` 등)은 URL 로케일이 없어 쿠키로 언어를 정한다(쿠키 없으면 ko).
  */
 export default getRequestConfig(async ({ requestLocale }) => {
   const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale;
+  let locale = hasLocale(routing.locales, requested) ? requested : undefined;
+
+  if (!locale) {
+    const cookieLocale = (await cookies()).get(LOCALE_COOKIE)?.value;
+    locale = hasLocale(routing.locales, cookieLocale) ? cookieLocale : routing.defaultLocale;
+  }
 
   return {
     locale,

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -15,3 +15,9 @@ export const routing = defineRouting({
 });
 
 export type Locale = (typeof routing.locales)[number];
+
+/**
+ * 제품 화면(URL 접두 없는 비공개 영역)의 로케일을 담는 쿠키 이름.
+ * next-intl 기본 쿠키명과 동일하게 둬 호환성을 확보한다.
+ */
+export const LOCALE_COOKIE = 'NEXT_LOCALE';

--- a/apps/web/src/widgets/aside/aside.tsx
+++ b/apps/web/src/widgets/aside/aside.tsx
@@ -1,10 +1,12 @@
 'use client';
 import React, { useCallback, useMemo } from 'react';
 
+import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { useParams, usePathname } from 'next/navigation';
 
 import { dashboardQueryKeys } from '@/features/dashboard';
+import { ProductLanguageSwitcher } from '@/features/locale-switcher';
 import { NAVIGATION_EVENTS, track } from '@/shared/lib/analytics';
 import { AsideMenuItem, createAsideMenus } from '@/widgets/aside/model';
 import { AsideNavItem } from '@/widgets/aside/ui';
@@ -27,10 +29,10 @@ const isPathActive = (currentPath: string, matchPath: string): boolean => {
   return currentPath.startsWith(matchPath);
 };
 
-const handleAwaitItem = (e: React.MouseEvent, href: string) => {
+const handleAwaitItem = (e: React.MouseEvent, href: string, comingSoonMessage: string) => {
   if (href === '#') {
     e.preventDefault();
-    toast.info('해당 기능은 준비중 입니다.');
+    toast.info(comingSoonMessage);
   }
 };
 
@@ -40,20 +42,21 @@ type PrefetchOptions = {
   queryFn: () => Promise<unknown>;
   staleTime?: number;
 };
+// 메뉴 식별 키(menu.ts 의 label) → prefetch 쿼리 옵션 로더.
 const PREFETCH_LOADERS: Record<string, (pid: string) => Promise<PrefetchOptions>> = {
-  '테스트 케이스': async (pid) => {
+  'items.cases': async (pid) => {
     const { testCasesQueryOptions } = await import('@/features/cases-list');
     return testCasesQueryOptions(pid) as unknown as PrefetchOptions;
   },
-  '테스트 스위트': async (pid) => {
+  'items.suites': async (pid) => {
     const { testSuitesQueryOptions } = await import('@/entities/test-suite');
     return testSuitesQueryOptions(pid) as unknown as PrefetchOptions;
   },
-  마일스톤: async (pid) => {
+  'items.milestones': async (pid) => {
     const { milestonesQueryOptions } = await import('@/entities/milestone');
     return milestonesQueryOptions(pid) as unknown as PrefetchOptions;
   },
-  '테스트 실행': async (pid) => {
+  'items.runs': async (pid) => {
     const { testRunsQueryOptions } = await import('@/features/runs');
     return testRunsQueryOptions(pid) as unknown as PrefetchOptions;
   },
@@ -62,6 +65,7 @@ const PREFETCH_LOADERS: Record<string, (pid: string) => Promise<PrefetchOptions>
 const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
 export const Aside = () => {
+  const t = useTranslations('aside');
   const params = useParams();
   const pathname = usePathname();
   const queryClient = useQueryClient();
@@ -104,10 +108,10 @@ export const Aside = () => {
     >
       {/* 사이드바 상단 */}
       <div className="border-bg-4 border-b px-6 pt-10 pb-6">
-        <Link href={`/projects/${projectSlug}`} className="block" aria-label="대시보드로 이동">
+        <Link href={`/projects/${projectSlug}`} className="block" aria-label={t('dashboardAria')}>
           <Logo aria-hidden="true" />
         </Link>
-        <p className="typo-label-normal text-text-3 mt-4 tracking-[0.2em]">테스트 도구</p>
+        <p className="typo-label-normal text-text-3 mt-4 tracking-[0.2em]">{t('brand')}</p>
       </div>
 
       {/* 검색 트리거 */}
@@ -120,7 +124,7 @@ export const Aside = () => {
           className="rounded-3 border-line-2 bg-bg-3 text-text-4 hover:border-line-3 hover:text-text-3 flex w-full items-center gap-2 border px-3 py-1.5 transition-colors"
         >
           <Search size={14} />
-          <span className="typo-label-normal flex-1 text-left">검색</span>
+          <span className="typo-label-normal flex-1 text-left">{t('search')}</span>
           <kbd className="typo-label-normal text-text-4 flex items-center gap-1">
             <span>{isMac ? '⌘' : 'Ctrl'}</span>
             <span>K</span>
@@ -133,7 +137,7 @@ export const Aside = () => {
         {menus.sections.map((section) => (
           <section key={section.title} className="flex flex-col">
             <h2 className="typo-label-heading text-text-3 mb-3 tracking-[0.18em] uppercase">
-              {section.title}
+              {t(section.title)}
             </h2>
 
             <div className="flex flex-col gap-1">
@@ -143,7 +147,7 @@ export const Aside = () => {
                   onClick={() => track(NAVIGATION_EVENTS.NAV_CLICK, { menu_label: item.label })}
                 >
                   <AsideNavItem
-                    label={item.label}
+                    label={t(item.label)}
                     href={item.href}
                     icon={item.icon}
                     active={isPathActive(pathname, item.matchPath || '')}
@@ -157,18 +161,21 @@ export const Aside = () => {
       </nav>
 
       {/* 사이드바 하단 */}
-      <div className="border-bg-4 mt-auto border-t px-4 py-4">
+      <div className="border-bg-4 mt-auto flex flex-col gap-3 border-t px-4 py-4">
         <div className="flex flex-col gap-1">
           {menus.bottom.map((item: AsideMenuItem) => (
-            <div key={item.label} onClick={(e) => handleAwaitItem(e, item.href)}>
+            <div key={item.label} onClick={(e) => handleAwaitItem(e, item.href, t('comingSoon'))}>
               <AsideNavItem
-                label={item.label}
+                label={t(item.label)}
                 href={item.href}
                 icon={item.icon}
                 active={isPathActive(pathname, item.matchPath || '')}
               />
             </div>
           ))}
+        </div>
+        <div className="flex justify-center">
+          <ProductLanguageSwitcher />
         </div>
       </div>
     </aside>

--- a/apps/web/src/widgets/aside/model/menu.ts
+++ b/apps/web/src/widgets/aside/model/menu.ts
@@ -10,23 +10,25 @@ import {
   Trash2,
 } from 'lucide-react';
 
-// 동적 경로를 위한 함수
+// 동적 경로를 위한 함수.
+// label/title 은 표시 텍스트가 아니라 `aside` 네임스페이스의 메시지 키다(소비처 aside.tsx 에서
+// useTranslations 로 번역). 안정적 식별자라 React key·tracking·prefetch 키로도 그대로 쓴다.
 export const createAsideMenus = (projectSlug: string) => {
   const basePath = `/projects/${projectSlug}`;
 
   return {
     sections: [
       {
-        title: '요구사항',
+        title: 'sections.requirements',
         items: [
           {
-            label: '요구사항 생성',
+            label: 'items.requirements',
             href: `${basePath}/requirements`,
             icon: FileText,
             matchPath: `${basePath}/requirements`,
           },
           {
-            label: '시나리오 관리',
+            label: 'items.scenarios',
             href: `${basePath}/scenarios`,
             icon: ListChecks,
             matchPath: `${basePath}/scenarios`,
@@ -34,34 +36,34 @@ export const createAsideMenus = (projectSlug: string) => {
         ],
       },
       {
-        title: '테스트 관리',
+        title: 'sections.testManagement',
         items: [
           {
-            label: '테스트 케이스',
+            label: 'items.cases',
             href: `${basePath}/cases`,
             icon: FileText,
             matchPath: `${basePath}/cases`,
           },
           {
-            label: '테스트 스위트',
+            label: 'items.suites',
             href: `${basePath}/suites`,
             icon: FolderOpen,
             matchPath: `${basePath}/suites`,
           },
           {
-            label: '마일스톤',
+            label: 'items.milestones',
             href: `${basePath}/milestones`,
             icon: Flag,
             matchPath: `${basePath}/milestones`,
           },
           {
-            label: '테스트 실행',
+            label: 'items.runs',
             href: `${basePath}/runs`,
             icon: Play,
             matchPath: `${basePath}/runs`,
           },
           {
-            label: '체크리스트',
+            label: 'items.checklists',
             href: `${basePath}/checklists`,
             icon: CheckSquare,
             matchPath: `${basePath}/checklists`,
@@ -70,14 +72,19 @@ export const createAsideMenus = (projectSlug: string) => {
       },
     ],
     bottom: [
-      { label: '휴지통', href: `${basePath}/trash`, icon: Trash2, matchPath: `${basePath}/trash` },
       {
-        label: '설정',
+        label: 'items.trash',
+        href: `${basePath}/trash`,
+        icon: Trash2,
+        matchPath: `${basePath}/trash`,
+      },
+      {
+        label: 'items.settings',
         href: `${basePath}/settings`,
         icon: Settings,
         matchPath: `${basePath}/settings`,
       },
-      { label: '도움말', href: '#', icon: HelpCircle, matchPath: '' },
+      { label: 'items.help', href: '#', icon: HelpCircle, matchPath: '' },
     ],
   };
 };

--- a/apps/web/src/widgets/notification-center/announcement-detail-dialog.tsx
+++ b/apps/web/src/widgets/notification-center/announcement-detail-dialog.tsx
@@ -6,7 +6,7 @@ import type { AnnouncementWithReadState } from '@testea/db';
 import { DSButton, Dialog } from '@testea/ui';
 
 import { useMarkRead } from './hooks';
-import { CATEGORY_LABEL, SEVERITY_LABEL } from './labels';
+import { useAnnouncementLabels } from './labels';
 
 interface AnnouncementDetailDialogProps {
   announcement: AnnouncementWithReadState | null;
@@ -19,6 +19,7 @@ interface AnnouncementDetailDialogProps {
  */
 export function AnnouncementDetailDialog({ announcement, onClose }: AnnouncementDetailDialogProps) {
   const markRead = useMarkRead();
+  const labels = useAnnouncementLabels();
 
   useEffect(() => {
     if (!announcement) return;
@@ -55,14 +56,14 @@ export function AnnouncementDetailDialog({ announcement, onClose }: Announcement
           <div className="flex flex-col gap-4">
             <div className="flex items-center gap-2">
               <span className="bg-primary/15 text-primary typo-caption-heading rounded-full px-2.5 py-0.5">
-                {CATEGORY_LABEL[announcement.category] ?? announcement.category}
+                {labels.category(announcement.category)}
               </span>
               <span
                 className={`typo-caption-heading rounded-full px-2.5 py-0.5 ${severityClass(
                   announcement.severity
                 )}`}
               >
-                {SEVERITY_LABEL[announcement.severity]}
+                {labels.severity(announcement.severity)}
               </span>
               <time
                 dateTime={announcement.publishedAt}

--- a/apps/web/src/widgets/notification-center/labels.ts
+++ b/apps/web/src/widgets/notification-center/labels.ts
@@ -1,18 +1,15 @@
-/**
- * 공지 카테고리·심각도 라벨 매핑 (고객 측 UI 용).
- *
- * 어드민 측은 별도 입력값을 그대로 노출하지만, 고객 화면에는 한국어 라벨로 변환한다.
- */
-export const CATEGORY_LABEL: Record<string, string> = {
-  feature: '신규 기능',
-  maintenance: '점검',
-  policy: '정책',
-  event: '이벤트',
-  notice: '공지',
-};
+import { useTranslations } from 'next-intl';
 
-export const SEVERITY_LABEL: Record<string, string> = {
-  info: '안내',
-  warning: '주의',
-  critical: '긴급',
-};
+/**
+ * 공지 카테고리·심각도 라벨을 현재 로케일로 변환하는 훅 (고객 측 UI 용).
+ * 알 수 없는 값은 원본을 그대로 노출(폴백)한다.
+ */
+export function useAnnouncementLabels() {
+  const t = useTranslations('notifications');
+  return {
+    category: (category: string) =>
+      t.has(`category.${category}`) ? t(`category.${category}`) : category,
+    severity: (severity: string) =>
+      t.has(`severity.${severity}`) ? t(`severity.${severity}`) : severity,
+  };
+}

--- a/apps/web/src/widgets/notification-center/notification-bell.tsx
+++ b/apps/web/src/widgets/notification-center/notification-bell.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import { useTranslations } from 'next-intl';
+
 import type { AnnouncementWithReadState } from '@testea/db';
 import { Bell } from 'lucide-react';
 
 import { AnnouncementDetailDialog } from './announcement-detail-dialog';
 import { useAnnouncementList, useUnreadCount } from './hooks';
-import { CATEGORY_LABEL, SEVERITY_LABEL } from './labels';
+import { useAnnouncementLabels } from './labels';
 
 /**
  * 헤더 우측 알림 벨 + 드롭다운 패널.
@@ -17,6 +19,8 @@ import { CATEGORY_LABEL, SEVERITY_LABEL } from './labels';
  * - 외부 클릭/ESC 로 드롭다운 닫힘.
  */
 export function NotificationBell() {
+  const t = useTranslations('notifications');
+  const labels = useAnnouncementLabels();
   const [isOpen, setIsOpen] = useState(false);
   const [activeAnnouncement, setActiveAnnouncement] = useState<AnnouncementWithReadState | null>(
     null
@@ -102,12 +106,12 @@ export function NotificationBell() {
                       <span className="flex items-center gap-2">
                         {!item.readAt && (
                           <span
-                            aria-label="미읽음"
+                            aria-label={t('unread')}
                             className="bg-primary inline-block h-2 w-2 shrink-0 rounded-full"
                           />
                         )}
                         <span className="typo-caption-heading bg-bg-3 text-text-2 rounded-full px-2 py-0.5">
-                          {CATEGORY_LABEL[item.category] ?? item.category}
+                          {labels.category(item.category)}
                         </span>
                         {item.severity !== 'info' && (
                           <span
@@ -117,7 +121,7 @@ export function NotificationBell() {
                                 : 'bg-amber-500/15 text-amber-400'
                             }`}
                           >
-                            {SEVERITY_LABEL[item.severity]}
+                            {labels.severity(item.severity)}
                           </span>
                         )}
                       </span>


### PR DESCRIPTION
@
## 배경

마케팅 페이지는 URL 기반(ko 무접두 / en /en)으로 국제화돼 있다. 제품 화면(/projects/**)은 프로젝트 비밀번호 뒤 비공개·검색 제외 영역이라 URL 접두의 SEO 가치가 없으므로, 제품은 **쿠키 기반 로케일**로 국제화한다(URL·라우트 변경 없음). 제품 전체 번역은 도메인 단위로 점진 진행하는 대규모 작업이라, 이번 단계는 (1) 로케일 전달 메커니즘과 언어 전환 UI, (2) 재사용도가 가장 높은 공용 라벨(사이드바·알림센터)을 먼저 올려 메커니즘을 입증한다.

## 변경 사항

- 제품 화면의 언어를 쿠키로 결정하도록 했다. 주소를 바꾸지 않고 현재 화면에서 언어를 전환하며, 마케팅 영역은 기존대로 주소의 언어가 우선한다(쿠키와 충돌 없음).
- 제품 사이드바 하단에 언어 전환 버튼(한국어 / English)을 추가했다. 누르면 현재 화면을 유지한 채 즉시 언어가 바뀐다.
- 제품 사이드바(섹션·메뉴 항목·검색·도움말 등)와 알림센터(공지 분류·중요도 라벨)를 한국어/영어로 분리해 번역했다.
- 잘못된 언어 값이 들어오면 한국어로 안전하게 폴백한다.

## 범위 밖 (후속 단계)

- 케이스·스위트·테스트 실행·마일스톤 등 제품 도메인별 문자열과 서버 응답 메시지 번역은 도메인 단위 후속 작업으로 진행한다. 서버에서 내려주는 사용자 메시지는 안정적 코드로 바꿔 클라이언트에서 번역하는 방식을 적용할 예정이다.
- 상태 라벨(통과/실패/차단 등)은 사용처가 넓어 별도 단계에서 중앙화와 함께 다룬다.

## 검증

- 제품 경로에서 언어 쿠키에 따라 화면 언어가 바뀌고(미설정·잘못된 값은 한국어), 마케팅 주소의 언어가 쿠키보다 우선함을 프로덕션 빌드와 로컬 실행으로 확인했다. 타입체크·린트·포맷 통과. 한/영 메시지 키 완전 동기화.
- 인증된 제품 화면의 사이드바·알림 영어 표시는 프리뷰 배포에서 시각 확인 권장.
@