### PR TITLE
feat(TR10): 테스트 대상 등록·시크릿 관리 (#188)

### DIFF
--- a/apps/web/src/features/target-sites/api/get-target-site-for-execution.ts
+++ b/apps/web/src/features/target-sites/api/get-target-site-for-execution.ts
@@ -1,0 +1,57 @@
+import { CryptoError, decrypt } from '@/shared/lib/crypto';
+import { getDatabase, targetSites } from '@testea/db';
+import { and, eq } from 'drizzle-orm';
+import 'server-only';
+
+import type { TargetSiteAuthSecret, TargetSiteExecutionConfig } from '../model/types';
+
+/**
+ * 러너(#186) 실행용: base_url + 복호화된 인증 시크릿 반환.
+ *
+ * 서버 전용. 'use server' 파일이 아니므로 RSC action 으로 자동 노출되지 않고,
+ * 'server-only' 가 클라이언트 import 를 빌드 단에서 차단한다. 같은 process 의
+ * 서버 코드(Route Handler, server component)에서만 호출한다.
+ *
+ * 접근 가드: projectId 를 인자로 받아 해당 프로젝트 소유 row 만 반환한다.
+ * 호출부(러너 라우트)는 프로젝트 API 키 인증(#186)으로 projectId 를 이미 검증한 뒤
+ * 이 함수를 호출해야 한다(쿠키 기반 requireProjectAccess 는 서버↔서버 러너 경로에 없음).
+ *
+ * 복호화 실패(키 누락/형식 오류/인증 실패)는 CryptoError 로 전파해
+ * 호출부가 운영 알림·재등록 안내 등으로 분기하게 한다.
+ *
+ * @returns 대상이 없거나 타 프로젝트 소유면 null.
+ */
+export const getTargetSiteForExecution = async (
+  projectId: string,
+  targetSiteId: string
+): Promise<TargetSiteExecutionConfig | null> => {
+  const db = getDatabase();
+
+  const [row] = await db
+    .select()
+    .from(targetSites)
+    .where(and(eq(targetSites.id, targetSiteId), eq(targetSites.project_id, projectId)))
+    .limit(1);
+
+  if (!row) return null;
+
+  let auth: TargetSiteAuthSecret | null = null;
+  if (row.auth_secret_encrypted != null) {
+    try {
+      auth = JSON.parse(decrypt(row.auth_secret_encrypted)) as TargetSiteAuthSecret;
+    } catch (error) {
+      // CryptoError 는 그대로 전파(키 불일치/손상 식별). JSON 파싱 오류도 데이터 무결성
+      // 문제이므로 삼키지 않고 던진다.
+      if (error instanceof CryptoError) throw error;
+      throw error;
+    }
+  }
+
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    name: row.name,
+    baseUrl: row.base_url,
+    auth,
+  };
+};

--- a/apps/web/src/features/target-sites/api/server-actions.ts
+++ b/apps/web/src/features/target-sites/api/server-actions.ts
@@ -1,0 +1,198 @@
+'use server';
+
+import { requireProjectAccess } from '@/access/lib/require-access';
+import type { ActionResult } from '@/shared/types';
+import * as Sentry from '@sentry/nextjs';
+import { getDatabase, targetSites } from '@testea/db';
+import { and, asc, eq } from 'drizzle-orm';
+
+import { encryptAuthSecret } from '../lib/auth-secret';
+import {
+  CreateTargetSiteSchema,
+  DeleteTargetSiteSchema,
+  UpdateTargetSiteSchema,
+} from '../model/schema';
+import type { TargetSite } from '../model/types';
+
+/**
+ * DB row → 클라이언트 노출 형태.
+ * 시크릿 평문은 절대 내려보내지 않고 존재 여부(hasAuth)만 표시한다.
+ */
+function toTargetSite(row: {
+  id: string;
+  project_id: string;
+  name: string;
+  base_url: string;
+  auth_secret_encrypted: string | null;
+  created_at: Date;
+  updated_at: Date;
+}): TargetSite {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    name: row.name,
+    baseUrl: row.base_url,
+    hasAuth: row.auth_secret_encrypted != null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  };
+}
+
+// 조회는 ciphertext 컬럼을 select 하더라도 toTargetSite 매핑에서 평문을 만들지 않고
+// 존재 여부(hasAuth boolean)로만 변환하므로 시크릿이 클라이언트로 새지 않는다.
+
+/** 테스트 대상 등록. 인증 시크릿은 암호화해 저장. */
+export const createTargetSite = async (input: {
+  projectId: string;
+  name: string;
+  baseUrl: string;
+  auth?: {
+    username?: string;
+    password?: string;
+    headers?: Record<string, string>;
+    cookies?: Record<string, string>;
+  };
+}): Promise<ActionResult<{ targetSite: TargetSite }>> => {
+  try {
+    const parsed = CreateTargetSiteSchema.safeParse(input);
+    if (!parsed.success) {
+      return { success: false, errors: { _targetSite: [parsed.error.errors[0].message] } };
+    }
+
+    const { projectId, name, baseUrl, auth } = parsed.data;
+
+    if (!(await requireProjectAccess(projectId))) {
+      return { success: false, errors: { _general: ['접근 권한이 없습니다.'] } };
+    }
+
+    const db = getDatabase();
+    const [row] = await db
+      .insert(targetSites)
+      .values({
+        project_id: projectId,
+        name,
+        base_url: baseUrl,
+        auth_secret_encrypted: encryptAuthSecret(auth),
+      })
+      .returning();
+
+    return { success: true, data: { targetSite: toTargetSite(row) } };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'createTargetSite' } });
+    return { success: false, errors: { _targetSite: ['테스트 대상 등록에 실패했습니다.'] } };
+  }
+};
+
+/** 프로젝트의 테스트 대상 목록. 시크릿 평문 미포함(hasAuth 만). */
+export const listTargetSites = async (projectId: string): Promise<ActionResult<TargetSite[]>> => {
+  try {
+    if (!(await requireProjectAccess(projectId))) {
+      return { success: false, errors: { _general: ['접근 권한이 없습니다.'] } };
+    }
+
+    const db = getDatabase();
+    const rows = await db
+      .select()
+      .from(targetSites)
+      .where(eq(targetSites.project_id, projectId))
+      .orderBy(asc(targetSites.created_at));
+
+    return { success: true, data: rows.map(toTargetSite) };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'listTargetSites' } });
+    return { success: false, errors: { _targetSite: ['테스트 대상을 불러올 수 없습니다.'] } };
+  }
+};
+
+/**
+ * 테스트 대상 수정.
+ * auth: undefined=유지, null=제거, 객체=교체.
+ */
+export const updateTargetSite = async (input: {
+  projectId: string;
+  targetSiteId: string;
+  name?: string;
+  baseUrl?: string;
+  auth?: {
+    username?: string;
+    password?: string;
+    headers?: Record<string, string>;
+    cookies?: Record<string, string>;
+  } | null;
+}): Promise<ActionResult<{ targetSite: TargetSite }>> => {
+  try {
+    const parsed = UpdateTargetSiteSchema.safeParse(input);
+    if (!parsed.success) {
+      return { success: false, errors: { _targetSite: [parsed.error.errors[0].message] } };
+    }
+
+    const { projectId, targetSiteId, name, baseUrl, auth } = parsed.data;
+
+    if (!(await requireProjectAccess(projectId))) {
+      return { success: false, errors: { _general: ['접근 권한이 없습니다.'] } };
+    }
+
+    const db = getDatabase();
+
+    const set: {
+      name?: string;
+      base_url?: string;
+      auth_secret_encrypted?: string | null;
+      updated_at: Date;
+    } = { updated_at: new Date() };
+
+    if (name !== undefined) set.name = name;
+    if (baseUrl !== undefined) set.base_url = baseUrl;
+    // auth 키가 input 에 실제로 들어온 경우에만 시크릿을 손댄다.
+    // (undefined 면 기존 유지, null 이면 제거, 객체면 교체)
+    if ('auth' in input) {
+      set.auth_secret_encrypted = auth == null ? null : encryptAuthSecret(auth);
+    }
+
+    const [row] = await db
+      .update(targetSites)
+      .set(set)
+      // project_id 까지 조건에 넣어 타 프로젝트 row 수정 차단(소유 검증 이중화).
+      .where(and(eq(targetSites.id, targetSiteId), eq(targetSites.project_id, projectId)))
+      .returning();
+
+    if (!row) {
+      return { success: false, errors: { _targetSite: ['테스트 대상을 찾을 수 없습니다.'] } };
+    }
+
+    return { success: true, data: { targetSite: toTargetSite(row) } };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'updateTargetSite' } });
+    return { success: false, errors: { _targetSite: ['테스트 대상 수정에 실패했습니다.'] } };
+  }
+};
+
+/** 테스트 대상 삭제. */
+export const deleteTargetSite = async (input: {
+  projectId: string;
+  targetSiteId: string;
+}): Promise<ActionResult<{ deleted: boolean }>> => {
+  try {
+    const parsed = DeleteTargetSiteSchema.safeParse(input);
+    if (!parsed.success) {
+      return { success: false, errors: { _targetSite: [parsed.error.errors[0].message] } };
+    }
+
+    const { projectId, targetSiteId } = parsed.data;
+
+    if (!(await requireProjectAccess(projectId))) {
+      return { success: false, errors: { _general: ['접근 권한이 없습니다.'] } };
+    }
+
+    const db = getDatabase();
+    const deleted = await db
+      .delete(targetSites)
+      .where(and(eq(targetSites.id, targetSiteId), eq(targetSites.project_id, projectId)))
+      .returning({ id: targetSites.id });
+
+    return { success: true, data: { deleted: deleted.length > 0 } };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'deleteTargetSite' } });
+    return { success: false, errors: { _targetSite: ['테스트 대상 삭제에 실패했습니다.'] } };
+  }
+};

--- a/apps/web/src/features/target-sites/hooks/index.ts
+++ b/apps/web/src/features/target-sites/hooks/index.ts
@@ -1,0 +1,7 @@
+export {
+  targetSiteKeys,
+  useTargetSites,
+  useCreateTargetSite,
+  useUpdateTargetSite,
+  useDeleteTargetSite,
+} from './use-target-sites';

--- a/apps/web/src/features/target-sites/hooks/use-target-sites.ts
+++ b/apps/web/src/features/target-sites/hooks/use-target-sites.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createTargetSite,
+  deleteTargetSite,
+  listTargetSites,
+  updateTargetSite,
+} from '../api/server-actions';
+import type {
+  CreateTargetSiteInput,
+  DeleteTargetSiteInput,
+  UpdateTargetSiteInput,
+} from '../model/schema';
+
+export const targetSiteKeys = {
+  all: ['target-sites'] as const,
+  list: (projectId: string) => [...targetSiteKeys.all, projectId] as const,
+};
+
+export const useTargetSites = (projectId: string | undefined) =>
+  useQuery({
+    queryKey: targetSiteKeys.list(projectId ?? ''),
+    queryFn: () => listTargetSites(projectId as string),
+    enabled: !!projectId,
+  });
+
+export const useCreateTargetSite = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateTargetSiteInput) => createTargetSite(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: targetSiteKeys.list(projectId) }),
+  });
+};
+
+export const useUpdateTargetSite = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateTargetSiteInput) => updateTargetSite(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: targetSiteKeys.list(projectId) }),
+  });
+};
+
+export const useDeleteTargetSite = (projectId: string) => {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: DeleteTargetSiteInput) => deleteTargetSite(input),
+    onSuccess: () => qc.invalidateQueries({ queryKey: targetSiteKeys.list(projectId) }),
+  });
+};

--- a/apps/web/src/features/target-sites/index.ts
+++ b/apps/web/src/features/target-sites/index.ts
@@ -1,0 +1,30 @@
+export {
+  targetSiteKeys,
+  useTargetSites,
+  useCreateTargetSite,
+  useUpdateTargetSite,
+  useDeleteTargetSite,
+} from './hooks';
+export {
+  createTargetSite,
+  listTargetSites,
+  updateTargetSite,
+  deleteTargetSite,
+} from './api/server-actions';
+export {
+  CreateTargetSiteSchema,
+  UpdateTargetSiteSchema,
+  DeleteTargetSiteSchema,
+  TargetSiteAuthSecretSchema,
+} from './model/schema';
+export type {
+  CreateTargetSiteInput,
+  UpdateTargetSiteInput,
+  DeleteTargetSiteInput,
+} from './model/schema';
+export type { TargetSite, TargetSiteAuthSecret } from './model/types';
+
+// 러너 주입용 복호화 함수는 서버 전용('server-only')이라 클라이언트 번들에 끌려가지
+// 않도록 본 배럴에서 노출하지 않는다. 러너 라우트 핸들러는 직접 import 한다:
+//   import { getTargetSiteForExecution } from '@/features/target-sites/api/get-target-site-for-execution';
+// (TargetSiteExecutionConfig 타입도 동일 경로 또는 model/types 에서 직접 import)

--- a/apps/web/src/features/target-sites/lib/auth-secret.ts
+++ b/apps/web/src/features/target-sites/lib/auth-secret.ts
@@ -1,0 +1,24 @@
+import { encrypt } from '@/shared/lib/crypto';
+
+import type { TargetSiteAuthSecret } from '../model/types';
+
+/**
+ * 인증 시크릿 객체에 실제 값이 하나라도 있는지 판별한다.
+ * 빈 객체나 빈 헤더/쿠키 맵은 "인증 없음"으로 본다.
+ */
+export function hasAuthValues(auth: TargetSiteAuthSecret | null | undefined): boolean {
+  if (!auth) return false;
+  if (auth.username || auth.password) return true;
+  if (auth.headers && Object.keys(auth.headers).length > 0) return true;
+  if (auth.cookies && Object.keys(auth.cookies).length > 0) return true;
+  return false;
+}
+
+/**
+ * 인증 시크릿을 암호화된 컬럼 값으로 변환한다.
+ * 값이 없으면 null 을 반환해 평문/빈 ciphertext 저장을 피한다.
+ */
+export function encryptAuthSecret(auth: TargetSiteAuthSecret | null | undefined): string | null {
+  if (!hasAuthValues(auth)) return null;
+  return encrypt(JSON.stringify(auth));
+}

--- a/apps/web/src/features/target-sites/model/schema.ts
+++ b/apps/web/src/features/target-sites/model/schema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+/**
+ * 인증 시크릿 입력 검증. 모든 필드 optional. 빈 객체는 "인증 없음"으로 취급한다.
+ * 헤더/쿠키 키·값 길이는 합리적 상한으로 제한해 비정상 payload 를 막는다.
+ */
+export const TargetSiteAuthSecretSchema = z.object({
+  username: z.string().max(500).optional(),
+  password: z.string().max(2000).optional(),
+  headers: z.record(z.string().max(200), z.string().max(4000)).optional(),
+  cookies: z.record(z.string().max(200), z.string().max(4000)).optional(),
+});
+
+const baseUrlSchema = z
+  .string()
+  .trim()
+  .url('올바른 URL 형식이 아닙니다.')
+  .max(2000)
+  .refine((v) => /^https?:\/\//i.test(v), {
+    message: 'http 또는 https 로 시작하는 주소를 입력해주세요.',
+  });
+
+export const CreateTargetSiteSchema = z.object({
+  projectId: z.string().uuid(),
+  name: z.string().trim().min(1, '대상 이름을 입력해주세요.').max(200),
+  baseUrl: baseUrlSchema,
+  /** 미지정이면 인증 없음으로 저장. */
+  auth: TargetSiteAuthSecretSchema.optional(),
+});
+
+export const UpdateTargetSiteSchema = z.object({
+  projectId: z.string().uuid(),
+  targetSiteId: z.string().uuid(),
+  name: z.string().trim().min(1, '대상 이름을 입력해주세요.').max(200).optional(),
+  baseUrl: baseUrlSchema.optional(),
+  /**
+   * 인증 갱신 의도 표현:
+   * - 필드 누락(undefined): 기존 시크릿 유지.
+   * - null: 기존 시크릿 제거.
+   * - 객체: 해당 값으로 교체.
+   */
+  auth: TargetSiteAuthSecretSchema.nullish(),
+});
+
+export const DeleteTargetSiteSchema = z.object({
+  projectId: z.string().uuid(),
+  targetSiteId: z.string().uuid(),
+});
+
+export type CreateTargetSiteInput = z.infer<typeof CreateTargetSiteSchema>;
+export type UpdateTargetSiteInput = z.infer<typeof UpdateTargetSiteSchema>;
+export type DeleteTargetSiteInput = z.infer<typeof DeleteTargetSiteSchema>;

--- a/apps/web/src/features/target-sites/model/types.ts
+++ b/apps/web/src/features/target-sites/model/types.ts
@@ -1,0 +1,51 @@
+/**
+ * 테스트 대상(target site) 도메인 타입.
+ *
+ * 인증 시크릿 평문(`TargetSiteAuthSecret`)은 서버 내부와 러너 주입 경로에서만 다룬다.
+ * 클라이언트로 내려가는 조회 타입(`TargetSite`)에는 시크릿 평문이 절대 포함되지 않고,
+ * 존재 여부(`hasAuth`)만 노출한다.
+ */
+
+/**
+ * 로그인 인증 정보의 유연한 구조. DB 에는 이 객체를 JSON 직렬화 후 AES-256-GCM 으로
+ * 암호화해 `target_sites.auth_secret_encrypted` 에 저장한다. 평문 저장 금지.
+ * 모든 필드 optional: 대상마다 필요한 인증 수단이 다르다(폼 로그인/헤더/쿠키 등).
+ */
+export type TargetSiteAuthSecret = {
+  /** 폼 로그인 사용자명. */
+  username?: string;
+  /** 폼 로그인 비밀번호. */
+  password?: string;
+  /** 요청에 주입할 커스텀 헤더 (예: Authorization, x-api-key). */
+  headers?: Record<string, string>;
+  /** 주입할 쿠키 (name → value). */
+  cookies?: Record<string, string>;
+};
+
+/**
+ * 클라이언트로 노출되는 테스트 대상. 시크릿 평문 없음.
+ * `hasAuth` 로 인증 정보 등록 여부만 표시한다.
+ */
+export type TargetSite = {
+  id: string;
+  projectId: string;
+  name: string;
+  baseUrl: string;
+  /** 인증 시크릿이 등록되어 있는지 여부. 평문은 노출하지 않는다. */
+  hasAuth: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * 러너(#186) 주입용. base_url + 복호화된 인증 시크릿.
+ * 서버 전용 경로(getTargetSiteForExecution)에서만 생성·반환된다.
+ */
+export type TargetSiteExecutionConfig = {
+  id: string;
+  projectId: string;
+  name: string;
+  baseUrl: string;
+  /** 복호화된 인증 정보. 등록 안 된 대상은 null. */
+  auth: TargetSiteAuthSecret | null;
+};

--- a/apps/web/src/view/project/settings/_components/target-sites-section.tsx
+++ b/apps/web/src/view/project/settings/_components/target-sites-section.tsx
@@ -1,0 +1,562 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  useCreateTargetSite,
+  useDeleteTargetSite,
+  useTargetSites,
+  useUpdateTargetSite,
+} from '@/features/target-sites';
+import type { TargetSite, TargetSiteAuthSecret } from '@/features/target-sites';
+import { DSButton, Dialog, DsInput, SettingsCard } from '@testea/ui';
+import { Globe, Info, KeyRound, Loader2, Pencil, Plus, ShieldOff, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface TargetSitesSectionProps {
+  projectId: string;
+}
+
+// 폼에서 다루는 인증 입력 모드.
+// - keep: 기존 시크릿 유지(수정 시 기본값). 등록 폼에는 없음.
+// - set: username/password 로 새 시크릿 저장 또는 교체.
+// - remove: 기존 시크릿 제거(수정 시에만 의미 있음).
+type AuthMode = 'keep' | 'set' | 'remove';
+
+interface DialogState {
+  mode: 'create' | 'edit';
+  target: TargetSite | null;
+}
+
+/**
+ * 프로젝트 설정 화면의 "테스트 대상" 섹션 (#188).
+ *
+ * - 등록된 대상 목록(name, baseUrl, 인증 설정 여부 hasAuth 배지)
+ * - 대상 추가/수정: 모달 폼. 인증은 username/password 로 입력하며 시크릿 평문은
+ *   저장 후 다시 표시되지 않는다(hasAuth 만 노출).
+ * - 수정 시 인증 모드: 유지(누락)/교체(객체)/제거(null) 를 라디오로 표현.
+ * - 삭제: 확인 다이얼로그.
+ *
+ * dev DB 에 target_sites 테이블이 아직 없을 수 있어 조회 실패/빈 상태에서도
+ * 화면이 깨지지 않도록 방어적으로 렌더한다.
+ */
+export const TargetSitesSection = ({ projectId }: TargetSitesSectionProps) => {
+  const listQuery = useTargetSites(projectId);
+  const createMutation = useCreateTargetSite(projectId);
+  const updateMutation = useUpdateTargetSite(projectId);
+  const deleteMutation = useDeleteTargetSite(projectId);
+
+  const [dialog, setDialog] = useState<DialogState | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<TargetSite | null>(null);
+
+  const sites = listQuery.data?.success ? listQuery.data.data : [];
+  const loadError = listQuery.data && !listQuery.data.success;
+
+  const handleDelete = () => {
+    if (!confirmDelete) return;
+    deleteMutation.mutate(
+      { projectId, targetSiteId: confirmDelete.id },
+      {
+        onSuccess: (result) => {
+          if (result.success) {
+            toast.success('테스트 대상을 삭제했습니다.');
+            setConfirmDelete(null);
+          } else {
+            toast.error(Object.values(result.errors).flat().join(', '));
+          }
+        },
+      }
+    );
+  };
+
+  return (
+    <>
+      <SettingsCard.Root>
+        <SettingsCard.Header
+          icon={<Globe className="h-5 w-5" />}
+          title="테스트 대상"
+          description="자동화 러너가 테스트를 실행할 대상 환경(base URL)과 로그인 인증 정보를 등록합니다."
+        />
+        <SettingsCard.Divider />
+
+        <SettingsCard.Body className="flex flex-col gap-4">
+          {/* 공개 접근 제약 안내 */}
+          <div className="bg-bg-3 border-line-2 flex items-start gap-2.5 rounded-md border p-3">
+            <Info className="text-text-3 mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+            <p className="typo-caption text-text-3 leading-relaxed">
+              테스트 대상은 러너가 외부에서 접근 가능한 환경이어야 합니다. 공개 스테이징처럼 외부
+              네트워크에서 도달 가능한 주소를 등록하세요. 로컬호스트나 사내망 전용 주소는 러너가
+              접근할 수 없습니다.
+            </p>
+          </div>
+
+          {/* 목록 */}
+          {listQuery.isLoading && (
+            <div className="text-text-3 flex items-center gap-2 py-6">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="typo-caption">불러오는 중...</span>
+            </div>
+          )}
+
+          {!listQuery.isLoading && loadError && (
+            <div className="border-line-2 text-text-3 typo-caption rounded-md border border-dashed px-4 py-6 text-center">
+              테스트 대상을 불러올 수 없습니다. 잠시 후 다시 시도해주세요.
+            </div>
+          )}
+
+          {!listQuery.isLoading && !loadError && sites.length === 0 && (
+            <div className="border-line-2 text-text-3 typo-caption rounded-md border border-dashed px-4 py-6 text-center">
+              등록된 테스트 대상이 없습니다. 대상을 추가해 자동화 실행 환경을 지정하세요.
+            </div>
+          )}
+
+          {!listQuery.isLoading && !loadError && sites.length > 0 && (
+            <ul className="flex flex-col gap-2">
+              {sites.map((site) => (
+                <li
+                  key={site.id}
+                  className="border-line-2 bg-bg-2 flex items-center justify-between gap-3 rounded-md border px-4 py-3"
+                >
+                  <div className="flex min-w-0 flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                      <span className="typo-body2-heading text-text-1 truncate">{site.name}</span>
+                      {site.hasAuth ? (
+                        <span className="typo-caption text-primary bg-primary/10 inline-flex items-center gap-1 rounded-full px-2 py-0.5">
+                          <KeyRound className="h-3 w-3" aria-hidden="true" />
+                          인증 설정됨
+                        </span>
+                      ) : (
+                        <span className="typo-caption text-text-4 bg-bg-3 inline-flex items-center gap-1 rounded-full px-2 py-0.5">
+                          <ShieldOff className="h-3 w-3" aria-hidden="true" />
+                          인증 없음
+                        </span>
+                      )}
+                    </div>
+                    <span className="typo-caption text-text-3 truncate font-mono">
+                      {site.baseUrl}
+                    </span>
+                  </div>
+
+                  <div className="flex shrink-0 gap-1">
+                    <DSButton
+                      variant="ghost"
+                      size="small"
+                      onClick={() => setDialog({ mode: 'edit', target: site })}
+                      aria-label={`${site.name} 수정`}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </DSButton>
+                    <DSButton
+                      variant="ghost"
+                      size="small"
+                      onClick={() => setConfirmDelete(site)}
+                      aria-label={`${site.name} 삭제`}
+                    >
+                      <Trash2 className="h-3.5 w-3.5 text-red-400" />
+                    </DSButton>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* 추가 버튼 */}
+          <div className="flex justify-end">
+            <DSButton
+              variant="solid"
+              size="small"
+              onClick={() => setDialog({ mode: 'create', target: null })}
+              className="shrink-0"
+            >
+              <span className="flex items-center gap-2">
+                <Plus className="h-3.5 w-3.5" />
+                대상 추가
+              </span>
+            </DSButton>
+          </div>
+        </SettingsCard.Body>
+      </SettingsCard.Root>
+
+      {/* 추가/수정 모달 */}
+      {dialog && (
+        <TargetSiteFormDialog
+          key={dialog.target?.id ?? 'create'}
+          projectId={projectId}
+          mode={dialog.mode}
+          target={dialog.target}
+          isPending={dialog.mode === 'create' ? createMutation.isPending : updateMutation.isPending}
+          onClose={() => setDialog(null)}
+          onSubmitCreate={(payload, onDone) =>
+            createMutation.mutate(payload, {
+              onSuccess: (result) => {
+                if (result.success) {
+                  toast.success('테스트 대상을 등록했습니다.');
+                  onDone();
+                } else {
+                  toast.error(Object.values(result.errors).flat().join(', '));
+                }
+              },
+            })
+          }
+          onSubmitUpdate={(payload, onDone) =>
+            updateMutation.mutate(payload, {
+              onSuccess: (result) => {
+                if (result.success) {
+                  toast.success('테스트 대상을 수정했습니다.');
+                  onDone();
+                } else {
+                  toast.error(Object.values(result.errors).flat().join(', '));
+                }
+              },
+            })
+          }
+        />
+      )}
+
+      {/* 삭제 확인 다이얼로그 */}
+      {confirmDelete && (
+        <Dialog.Root defaultOpen>
+          <Dialog.Portal>
+            <Dialog.Overlay
+              className="animate-in fade-in"
+              style={{
+                position: 'fixed',
+                inset: 0,
+                backgroundColor: 'rgba(0,0,0,0.5)',
+                zIndex: 1010,
+              }}
+            />
+            <Dialog.Content
+              className="bg-bg-2 w-full max-w-md rounded-2xl p-6 shadow-2xl"
+              style={{
+                position: 'fixed',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                zIndex: 1011,
+                outline: 'none',
+              }}
+            >
+              <div className="flex flex-col gap-4">
+                <Dialog.Title className="typo-h2-heading text-text-1">
+                  테스트 대상을 삭제할까요?
+                </Dialog.Title>
+                <Dialog.Description className="typo-body2-normal text-text-3">
+                  <strong className="text-text-1">{confirmDelete.name}</strong> 대상과 저장된 인증
+                  정보가 함께 삭제됩니다. 이 작업은 되돌릴 수 없습니다.
+                </Dialog.Description>
+                <div className="flex justify-end gap-2">
+                  <DSButton
+                    variant="ghost"
+                    size="small"
+                    onClick={() => setConfirmDelete(null)}
+                    disabled={deleteMutation.isPending}
+                  >
+                    취소
+                  </DSButton>
+                  <DSButton
+                    variant="text"
+                    size="small"
+                    className="bg-red-500/10 text-red-400 hover:bg-red-500/20 disabled:opacity-40"
+                    onClick={handleDelete}
+                    disabled={deleteMutation.isPending}
+                  >
+                    {deleteMutation.isPending ? (
+                      <span className="flex items-center gap-2">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        삭제 중...
+                      </span>
+                    ) : (
+                      <span className="flex items-center gap-2">
+                        <Trash2 className="h-3.5 w-3.5" />
+                        삭제
+                      </span>
+                    )}
+                  </DSButton>
+                </div>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      )}
+    </>
+  );
+};
+
+// ─── Form Dialog ─────────────────────────────────────────────────────────────
+
+interface TargetSiteFormDialogProps {
+  projectId: string;
+  mode: 'create' | 'edit';
+  target: TargetSite | null;
+  isPending: boolean;
+  onClose: () => void;
+  onSubmitCreate: (
+    payload: { projectId: string; name: string; baseUrl: string; auth?: TargetSiteAuthSecret },
+    onDone: () => void
+  ) => void;
+  onSubmitUpdate: (
+    payload: {
+      projectId: string;
+      targetSiteId: string;
+      name?: string;
+      baseUrl?: string;
+      auth?: TargetSiteAuthSecret | null;
+    },
+    onDone: () => void
+  ) => void;
+}
+
+const TargetSiteFormDialog = ({
+  projectId,
+  mode,
+  target,
+  isPending,
+  onClose,
+  onSubmitCreate,
+  onSubmitUpdate,
+}: TargetSiteFormDialogProps) => {
+  const [name, setName] = useState(target?.name ?? '');
+  const [baseUrl, setBaseUrl] = useState(target?.baseUrl ?? '');
+  // 등록: 인증 입력이 없으면 'keep'(=auth 미전송, 인증 없음으로 저장).
+  // 수정: 기존 인증이 있으면 기본 'keep'(유지), 없으면 'keep'(그대로 없음).
+  const [authMode, setAuthMode] = useState<AuthMode>('keep');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const isEdit = mode === 'edit';
+  const trimmedName = name.trim();
+  const trimmedBaseUrl = baseUrl.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedBaseUrl.length > 0 && !isPending;
+
+  // 'set' 모드인데 username/password 둘 다 비면 의미 없는 빈 시크릿이라 막는다.
+  const setModeEmpty = authMode === 'set' && !username.trim() && !password.trim();
+
+  const buildAuthSecret = (): TargetSiteAuthSecret => {
+    const secret: TargetSiteAuthSecret = {};
+    if (username.trim()) secret.username = username.trim();
+    if (password) secret.password = password;
+    return secret;
+  };
+
+  const handleSubmit = () => {
+    if (!canSubmit || setModeEmpty) return;
+
+    if (mode === 'create') {
+      const auth = authMode === 'set' ? buildAuthSecret() : undefined;
+      onSubmitCreate(
+        {
+          projectId,
+          name: trimmedName,
+          baseUrl: trimmedBaseUrl,
+          ...(auth ? { auth } : {}),
+        },
+        onClose
+      );
+      return;
+    }
+
+    if (!target) return;
+    // auth 의도: keep=키 누락(유지), remove=null(제거), set=객체(교체)
+    let auth: TargetSiteAuthSecret | null | undefined;
+    if (authMode === 'remove') auth = null;
+    else if (authMode === 'set') auth = buildAuthSecret();
+    else auth = undefined;
+
+    onSubmitUpdate(
+      {
+        projectId,
+        targetSiteId: target.id,
+        name: trimmedName,
+        baseUrl: trimmedBaseUrl,
+        // auth 키 자체를 조건부로 넣어 'keep' 일 때는 전송하지 않는다.
+        ...(auth === undefined ? {} : { auth }),
+      },
+      onClose
+    );
+  };
+
+  return (
+    <Dialog.Root defaultOpen>
+      <Dialog.Portal>
+        <Dialog.Overlay
+          className="animate-in fade-in"
+          style={{
+            position: 'fixed',
+            inset: 0,
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            zIndex: 1010,
+          }}
+        />
+        <Dialog.Content
+          className="bg-bg-2 w-full max-w-lg rounded-2xl p-6 shadow-2xl"
+          style={{
+            position: 'fixed',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            zIndex: 1011,
+            outline: 'none',
+          }}
+        >
+          <div className="flex max-h-[80vh] flex-col gap-4 overflow-y-auto">
+            <Dialog.Title className="typo-h2-heading text-text-1">
+              {isEdit ? '테스트 대상 수정' : '테스트 대상 추가'}
+            </Dialog.Title>
+
+            {/* 이름 */}
+            <label className="flex flex-col gap-1.5">
+              <span className="typo-caption text-text-2">대상 이름</span>
+              <DsInput
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="예: 스테이징 환경"
+                autoFocus
+              />
+            </label>
+
+            {/* base URL */}
+            <label className="flex flex-col gap-1.5">
+              <span className="typo-caption text-text-2">Base URL</span>
+              <DsInput
+                value={baseUrl}
+                onChange={(e) => setBaseUrl(e.target.value)}
+                placeholder="https://staging.example.com"
+              />
+              <span className="typo-caption text-text-4">
+                http 또는 https 로 시작하는 외부 접근 가능한 주소를 입력하세요.
+              </span>
+            </label>
+
+            {/* 인증 */}
+            <div className="border-line-2 flex flex-col gap-3 border-t pt-4">
+              <div className="flex flex-col gap-1">
+                <span className="typo-body2-heading text-text-1">로그인 인증 (선택)</span>
+                <span className="typo-caption text-text-4">
+                  저장된 시크릿은 보안상 다시 표시되지 않습니다. 변경하려면 새 값을 입력하세요.
+                </span>
+              </div>
+
+              {isEdit && (
+                <div className="bg-bg-3 border-line-2 typo-caption text-text-3 flex items-center gap-2 rounded-md border px-3 py-2">
+                  {target?.hasAuth ? (
+                    <>
+                      <KeyRound className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      현재 인증 정보가 저장되어 있습니다.
+                    </>
+                  ) : (
+                    <>
+                      <ShieldOff className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                      현재 저장된 인증 정보가 없습니다.
+                    </>
+                  )}
+                </div>
+              )}
+
+              {/* 인증 모드 선택 */}
+              <div className="flex flex-col gap-2">
+                <AuthModeOption
+                  checked={authMode === 'keep'}
+                  onChange={() => setAuthMode('keep')}
+                  label={
+                    isEdit
+                      ? target?.hasAuth
+                        ? '기존 인증 정보 유지'
+                        : '인증 없이 유지'
+                      : '인증 없이 등록'
+                  }
+                />
+                <AuthModeOption
+                  checked={authMode === 'set'}
+                  onChange={() => setAuthMode('set')}
+                  label={isEdit ? '인증 정보 새로 설정 / 교체' : '로그인 인증 추가'}
+                />
+                {isEdit && target?.hasAuth && (
+                  <AuthModeOption
+                    checked={authMode === 'remove'}
+                    onChange={() => setAuthMode('remove')}
+                    label="저장된 인증 정보 제거"
+                  />
+                )}
+              </div>
+
+              {authMode === 'set' && (
+                <div className="flex flex-col gap-3 pl-6">
+                  <label className="flex flex-col gap-1.5">
+                    <span className="typo-caption text-text-2">사용자명</span>
+                    <DsInput
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      placeholder="username"
+                      autoComplete="off"
+                    />
+                  </label>
+                  <label className="flex flex-col gap-1.5">
+                    <span className="typo-caption text-text-2">비밀번호</span>
+                    <DsInput
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      placeholder="password"
+                      autoComplete="new-password"
+                    />
+                  </label>
+                  {setModeEmpty && (
+                    <span className="typo-caption text-red-400">
+                      사용자명 또는 비밀번호 중 하나 이상을 입력하세요.
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <DSButton variant="ghost" size="small" onClick={onClose} disabled={isPending}>
+                취소
+              </DSButton>
+              <DSButton
+                variant="solid"
+                size="small"
+                onClick={handleSubmit}
+                disabled={!canSubmit || setModeEmpty}
+              >
+                {isPending ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    저장 중...
+                  </span>
+                ) : isEdit ? (
+                  '저장'
+                ) : (
+                  '추가'
+                )}
+              </DSButton>
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+// ─── Auth Mode Radio ─────────────────────────────────────────────────────────
+
+const AuthModeOption = ({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+}) => (
+  <label className="flex cursor-pointer items-center gap-2">
+    <input
+      type="radio"
+      checked={checked}
+      onChange={onChange}
+      className="accent-primary h-3.5 w-3.5"
+    />
+    <span className="typo-caption text-text-2">{label}</span>
+  </label>
+);

--- a/apps/web/src/view/project/settings/settings-view.tsx
+++ b/apps/web/src/view/project/settings/settings-view.tsx
@@ -19,6 +19,7 @@ import { GeneralSettingsSection } from './_components/general-settings-section';
 import { SecuritySection } from './_components/security-section';
 import { SettingsLoadingSkeleton } from './_components/settings-loading-skeleton';
 import { StorageSection } from './_components/storage-section';
+import { TargetSitesSection } from './_components/target-sites-section';
 
 // ─── Main View ───────────────────────────────────────────────────────────────
 
@@ -79,6 +80,9 @@ export const SettingsView = () => {
 
       {/* Section 5: Automation Token (FDD-TR09 V1) */}
       <AutomationTokenSection projectId={projectId} />
+
+      {/* Section 5b: Target Sites (#188) */}
+      <TargetSitesSection projectId={projectId} />
 
       {/* Section 6: Storage */}
       {storageData?.success && (

--- a/packages/db/drizzle/0013_target_sites.sql
+++ b/packages/db/drizzle/0013_target_sites.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "target_sites" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"project_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"base_url" text NOT NULL,
+	"auth_secret_encrypted" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "target_sites" ADD CONSTRAINT "target_sites_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+-- RLS deny-all: 정책을 만들지 않아 anon/authenticated 는 모든 접근이 거부된다.
+-- 서버(service_role)만 이 테이블에 접근한다. auth_secret_encrypted(시크릿)을 담으므로 필수.
+ALTER TABLE "target_sites" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "target_sites" FORCE ROW LEVEL SECURITY;

--- a/packages/db/drizzle/meta/0013_snapshot.json
+++ b/packages/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,2828 @@
+{
+  "id": "0a8999ce-5c99-4f39-833d-55b0fd37516f",
+  "prevId": "c21dde4c-420d-4d1b-8c09-17ce7f0020a6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_scenario_id": {
+          "name": "test_scenario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "test_suites_active_scenario_unq": {
+          "name": "test_suites_active_scenario_unq",
+          "columns": [
+            {
+              "expression": "test_scenario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"test_suites\".\"lifecycle_status\" = 'ACTIVE' AND \"test_suites\".\"test_scenario_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suites_test_scenario_id_test_scenarios_id_fk": {
+          "name": "test_suites_test_scenario_id_test_scenarios_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "test_scenarios",
+          "columnsFrom": [
+            "test_scenario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_key": {
+          "name": "case_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[10]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "automation_status": {
+          "name": "automation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_test_suite_id_test_suites_id_fk": {
+          "name": "test_cases_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_cases_section_id_test_suite_sections_id_fk": {
+          "name": "test_cases_section_id_test_suite_sections_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suite_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_cases_project_id_name_unique": {
+          "name": "test_cases_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        },
+        "test_cases_project_id_display_id_unique": {
+          "name": "test_cases_project_id_display_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "display_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_cases_automation_status_check": {
+          "name": "test_cases_automation_status_check",
+          "value": "\"test_cases\".\"automation_status\" in ('manual', 'candidate', 'automated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_STARTED'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_ai_summary": {
+          "name": "share_ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_milestone_id_milestones_id_fk": {
+          "name": "test_runs_milestone_id_milestones_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_runs_share_token_unique": {
+          "name": "test_runs_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_project_id_projects_id_fk": {
+          "name": "milestones_project_id_projects_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_runs": {
+      "name": "test_case_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'adhoc'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_source": {
+          "name": "result_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "automation_meta": {
+          "name": "automation_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_runs_test_run_id_test_runs_id_fk": {
+          "name": "test_case_runs_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_runs_test_case_id_test_cases_id_fk": {
+          "name": "test_case_runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_case_runs_result_source_check": {
+          "name": "test_case_runs_result_source_check",
+          "value": "\"test_case_runs\".\"result_source\" in ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_run_milestones": {
+      "name": "test_run_milestones",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_milestones_test_run_id_test_runs_id_fk": {
+          "name": "test_run_milestones_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_milestones_milestone_id_milestones_id_fk": {
+          "name": "test_run_milestones_milestone_id_milestones_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_milestones_test_run_id_milestone_id_pk": {
+          "name": "test_run_milestones_test_run_id_milestone_id_pk",
+          "columns": [
+            "test_run_id",
+            "milestone_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_run_suites": {
+      "name": "test_run_suites",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_suites_test_run_id_test_runs_id_fk": {
+          "name": "test_run_suites_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_suites_test_suite_id_test_suites_id_fk": {
+          "name": "test_run_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_suites_test_run_id_test_suite_id_pk": {
+          "name": "test_run_suites_test_run_id_test_suite_id_pk",
+          "columns": [
+            "test_run_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suite_test_cases": {
+      "name": "suite_test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suite_test_cases_suite_id_test_suites_id_fk": {
+          "name": "suite_test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suite_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "suite_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_cases": {
+      "name": "milestone_test_cases",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_cases_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_cases_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "milestone_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_cases_milestone_id_test_case_id_pk": {
+          "name": "milestone_test_cases_milestone_id_test_case_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_case_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_suites": {
+      "name": "milestone_test_suites",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_suites_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_suites_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_suites_test_suite_id_test_suites_id_fk": {
+          "name": "milestone_test_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_suites_milestone_id_test_suite_id_pk": {
+          "name": "milestone_test_suites_milestone_id_test_suite_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_preferences": {
+      "name": "project_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_preferences_project_id_projects_id_fk": {
+          "name": "project_preferences_project_id_projects_id_fk",
+          "tableFrom": "project_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_preferences_project_id_key_unique": {
+          "name": "project_preferences_project_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_project_id_projects_id_fk": {
+          "name": "audit_logs_project_id_projects_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_attachments": {
+      "name": "test_case_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_attachments_test_case_id_test_cases_id_fk": {
+          "name": "test_case_attachments_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_attachments_project_id_projects_id_fk": {
+          "name": "test_case_attachments_project_id_projects_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_templates": {
+      "name": "test_case_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_steps": {
+          "name": "test_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_templates_project_id_projects_id_fk": {
+          "name": "test_case_templates_project_id_projects_id_fk",
+          "tableFrom": "test_case_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_templates_project_id_name_unique": {
+          "name": "test_case_templates_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_versions": {
+      "name": "test_case_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_versions_test_case_id_test_cases_id_fk": {
+          "name": "test_case_versions_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_versions",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_versions_test_case_id_version_number_unique": {
+          "name": "test_case_versions_test_case_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_case_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suite_sections": {
+      "name": "test_suite_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suite_sections_suite_id_test_suites_id_fk": {
+          "name": "test_suite_sections_suite_id_test_suites_id_fk",
+          "tableFrom": "test_suite_sections",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_sections_suite_id_name_unique": {
+          "name": "test_suite_sections_suite_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suite_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklists_project_id_projects_id_fk": {
+          "name": "checklists_project_id_projects_id_fk",
+          "tableFrom": "checklists",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_checklist_id_checklists_id_fk": {
+          "name": "checklist_items_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_connections_project_id_projects_id_fk": {
+          "name": "github_connections_project_id_projects_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_project_id_unique": {
+          "name": "github_connections_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_external_links": {
+      "name": "test_case_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tc_ext_links_case": {
+          "name": "idx_tc_ext_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tc_ext_links_external": {
+          "name": "idx_tc_ext_links_external",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_case_external_links_test_case_id_test_cases_id_fk": {
+          "name": "test_case_external_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_external_links",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ai_configs": {
+      "name": "project_ai_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_ai_configs_project_id_projects_id_fk": {
+          "name": "project_ai_configs_project_id_projects_id_fk",
+          "tableFrom": "project_ai_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_ai_configs_project_id_unique": {
+          "name": "project_ai_configs_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generated_count": {
+          "name": "generated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_size_bytes": {
+          "name": "attached_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_page_count": {
+          "name": "attached_file_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_project_id_projects_id_fk": {
+          "name": "ai_usage_logs_project_id_projects_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_logs_attached_file_type_check": {
+          "name": "ai_usage_logs_attached_file_type_check",
+          "value": "\"ai_usage_logs\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_active_idx": {
+          "name": "announcements_active_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_category_idx": {
+          "name": "announcements_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reads": {
+      "name": "notification_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_reads_user_idx": {
+          "name": "notification_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_reads_announcement_idx": {
+          "name": "notification_reads_announcement_idx",
+          "columns": [
+            {
+              "expression": "announcement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reads_announcement_id_announcements_id_fk": {
+          "name": "notification_reads_announcement_id_announcements_id_fk",
+          "tableFrom": "notification_reads",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reads_user_announcement_unq": {
+          "name": "notification_reads_user_announcement_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "announcement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_tokens": {
+      "name": "project_automation_tokens",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_tokens_token_hash_unq": {
+          "name": "project_automation_tokens_token_hash_unq",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_tokens_project_id_projects_id_fk": {
+          "name": "project_automation_tokens_project_id_projects_id_fk",
+          "tableFrom": "project_automation_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_requirement_analyses": {
+      "name": "ai_requirement_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_input": {
+          "name": "source_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko'"
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_requirement_analyses_project_id_projects_id_fk": {
+          "name": "ai_requirement_analyses_project_id_projects_id_fk",
+          "tableFrom": "ai_requirement_analyses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_requirement_analyses_attached_file_type_check": {
+          "name": "ai_requirement_analyses_attached_file_type_check",
+          "value": "\"ai_requirement_analyses\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_scenarios": {
+      "name": "test_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "related_requirement_ids": {
+          "name": "related_requirement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_scenarios_project_id_projects_id_fk": {
+          "name": "test_scenarios_project_id_projects_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_scenarios_type_check": {
+          "name": "test_scenarios_type_check",
+          "value": "\"test_scenarios\".\"type\" in ('positive', 'negative', 'edge_case')"
+        },
+        "test_scenarios_status_check": {
+          "name": "test_scenarios_status_check",
+          "value": "\"test_scenarios\".\"status\" in ('DRAFT', 'REVIEW', 'CONFIRMED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.target_sites": {
+      "name": "target_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_secret_encrypted": {
+          "name": "auth_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_sites_project_id_projects_id_fk": {
+          "name": "target_sites_project_id_projects_id_fk",
+          "tableFrom": "target_sites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1780412332136,
       "tag": "0012_automation_status",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1780542183294,
+      "tag": "0013_target_sites",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -25,4 +25,5 @@ export * from './announcements';
 export * from './project-automation-tokens';
 export * from './ai-requirement-analyses';
 export * from './test-scenarios';
+export * from './target-sites';
 export * from './relations';

--- a/packages/db/src/schema/relations.ts
+++ b/packages/db/src/schema/relations.ts
@@ -13,6 +13,7 @@ import { projectAiConfigs } from './project-ai-configs';
 import { projectPreferences } from './project-preferences';
 import { projects } from './projects';
 import { suiteTestCases } from './suite-test-cases';
+import { targetSites } from './target-sites';
 import { testCaseExternalLinks } from './test-case-external-links';
 import { testCaseRuns } from './test-case-runs';
 import { testCaseVersions } from './test-case-versions';
@@ -37,6 +38,7 @@ export const projectRelations = relations(projects, ({ many }) => ({
   aiUsageLogs: many(aiUsageLogs),
   aiRequirementAnalyses: many(aiRequirementAnalyses),
   testScenarios: many(testScenarios),
+  targetSites: many(targetSites),
 }));
 
 // Project Preferences Relations
@@ -274,5 +276,13 @@ export const testCaseExternalLinksRelations = relations(testCaseExternalLinks, (
   testCase: one(testCases, {
     fields: [testCaseExternalLinks.test_case_id],
     references: [testCases.id],
+  }),
+}));
+
+// Target Site Relations
+export const targetSiteRelations = relations(targetSites, ({ one }) => ({
+  project: one(projects, {
+    fields: [targetSites.project_id],
+    references: [projects.id],
   }),
 }));

--- a/packages/db/src/schema/target-sites.ts
+++ b/packages/db/src/schema/target-sites.ts
@@ -1,0 +1,38 @@
+import { pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+import { projects } from './projects';
+
+/**
+ * target_sites: 프로젝트가 자동 실행 대행(FDD-TR10)을 위해 등록하는 테스트 대상 환경.
+ *
+ * 고객은 케이스만 등록하고 실행은 Testea 가 소유하므로, 테스트 대상의 주소와
+ * 로그인 인증·시크릿을 여기에 등록한다. 러너(#186)가 실행 시 이 row 를 복호화해
+ * 대상 환경에 인증 정보를 주입한다.
+ *
+ * - 한 프로젝트가 여러 대상(스테이징/프로덕션 등)을 가질 수 있어 1:N.
+ * - `auth_secret_encrypted`: 로그인 인증 정보 JSON 을 AES-256-GCM 으로 암호화한
+ *   base64 ciphertext. 평문 저장 금지. nullable (인증이 필요 없는 공개 대상도 허용).
+ *   암복호화는 `apps/web/src/shared/lib/crypto/encrypt.ts` 재사용.
+ * - RLS: anon deny-all 유지(ENABLE + FORCE, 정책 없음). 서버(service_role) 라우트만 접근.
+ *   시크릿을 담으므로 정책 누락은 곧 평문 노출 회귀.
+ *
+ * 자세한 명세: Notion FDD-TR10.
+ */
+export const targetSites = pgTable('target_sites', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  project_id: uuid('project_id')
+    .notNull()
+    .references(() => projects.id, { onDelete: 'cascade' }),
+  /** 대상 별칭 (예: "스테이징", "프로덕션"). 표시용. */
+  name: text('name').notNull(),
+  /** 테스트 대상 주소 (예: https://staging.example.com). 비밀 아님. */
+  base_url: text('base_url').notNull(),
+  /**
+   * 로그인 인증 정보(JSON)를 AES-256-GCM 으로 암호화한 base64 문자열.
+   * 평문 구조는 `TargetSiteAuthSecret` 참고 (username/password/headers/cookies 등 유연).
+   * 인증 불필요 시 NULL.
+   */
+  auth_secret_encrypted: text('auth_secret_encrypted'),
+  created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});


### PR DESCRIPTION
## 개요
FDD-TR10(수동 테스트케이스 자동 실행) 제품화의 일부입니다. 자동 실행 대행 포지션의 입력 부분으로, 고객이 테스트 대상 주소와 로그인 인증·시크릿을 등록하면 러너가 실행 시 주입합니다.

## 변경 사항
- 프로젝트별 테스트 대상(주소와 별칭)을 등록·수정·삭제한다.
- 대상 접근에 필요한 로그인 인증·시크릿을 암호화해 저장한다. 평문은 저장하지 않고, 저장 후 다시 표시하지 않으며 인증 설정 여부만 화면에 노출한다.
- 러너가 실행 시점에 대상 주소와 인증을 복호화해 주입할 수 있는 서버 전용 경로를 제공한다.
- 설정 화면에 테스트 대상 섹션을 추가하고, 대상이 외부에서 접근 가능한 환경이어야 한다는 제약을 안내한다.

## 검증
- 웹 타입체크 통과. 신규 테이블은 RLS deny-all로 서버 경유만 접근 가능.
- 시크릿은 기존 암호화 유틸을 재사용해 저장하며 조회 응답에 평문이 포함되지 않는다.

## 배포 전 확인
- [x] 대상 테이블 마이그레이션을 dev와 운영 DB에 수동 반영 완료 (이 저장소는 마이그레이션 수동 관리)

Closes #188