### PR TITLE
feat(TR10): 자동 실행 러너·연동·UI (#186)

### DIFF
--- a/apps/runner/.dockerignore
+++ b/apps/runner/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.runs
+*.log
+.git
+.gitignore
+.dockerignore
+Dockerfile
+fly.toml
+README.md

--- a/apps/runner/.gitignore
+++ b/apps/runner/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
 .runs
+test-results
 *.log

--- a/apps/runner/.gitignore
+++ b/apps/runner/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.runs
+*.log

--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -1,0 +1,35 @@
+# Base image bundles the Playwright browsers matching @playwright/test@1.60.0.
+# Keep this tag in lockstep with the resolved @playwright/test version in the lockfile.
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
+
+WORKDIR /app
+
+# Build context is this directory (apps/runner). fly.toml sets build.dockerfile
+# accordingly so the runner ships independently of the rest of the monorepo
+# (it has no @testea/* dependencies).
+
+# Corepack ships with the Node bundled in the Playwright image; pin pnpm to the
+# repo's packageManager version.
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
+
+# --- Dependency layer -------------------------------------------------------
+# Copy only the manifest first so this layer caches across spec/code changes.
+COPY package.json ./package.json
+
+# Browsers are already in the base image, so skip the post-install download.
+# --ignore-workspace keeps this install scoped to the runner (no root lockfile).
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
+RUN pnpm install --prod=false --ignore-workspace
+
+# --- Build ------------------------------------------------------------------
+COPY tsconfig.json ./tsconfig.json
+COPY src ./src
+RUN pnpm run build
+
+ENV NODE_ENV=production
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["node", "dist/server.js"]

--- a/apps/runner/README.md
+++ b/apps/runner/README.md
@@ -1,0 +1,101 @@
+# @testea/runner
+
+FDD-TR10 자동 실행 러너 서비스. **순수 Playwright 실행기**다.
+
+Testea 서버가 HTTP 로 이 러너를 호출하면, 러너는 받은 spec 코드를 격리 실행하고
+결과만 돌려준다. 러너는 DB 에 접근하지 않으며 (`@testea/*` 의존 없음), 결과 회수와
+Test Run 기록(TR09 auto-results)은 Testea 쪽이 담당한다.
+
+## 실행 방식 (PoC 에서 확정)
+
+- 요청마다 격리된 임시 디렉터리 + 자체 Playwright config 생성 (기존 앱 config 미사용).
+- `@playwright/test` CLI 를 `child_process` 로 실행하되 `--workers=1`, `stdio: 'ignore'`,
+  하드 타임아웃 적용.
+- 결과는 stdout 이 아니라 JSON reporter `outputFile` 에서 파싱 (버퍼 hang 회피).
+- 파싱 기준: `stats.expected`/`stats.unexpected` + 첫 test result 의 `status`/`duration`/`error.message`.
+
+## HTTP 계약
+
+### `GET /health`
+
+인증 예외. 200 `{ "ok": true }`.
+
+### `POST /run`
+
+인증 필요. 요청:
+
+```jsonc
+{
+  "spec": "import { test, expect } from '@playwright/test'; ...", // 필수, 단일 spec 소스
+  "baseUrl": "https://target.example.com", // 선택, config use.baseURL
+  "storageState": { "cookies": [], "origins": [] }, // 선택, config use.storageState
+  "timeoutMs": 60000, // 선택, 전체 하드 타임아웃 (기본 60s)
+}
+```
+
+응답:
+
+```jsonc
+{
+  "ok": true, // expected > 0 && unexpected === 0
+  "status": "passed", // passed | failed | timedOut | skipped | ...
+  "durationMs": 1234, // 첫 test result 의 duration
+  "errorMessage": "...", // 실패/타임아웃 시에만
+}
+```
+
+`spec` 누락/빈 문자열, 잘못된 `baseUrl`/`timeoutMs` 타입은 400.
+
+### 인증
+
+`/health` 를 제외한 모든 요청은 헤더 `X-Runner-Secret` 가 `RUNNER_SHARED_SECRET`
+환경변수와 일치해야 한다. 불일치는 401, 시크릿 미설정은 503.
+
+## 환경변수
+
+| 이름                   | 용도                                                |
+| ---------------------- | --------------------------------------------------- |
+| `PORT`                 | 리슨 포트 (기본 8080)                               |
+| `RUNNER_SHARED_SECRET` | Testea ↔ 러너 공유 시크릿. **Fly secret 으로 주입** |
+
+평문으로 코드/레포에 두지 않는다. 운영 주입:
+
+```bash
+fly secrets set RUNNER_SHARED_SECRET=... --app testea-runner
+```
+
+## 보안 전제
+
+`spec` 은 **임의 코드 실행**이다. 러너는 격리된 Fly 컨테이너에서만 돌고,
+공유 시크릿으로 인증된 Testea 호출만 받는다. 이 두 전제 밖에서는 절대 노출하지 않는다.
+
+대상 사이트 인증은 러너가 다루지 않는다. Testea 가 target_sites 시크릿을 복호화해
+`storageState`(쿠키/오리진 인증 상태)로 구성한 뒤 요청에 실어 보낸다.
+
+## 로컬 실행
+
+```bash
+pnpm --filter @testea/runner dev      # tsx watch
+# 또는
+pnpm --filter @testea/runner build && pnpm --filter @testea/runner start
+```
+
+```bash
+curl localhost:8080/health
+curl -X POST localhost:8080/run \
+  -H "X-Runner-Secret: $RUNNER_SHARED_SECRET" \
+  -H "content-type: application/json" \
+  -d '{"spec":"import {test,expect} from \"@playwright/test\"; test(\"t\", async()=>{expect(1).toBe(1);});"}'
+```
+
+## 배포 (Fly.io)
+
+```bash
+cd apps/runner
+fly apps create testea-runner          # 최초 1회
+fly secrets set RUNNER_SHARED_SECRET=...
+fly deploy --config fly.toml
+```
+
+베이스 이미지 `mcr.microsoft.com/playwright:v1.60.0-jammy` 는 `@playwright/test` 버전과
+같이 올려야 한다 (lockfile 의 resolved 버전과 Dockerfile 태그를 일치시킬 것).

--- a/apps/runner/fly.toml
+++ b/apps/runner/fly.toml
@@ -1,0 +1,42 @@
+# Fly.io configuration for the Testea Playwright runner.
+# Rename `app` before first deploy (e.g. `fly apps create testea-runner`).
+#
+# Build context is this directory so the runner deploys independently of the
+# monorepo. Deploy from apps/runner:  fly deploy --config fly.toml
+app = "testea-runner"
+primary_region = "nrt"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8080"
+  NODE_ENV = "production"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+  # Playwright runs are heavy and single-worker; keep concurrency conservative
+  # so one machine does not accept more runs than it can isolate cleanly.
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 1
+    hard_limit = 2
+
+[http_service.checks]
+  [[http_service.checks]]
+    method = "get"
+    path = "/health"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  # Playwright/Chromium needs headroom; 1GB is the practical floor for stable runs.
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/apps/runner/package.json
+++ b/apps/runner/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@testea/runner",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/server.js",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "start": "node dist/server.js",
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "@playwright/test": "^1.60.0",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5"
+  }
+}

--- a/apps/runner/src/capture.ts
+++ b/apps/runner/src/capture.ts
@@ -1,0 +1,69 @@
+import { chromium } from '@playwright/test';
+
+/**
+ * 대상 페이지 접근성 트리 캡처기. DB 에 접근하지 않는다.
+ *
+ * Testea(Vercel 서버리스)는 Playwright 를 못 돌리므로, 코드 생성 LLM 에 넣을
+ * 실시간 접근성 스냅샷 캡처를 러너가 대신한다. PoC 교훈 그대로:
+ * - `page.locator('main').ariaSnapshot()` 가 코드 생성 셀렉터 정확도의 핵심 입력.
+ * - main 이 없으면 body 로 fallback.
+ * - storageState 로 인증 상태를 주입(있으면)해 보호된 페이지도 캡처.
+ * - 로딩 스켈레톤(데이터 로딩 중 헤더 미렌더) 대비 networkidle 대기 + 넉넉한 타임아웃.
+ */
+
+export interface CaptureInput {
+  /** 캡처 대상 절대 URL. */
+  url: string;
+  /**
+   * 브라우저 컨텍스트에 주입할 storageState (쿠키/오리진). Testea 가 대상 인증으로
+   * 구성해 전달한다. 러너는 복호화/인증 구성을 하지 않는다.
+   */
+  storageState?: unknown;
+  /** 전체 캡처 하드 타임아웃 (ms). 기본 30s. */
+  timeoutMs?: number;
+}
+
+export interface CaptureResult {
+  /** 캡처 성공 여부. */
+  ok: boolean;
+  /** 성공 시 main(또는 body) 의 aria 스냅샷 문자열. */
+  snapshot?: string;
+  /** 실패 시 에러 메시지. */
+  errorMessage?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export async function capture(input: CaptureInput): Promise<CaptureResult> {
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext(
+      // storageState 는 Playwright 가 받는 형태({cookies, origins})를 그대로 전달.
+      // 잘못된 형태면 newContext 가 던지므로 호출부에서 try/catch 로 흡수된다.
+      input.storageState ? { storageState: input.storageState as never } : undefined
+    );
+    const page = await context.newPage();
+
+    await page.goto(input.url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+
+    // 데이터 로딩(스켈레톤) 후 본문이 채워질 때까지 대기. networkidle 실패는 치명적이지
+    // 않으므로(SPA 폴링 등) 흡수하고 캡처를 진행한다.
+    await page.waitForLoadState('networkidle', { timeout: timeoutMs }).catch(() => {});
+
+    const main = page.locator('main');
+    const target = (await main.count()) > 0 ? main.first() : page.locator('body');
+
+    const snapshot = await target.ariaSnapshot({ timeout: timeoutMs });
+
+    return { ok: true, snapshot };
+  } catch (error) {
+    return {
+      ok: false,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}

--- a/apps/runner/src/run-spec.ts
+++ b/apps/runner/src/run-spec.ts
@@ -1,0 +1,239 @@
+import { spawn } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * 순수 Playwright 실행기. DB 에 접근하지 않는다.
+ *
+ * PoC 에서 확정한 운영 교훈을 그대로 반영한다:
+ * - 요청마다 격리된 임시 디렉터리 + 자체 playwright config 를 생성한다 (기존 앱 config 미사용).
+ * - @playwright/test CLI 를 child_process 로 실행하되 workers=1, stdio 분리, 하드 타임아웃을 건다.
+ * - 결과는 stdout 이 아니라 JSON reporter outputFile 에서 파싱한다 (버퍼 hang 회피).
+ * - 결과 파싱은 stats.expected/unexpected + 첫 test result 의 status/duration/error.message 기준.
+ */
+
+export interface RunSpecInput {
+  /** 실행할 단일 Playwright spec 의 소스 코드. 임의 코드 실행이므로 격리 컨테이너 전제. */
+  spec: string;
+  /** config use.baseURL 로 주입. 대상 사이트 주소. */
+  baseUrl?: string;
+  /**
+   * config use.storageState 로 주입. Testea 가 대상 인증으로 구성해 전달하는
+   * 쿠키/오리진 인증 상태 객체. (러너는 복호화/인증 구성을 하지 않는다.)
+   */
+  storageState?: unknown;
+  /** 전체 실행 하드 타임아웃 (ms). 기본 60s. */
+  timeoutMs?: number;
+}
+
+export interface RunSpecResult {
+  /** 기대대로 통과했는지 (expected > 0 && unexpected === 0). */
+  ok: boolean;
+  /** 첫 test result 의 status: passed | failed | timedOut | skipped | interrupted | unknown. */
+  status: string;
+  /** 첫 test result 의 duration(ms). 없으면 전체 경과시간. */
+  durationMs: number;
+  /** 실패/타임아웃 시 첫 에러 메시지. 정상 통과 시 undefined. */
+  errorMessage?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+/**
+ * 러너 앱 루트 (이 모듈 기준 dist/ 또는 src/ 의 상위).
+ * 임시 실행 디렉터리를 이 루트 아래에 만들어, 생성한 playwright config 가
+ * @playwright/test 를 트리 상위 node_modules 에서 해석할 수 있게 한다.
+ * os tmpdir 에 두면 pnpm 심볼릭 레이아웃에서 모듈 해석이 깨진다.
+ */
+const APP_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const RUNS_ROOT = join(APP_ROOT, '.runs');
+
+/** child_process 환경에서 @playwright/test CLI 진입점 경로를 해석한다. */
+function resolvePlaywrightCli(): string {
+  const require = createRequire(import.meta.url);
+  // @playwright/test 의 cli 진입점. 패키지 내부 cli.js 를 직접 해석.
+  return require.resolve('@playwright/test/cli');
+}
+
+/** 임시 디렉터리에 자체 playwright config 와 spec 파일을 쓴다. */
+async function writeRunFiles(
+  dir: string,
+  input: RunSpecInput
+): Promise<{ specPath: string; configPath: string; reportPath: string }> {
+  const specPath = join(dir, 'run.spec.ts');
+  const configPath = join(dir, 'playwright.config.ts');
+  const reportPath = join(dir, 'report.json');
+  const storageStatePath = join(dir, 'storage-state.json');
+
+  await writeFile(specPath, input.spec, 'utf8');
+
+  const useEntries: string[] = [];
+  if (input.baseUrl) {
+    useEntries.push(`baseURL: ${JSON.stringify(input.baseUrl)}`);
+  }
+  if (input.storageState !== undefined && input.storageState !== null) {
+    await writeFile(storageStatePath, JSON.stringify(input.storageState), 'utf8');
+    useEntries.push(`storageState: ${JSON.stringify(storageStatePath)}`);
+  }
+  // chromium 만 사용 (베이스 이미지 내장 브라우저 재사용, 추가 다운로드 최소화).
+  useEntries.push(`browserName: 'chromium'`);
+
+  const config = `import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: ${JSON.stringify(dir)},
+  testMatch: ${JSON.stringify('run.spec.ts')},
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: [['json', { outputFile: ${JSON.stringify(reportPath)} }]],
+  use: {
+    ${useEntries.join(',\n    ')},
+  },
+});
+`;
+  await writeFile(configPath, config, 'utf8');
+
+  return { specPath, configPath, reportPath };
+}
+
+/** Playwright 에러 메시지의 ANSI 색상 코드를 제거한다 (Testea 기록용 평문). */
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
+function stripAnsi(value: string | undefined): string | undefined {
+  return value?.replace(ANSI_PATTERN, '');
+}
+
+/** Playwright JSON reporter 산출물에서 첫 test result 를 끌어낸다. */
+function parseReport(raw: string): RunSpecResult {
+  const report = JSON.parse(raw) as PlaywrightJsonReport;
+
+  const expected = report.stats?.expected ?? 0;
+  const unexpected = report.stats?.unexpected ?? 0;
+  const ok = expected > 0 && unexpected === 0;
+
+  const firstResult = findFirstResult(report);
+  const status = firstResult?.status ?? (ok ? 'passed' : 'unknown');
+  const durationMs = firstResult?.duration ?? report.stats?.duration ?? 0;
+  const errorMessage = stripAnsi(firstResult?.errors?.[0]?.message ?? firstResult?.error?.message);
+
+  return {
+    ok,
+    status,
+    durationMs,
+    errorMessage: ok ? undefined : errorMessage,
+  };
+}
+
+function findFirstResult(report: PlaywrightJsonReport): PwTestResult | undefined {
+  for (const suite of report.suites ?? []) {
+    const found = findResultInSuite(suite);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function findResultInSuite(suite: PwSuite): PwTestResult | undefined {
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      const result = test.results?.[0];
+      if (result) return result;
+    }
+  }
+  for (const child of suite.suites ?? []) {
+    const found = findResultInSuite(child);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export async function runSpec(input: RunSpecInput): Promise<RunSpecResult> {
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const startedAt = Date.now();
+  await mkdir(RUNS_ROOT, { recursive: true });
+  const dir = await mkdtemp(join(RUNS_ROOT, 'run-'));
+
+  try {
+    const { configPath, reportPath } = await writeRunFiles(dir, input);
+    const cli = resolvePlaywrightCli();
+
+    await new Promise<void>((resolve) => {
+      const child = spawn(process.execPath, [cli, 'test', '--config', configPath, '--workers=1'], {
+        cwd: dir,
+        // stdout/stderr 버퍼 hang 회피: 결과는 reporter outputFile 로만 읽는다.
+        stdio: 'ignore',
+        env: {
+          ...process.env,
+          // 컨테이너 내장 브라우저 경로 재사용 (베이스 이미지 ms-playwright).
+          CI: '1',
+        },
+      });
+
+      const killer = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, timeoutMs);
+
+      child.on('error', () => {
+        clearTimeout(killer);
+        resolve();
+      });
+      child.on('close', () => {
+        clearTimeout(killer);
+        resolve();
+      });
+    });
+
+    let raw: string | undefined;
+    try {
+      raw = await readFile(reportPath, 'utf8');
+    } catch {
+      raw = undefined;
+    }
+
+    if (!raw) {
+      // reporter 산출물이 없으면 (타임아웃 강제종료/크래시) 실패로 본다.
+      return {
+        ok: false,
+        status: 'timedOut',
+        durationMs: Date.now() - startedAt,
+        errorMessage: 'Run produced no report (timed out or crashed).',
+      };
+    }
+
+    return parseReport(raw);
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+// --- Playwright JSON reporter 최소 타입 (필요 필드만) ---
+
+interface PlaywrightJsonReport {
+  stats?: {
+    expected?: number;
+    unexpected?: number;
+    duration?: number;
+  };
+  suites?: PwSuite[];
+}
+
+interface PwSuite {
+  specs?: PwSpec[];
+  suites?: PwSuite[];
+}
+
+interface PwSpec {
+  tests?: PwTest[];
+}
+
+interface PwTest {
+  results?: PwTestResult[];
+}
+
+interface PwTestResult {
+  status?: string;
+  duration?: number;
+  error?: { message?: string };
+  errors?: Array<{ message?: string }>;
+}

--- a/apps/runner/src/server.ts
+++ b/apps/runner/src/server.ts
@@ -1,0 +1,136 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+
+import { capture } from './capture.js';
+import { runSpec } from './run-spec.js';
+
+const app = new Hono();
+
+const PORT = Number(process.env.PORT ?? 8080);
+const SHARED_SECRET = process.env.RUNNER_SHARED_SECRET;
+
+/**
+ * 헬스체크. 인증 예외.
+ */
+app.get('/health', (c) => c.json({ ok: true }));
+
+/**
+ * 공유 시크릿 인증 미들웨어. /health 를 제외한 전 경로에 적용.
+ * 헤더 X-Runner-Secret 가 RUNNER_SHARED_SECRET 와 일치해야 통과.
+ */
+app.use('*', async (c, next) => {
+  if (c.req.path === '/health') {
+    return next();
+  }
+
+  // 시크릿 미설정은 운영 사고. 어떤 요청도 통과시키지 않는다.
+  if (!SHARED_SECRET) {
+    return c.json({ ok: false, error: 'Runner is not configured.' }, 503);
+  }
+
+  const provided = c.req.header('X-Runner-Secret');
+  if (provided !== SHARED_SECRET) {
+    return c.json({ ok: false, error: 'Unauthorized.' }, 401);
+  }
+
+  return next();
+});
+
+interface RunRequestBody {
+  spec?: unknown;
+  baseUrl?: unknown;
+  storageState?: unknown;
+  timeoutMs?: unknown;
+}
+
+/**
+ * POST /run
+ * body: { spec: string, baseUrl?: string, storageState?: object, timeoutMs?: number }
+ * res:  { ok, status, durationMs, errorMessage }
+ *
+ * spec 은 임의 코드 실행이다. 격리 컨테이너 + 인증된 Testea 호출 전제.
+ */
+app.post('/run', async (c) => {
+  let body: RunRequestBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ ok: false, error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (typeof body.spec !== 'string' || body.spec.trim().length === 0) {
+    return c.json({ ok: false, error: 'Field "spec" (non-empty string) is required.' }, 400);
+  }
+
+  if (body.baseUrl !== undefined && typeof body.baseUrl !== 'string') {
+    return c.json({ ok: false, error: 'Field "baseUrl" must be a string.' }, 400);
+  }
+
+  if (
+    body.timeoutMs !== undefined &&
+    (typeof body.timeoutMs !== 'number' || !Number.isFinite(body.timeoutMs) || body.timeoutMs <= 0)
+  ) {
+    return c.json({ ok: false, error: 'Field "timeoutMs" must be a positive number.' }, 400);
+  }
+
+  const result = await runSpec({
+    spec: body.spec,
+    baseUrl: body.baseUrl,
+    storageState: body.storageState,
+    timeoutMs: body.timeoutMs,
+  });
+
+  return c.json(result);
+});
+
+interface CaptureRequestBody {
+  url?: unknown;
+  storageState?: unknown;
+  timeoutMs?: unknown;
+}
+
+/**
+ * POST /capture
+ * body: { url: string, storageState?: object, timeoutMs?: number }
+ * res:  { ok, snapshot?, errorMessage? }
+ *
+ * 대상 페이지를 열어 접근성 트리(main 또는 body 의 ariaSnapshot)를 반환한다.
+ * Testea 는 이 스냅샷을 코드 생성 LLM 입력으로 쓴다. /run 과 동일 인증.
+ */
+app.post('/capture', async (c) => {
+  let body: CaptureRequestBody;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ ok: false, error: 'Invalid JSON body.' }, 400);
+  }
+
+  if (typeof body.url !== 'string' || body.url.trim().length === 0) {
+    return c.json({ ok: false, error: 'Field "url" (non-empty string) is required.' }, 400);
+  }
+
+  if (
+    body.timeoutMs !== undefined &&
+    (typeof body.timeoutMs !== 'number' || !Number.isFinite(body.timeoutMs) || body.timeoutMs <= 0)
+  ) {
+    return c.json({ ok: false, error: 'Field "timeoutMs" must be a positive number.' }, 400);
+  }
+
+  const result = await capture({
+    url: body.url,
+    storageState: body.storageState,
+    timeoutMs: body.timeoutMs,
+  });
+
+  return c.json(result);
+});
+
+serve({ fetch: app.fetch, port: PORT }, (info) => {
+  // 시크릿 미설정 경고. 컨테이너 부팅 로그에서 바로 확인 가능.
+  if (!SHARED_SECRET) {
+    console.warn(
+      '[runner] RUNNER_SHARED_SECRET is not set. /run will reject all requests with 503.'
+    );
+  }
+  console.log(`[runner] listening on :${info.port}`);
+});

--- a/apps/runner/tsconfig.json
+++ b/apps/runner/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/web/src/features/auto-run/api/record-result.ts
+++ b/apps/web/src/features/auto-run/api/record-result.ts
@@ -1,0 +1,109 @@
+import {
+  type TestCaseRunResultSource,
+  type TestCaseRunStatus,
+  type TestRunStatus,
+  getDatabase,
+  testCaseRuns,
+  testCases,
+  testRuns,
+} from '@testea/db';
+import { and, eq, isNull } from 'drizzle-orm';
+import 'server-only';
+
+/**
+ * 자동 실행 결과를 TR09 방식으로 Run 에 기록한다.
+ *
+ * auto-results 라우트(app/api/.../auto-results/route.ts)와 동일한 정책:
+ * - 사용자가 미리 만든 Run 안의, 해당 case_key 를 가진 test_case_run 만 UPDATE.
+ * - result_source='auto', status, automation_meta, executed_at 설정.
+ * - 새 case_run 자동 생성 안 함(매칭 없으면 기록 실패로 반환).
+ * - 기록 후 Run 상태(untested 개수 기반) 재계산.
+ *
+ * 서버액션이 호출하는 단건 버전. 라우트는 토큰 인증·배치라 별도 유지한다.
+ */
+
+export interface RecordAutoResultInput {
+  runId: string;
+  caseKey: string;
+  status: TestCaseRunStatus;
+  comment?: string | null;
+  durationMs?: number;
+  errorMessage?: string;
+  meta?: { branch?: string; sha?: string; url?: string };
+}
+
+export interface RecordAutoResultOutcome {
+  /** case_key 가 Run 안의 case_run 과 매칭되어 기록됐는지. */
+  matched: boolean;
+}
+
+export async function recordAutoResult(
+  input: RecordAutoResultInput
+): Promise<RecordAutoResultOutcome> {
+  const db = getDatabase();
+
+  // Run 안에서 해당 case_key 의 case_run 찾기 (논리 삭제 제외).
+  const [target] = await db
+    .select({ caseRunId: testCaseRuns.id, caseKey: testCases.case_key })
+    .from(testCaseRuns)
+    .innerJoin(testCases, eq(testCaseRuns.test_case_id, testCases.id))
+    .where(
+      and(
+        eq(testCaseRuns.test_run_id, input.runId),
+        eq(testCases.case_key, input.caseKey),
+        isNull(testCaseRuns.excluded_at)
+      )
+    )
+    .limit(1);
+
+  if (!target) {
+    return { matched: false };
+  }
+
+  const automationMeta: Record<string, unknown> = {};
+  if (input.meta?.branch) automationMeta.branch = input.meta.branch;
+  if (input.meta?.sha) automationMeta.sha = input.meta.sha;
+  if (input.meta?.url) automationMeta.url = input.meta.url;
+  if (typeof input.durationMs === 'number') automationMeta.durationMs = input.durationMs;
+  if (input.errorMessage) automationMeta.errorMessage = input.errorMessage;
+
+  const now = new Date();
+  await db
+    .update(testCaseRuns)
+    .set({
+      status: input.status satisfies TestCaseRunStatus,
+      comment: input.comment ?? input.errorMessage ?? null,
+      executed_at: input.status !== 'untested' ? now : null,
+      result_source: 'auto' satisfies TestCaseRunResultSource,
+      automation_meta: Object.keys(automationMeta).length ? automationMeta : null,
+      updated_at: now,
+    })
+    .where(eq(testCaseRuns.id, target.caseRunId));
+
+  await recalcRunStatus(db, input.runId);
+
+  return { matched: true };
+}
+
+/** Run 상태 재계산 (auto-results route 와 동일 로직). */
+async function recalcRunStatus(db: ReturnType<typeof getDatabase>, testRunId: string) {
+  const rows = await db
+    .select({ status: testCaseRuns.status })
+    .from(testCaseRuns)
+    .where(and(eq(testCaseRuns.test_run_id, testRunId), isNull(testCaseRuns.excluded_at)));
+
+  if (rows.length === 0) return;
+
+  const untested = rows.filter((r) => r.status === 'untested').length;
+  const total = rows.length;
+
+  let next: TestRunStatus;
+  if (untested === total) next = 'NOT_STARTED';
+  else if (untested === 0) next = 'COMPLETED';
+  else next = 'IN_PROGRESS';
+
+  await db
+    .update(testRuns)
+    .set({ status: next, updated_at: new Date() })
+    .where(eq(testRuns.id, testRunId));
+}

--- a/apps/web/src/features/auto-run/api/run-automated-test.ts
+++ b/apps/web/src/features/auto-run/api/run-automated-test.ts
@@ -1,0 +1,167 @@
+'use server';
+
+import { requireProjectAccess } from '@/access/lib/require-access';
+import { getTargetSiteForExecution } from '@/features/target-sites/api/get-target-site-for-execution';
+import { ActionResult } from '@/shared/types';
+import * as Sentry from '@sentry/nextjs';
+import { getDatabase, testCases } from '@testea/db';
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { buildStorageState } from '../lib/build-storage-state';
+import { generateSpec } from '../lib/generate-spec';
+import { recordAutoResult } from './record-result';
+import { captureSnapshot, runSpecOnRunner } from './runner-client';
+
+/**
+ * FDD-TR10 자동 실행 오케스트레이션 (단건).
+ *
+ * Vercel(서버리스)에서 Playwright 를 못 돌리므로, 접근성 캡처와 spec 실행은 러너가 하고
+ * Testea 는 fetch + LLM + DB 만 한다. 흐름:
+ *   1) requireProjectAccess 가드
+ *   2) 케이스 조회(steps, case_key)
+ *   3) target_sites 복호화(baseUrl + auth → storageState)
+ *   4) 러너 /capture → 접근성 스냅샷
+ *   5) Gemini(2.5-flash-lite) → Playwright spec
+ *   6) 러너 /run → pass/fail
+ *   7) TR09 방식 결과 기록(result_source='auto')
+ *
+ * 스코프 밖: username/password 폼 로그인 자동화, 다중 케이스 배치, UI 버튼.
+ */
+
+export interface RunAutomatedTestParams {
+  projectId: string;
+  runId: string;
+  caseId: string;
+  targetSiteId: string;
+  /** 케이스가 가리키는 상대 경로(예: '/dashboard'). 없으면 baseUrl 루트 캡처. */
+  path?: string;
+}
+
+export interface RunAutomatedTestData {
+  /** 생성된 spec 요약(앞 N줄). 전체 spec 은 응답에 싣지 않는다. */
+  specPreview: string;
+  /** 러너 실행 status: passed | failed | timedOut | ... */
+  status: string;
+  /** 실행 소요(ms). */
+  durationMs: number;
+  /** 실패 시 에러 메시지. */
+  errorMessage?: string;
+  /** case_key 가 Run 안 case_run 과 매칭되어 기록됐는지. */
+  recorded: boolean;
+  /** 매칭에 사용한 case_key. */
+  caseKey: string;
+}
+
+function fail(message: string): ActionResult<RunAutomatedTestData> {
+  return { success: false, errors: { _general: [message] } };
+}
+
+function joinUrl(baseUrl: string, path?: string): string {
+  if (!path) return baseUrl;
+  const base = baseUrl.replace(/\/+$/, '');
+  const rel = path.startsWith('/') ? path : `/${path}`;
+  return `${base}${rel}`;
+}
+
+export async function runAutomatedTest(
+  params: RunAutomatedTestParams
+): Promise<ActionResult<RunAutomatedTestData>> {
+  try {
+    // 1) 접근 가드
+    if (!(await requireProjectAccess(params.projectId))) {
+      return fail('접근 권한이 없습니다.');
+    }
+
+    const db = getDatabase();
+
+    // 2) 케이스 조회 (steps 자연어, case_key)
+    const [testCase] = await db
+      .select({
+        id: testCases.id,
+        name: testCases.name,
+        steps: testCases.steps,
+        caseKey: testCases.case_key,
+        projectId: testCases.project_id,
+      })
+      .from(testCases)
+      .where(
+        and(
+          eq(testCases.id, params.caseId),
+          eq(testCases.project_id, params.projectId),
+          isNull(testCases.archived_at)
+        )
+      )
+      .limit(1);
+
+    if (!testCase) {
+      return fail('케이스를 찾을 수 없습니다.');
+    }
+    if (!testCase.caseKey) {
+      return fail('케이스에 case_key 가 없어 결과를 기록할 수 없습니다.');
+    }
+    if (!testCase.steps || !testCase.steps.trim()) {
+      return fail('케이스에 실행할 단계(steps)가 없습니다.');
+    }
+
+    // 3) 대상 사이트 복호화 (baseUrl + auth → storageState)
+    const target = await getTargetSiteForExecution(params.projectId, params.targetSiteId);
+    if (!target) {
+      return fail('테스트 대상을 찾을 수 없습니다.');
+    }
+
+    // auth 의 cookies 만 storageState 로 변환한다. username/password 폼 로그인
+    // 자동화는 이번 스코프 밖(주석). baseUrl 만으로도(비로그인) 동작한다.
+    const storageState = buildStorageState(target.auth, target.baseUrl);
+    const captureUrl = joinUrl(target.baseUrl, params.path);
+
+    // 4) 러너 /capture → 접근성 스냅샷
+    const captured = await captureSnapshot({
+      url: captureUrl,
+      storageState: storageState ?? undefined,
+    });
+    if (!captured.ok || !captured.snapshot) {
+      return fail(`대상 페이지 캡처 실패: ${captured.errorMessage ?? '알 수 없는 오류'}`);
+    }
+
+    // 5) Gemini → Playwright spec
+    const spec = await generateSpec({
+      steps: testCase.steps,
+      snapshot: captured.snapshot,
+      caseTitle: testCase.name,
+      path: params.path,
+    });
+
+    // 6) 러너 /run → pass/fail
+    const runResult = await runSpecOnRunner({
+      spec,
+      baseUrl: target.baseUrl,
+      storageState: storageState ?? undefined,
+    });
+
+    // 7) TR09 방식 결과 기록
+    const status = runResult.status === 'passed' ? 'pass' : 'fail';
+    const { matched } = await recordAutoResult({
+      runId: params.runId,
+      caseKey: testCase.caseKey,
+      status,
+      durationMs: runResult.durationMs,
+      errorMessage: runResult.errorMessage,
+    });
+
+    return {
+      success: true,
+      data: {
+        specPreview: spec.split('\n').slice(0, 12).join('\n'),
+        status: runResult.status,
+        durationMs: runResult.durationMs,
+        errorMessage: runResult.errorMessage,
+        recorded: matched,
+        caseKey: testCase.caseKey,
+      },
+    };
+  } catch (error) {
+    Sentry.captureException(error, { extra: { action: 'runAutomatedTest' } });
+    const message = error instanceof Error ? error.message : String(error);
+    return fail(`자동 실행 중 오류가 발생했습니다: ${message}`);
+  }
+}

--- a/apps/web/src/features/auto-run/api/run-automated-test.ts
+++ b/apps/web/src/features/auto-run/api/run-automated-test.ts
@@ -21,7 +21,7 @@ import { captureSnapshot, runSpecOnRunner } from './runner-client';
  *   2) 케이스 조회(steps, case_key)
  *   3) target_sites 복호화(baseUrl + auth → storageState)
  *   4) 러너 /capture → 접근성 스냅샷
- *   5) Gemini(2.5-flash-lite) → Playwright spec
+ *   5) OpenAI(gpt-4o-mini) → Playwright spec
  *   6) 러너 /run → pass/fail
  *   7) TR09 방식 결과 기록(result_source='auto')
  *
@@ -123,7 +123,7 @@ export async function runAutomatedTest(
       return fail(`대상 페이지 캡처 실패: ${captured.errorMessage ?? '알 수 없는 오류'}`);
     }
 
-    // 5) Gemini → Playwright spec
+    // 5) OpenAI → Playwright spec
     const spec = await generateSpec({
       steps: testCase.steps,
       snapshot: captured.snapshot,

--- a/apps/web/src/features/auto-run/api/runner-client.ts
+++ b/apps/web/src/features/auto-run/api/runner-client.ts
@@ -1,0 +1,103 @@
+import 'server-only';
+
+/**
+ * Testea → 자체 러너(apps/runner) HTTP 클라이언트.
+ *
+ * Vercel(서버리스)은 Playwright 를 못 돌리므로 접근성 캡처와 spec 실행을 러너가 한다.
+ * Testea 는 fetch + LLM + DB 만. 러너 접속 정보는 env 로 주입한다:
+ * - RUNNER_URL: 러너 베이스 URL (로컬 http://localhost:8080, prod 는 Fly URL).
+ * - RUNNER_SHARED_SECRET: 러너 인증 시크릿. X-Runner-Secret 헤더로 전송.
+ *
+ * 둘 중 하나라도 없으면 명확한 에러를 던져 호출부가 운영 설정 누락을 알게 한다.
+ */
+
+export class RunnerConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RunnerConfigError';
+  }
+}
+
+export class RunnerRequestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RunnerRequestError';
+  }
+}
+
+/** 러너 /capture 응답 계약. */
+export interface RunnerCaptureResponse {
+  ok: boolean;
+  snapshot?: string;
+  errorMessage?: string;
+}
+
+/** 러너 /run 응답 계약(run-spec.ts RunSpecResult 와 동형). */
+export interface RunnerRunResponse {
+  ok: boolean;
+  status: string;
+  durationMs: number;
+  errorMessage?: string;
+}
+
+function getRunnerConfig(): { url: string; secret: string } {
+  const url = process.env.RUNNER_URL;
+  const secret = process.env.RUNNER_SHARED_SECRET;
+  if (!url) {
+    throw new RunnerConfigError('RUNNER_URL is not set.');
+  }
+  if (!secret) {
+    throw new RunnerConfigError('RUNNER_SHARED_SECRET is not set.');
+  }
+  return { url: url.replace(/\/+$/, ''), secret };
+}
+
+async function postToRunner<T>(path: string, payload: unknown): Promise<T> {
+  const { url, secret } = getRunnerConfig();
+
+  let res: Response;
+  try {
+    res = await fetch(`${url}${path}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Runner-Secret': secret,
+      },
+      body: JSON.stringify(payload),
+      cache: 'no-store',
+    });
+  } catch (error) {
+    throw new RunnerRequestError(
+      `Failed to reach runner at ${url}${path}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!res.ok) {
+    throw new RunnerRequestError(`Runner ${path} responded ${res.status}.`);
+  }
+
+  return (await res.json()) as T;
+}
+
+/**
+ * 러너 /capture 호출: 대상 페이지 접근성 스냅샷을 받는다.
+ */
+export async function captureSnapshot(input: {
+  url: string;
+  storageState?: unknown;
+  timeoutMs?: number;
+}): Promise<RunnerCaptureResponse> {
+  return postToRunner<RunnerCaptureResponse>('/capture', input);
+}
+
+/**
+ * 러너 /run 호출: 생성된 spec 을 격리 실행하고 pass/fail 을 받는다.
+ */
+export async function runSpecOnRunner(input: {
+  spec: string;
+  baseUrl?: string;
+  storageState?: unknown;
+  timeoutMs?: number;
+}): Promise<RunnerRunResponse> {
+  return postToRunner<RunnerRunResponse>('/run', input);
+}

--- a/apps/web/src/features/auto-run/hooks/use-run-automated-test.ts
+++ b/apps/web/src/features/auto-run/hooks/use-run-automated-test.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { type RunAutomatedTestParams, runAutomatedTest } from '../api/run-automated-test';
+
+/**
+ * FDD-TR10 자동 실행 트리거 (단건). frontend 버튼이 이 훅으로 서버액션을 호출한다.
+ *
+ * 성공 시 해당 Run·대시보드 쿼리를 무효화해 기록된 결과가 화면에 반영되게 한다.
+ */
+export const useRunAutomatedTest = (projectId?: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: RunAutomatedTestParams) => {
+      const result = await runAutomatedTest(params);
+      if (!result.success) {
+        throw new Error(result.errors._general?.[0] ?? '자동 실행에 실패했습니다.');
+      }
+      return result.data;
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: projectId ? ['testRuns', projectId] : ['testRuns'],
+          refetchType: 'all',
+        }),
+        queryClient.invalidateQueries({ queryKey: ['dashboard'] }),
+      ]).catch(() => {});
+    },
+  });
+};

--- a/apps/web/src/features/auto-run/index.ts
+++ b/apps/web/src/features/auto-run/index.ts
@@ -1,0 +1,12 @@
+/**
+ * FDD-TR10 자동 실행(auto-run) feature.
+ *
+ * frontend(버튼)는 useRunAutomatedTest 훅으로 runAutomatedTest 서버액션을 호출한다.
+ * 러너 호출/캡처/spec 생성/결과 기록은 모두 서버 측에서 일어난다.
+ */
+export {
+  runAutomatedTest,
+  type RunAutomatedTestParams,
+  type RunAutomatedTestData,
+} from './api/run-automated-test';
+export { useRunAutomatedTest } from './hooks/use-run-automated-test';

--- a/apps/web/src/features/auto-run/lib/build-storage-state.ts
+++ b/apps/web/src/features/auto-run/lib/build-storage-state.ts
@@ -1,0 +1,61 @@
+import type { TargetSiteAuthSecret } from '@/features/target-sites/model/types';
+import 'server-only';
+
+/**
+ * Playwright storageState 최소 형태. 러너의 newContext({storageState}) 에 그대로 넘긴다.
+ */
+export interface PlaywrightStorageState {
+  cookies: Array<{
+    name: string;
+    value: string;
+    domain: string;
+    path: string;
+    expires: number;
+    httpOnly: boolean;
+    secure: boolean;
+    sameSite: 'Lax' | 'Strict' | 'None';
+  }>;
+  origins: Array<{ origin: string; localStorage: Array<{ name: string; value: string }> }>;
+}
+
+/**
+ * 대상 사이트 인증 시크릿을 Playwright storageState 로 변환한다.
+ *
+ * 이번 스코프: cookies / headers(쿠키화 불가하므로 storageState 로는 표현 못 함, 주석 참고)만.
+ * username/password 폼 로그인 자동화는 이번 스코프 밖이다(러너에서 로그인 시퀀스를
+ * 수행해야 하고 셀렉터 추론이 필요). 인증이 없거나 cookies 가 없으면 null 을 반환해
+ * baseUrl 만으로(비로그인 페이지) 동작하게 한다.
+ *
+ * 주의: HTTP 헤더(Authorization 등)는 storageState 로 표현할 수 없다. 헤더 주입이
+ * 필요한 대상은 러너 계약 확장(extraHTTPHeaders)이 별도로 필요하며 이번 스코프 밖이다.
+ *
+ * @param baseUrl 쿠키 domain 추론용 대상 베이스 URL.
+ */
+export function buildStorageState(
+  auth: TargetSiteAuthSecret | null,
+  baseUrl: string
+): PlaywrightStorageState | null {
+  if (!auth?.cookies || Object.keys(auth.cookies).length === 0) {
+    return null;
+  }
+
+  let domain: string;
+  try {
+    domain = new URL(baseUrl).hostname;
+  } catch {
+    return null;
+  }
+
+  const cookies = Object.entries(auth.cookies).map(([name, value]) => ({
+    name,
+    value,
+    domain,
+    path: '/',
+    expires: -1,
+    httpOnly: false,
+    secure: baseUrl.startsWith('https://'),
+    sameSite: 'Lax' as const,
+  }));
+
+  return { cookies, origins: [] };
+}

--- a/apps/web/src/features/auto-run/lib/generate-spec.ts
+++ b/apps/web/src/features/auto-run/lib/generate-spec.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+
+/**
+ * 케이스 자연어 steps + 대상 페이지 접근성 트리 → Playwright spec 코드 LLM 생성.
+ *
+ * PoC(2026-06-04)에서 확정한 레시피를 그대로 쓴다:
+ * - 모델: gemini-2.5-flash-lite (REST generateContent). gemini-2.0-flash 는 이 키에서
+ *   free quota 0(429) 이라 사용 금지. runs-share 의 요약과 동일 모델.
+ * - 입력: steps + 실시간 접근성 트리(role/name/level).
+ * - 규칙 프롬프트: 트리에 있는 role/name 만 getByRole, 추측 금지, 로딩 대비 첫 단언
+ *   timeout 30s, 마크다운 펜스 금지.
+ */
+
+const SPEC_SYSTEM_PROMPT = `너는 Playwright(@playwright/test, TypeScript) 테스트 코드 생성기다.
+입력으로 (1) 테스트 케이스의 자연어 단계, (2) 대상 페이지의 접근성 트리(aria snapshot)를 받는다.
+아래 규칙을 반드시 지켜 단일 spec 파일 코드만 출력한다.
+
+규칙:
+- 출력은 순수 TypeScript 코드만. 마크다운 코드펜스(\`\`\`), 설명 문장, 주석 머리말 금지.
+- import 는 \`import { test, expect } from '@playwright/test';\` 한 줄로 시작한다.
+- test 는 정확히 하나. test('...', async ({ page }) => { ... }).
+- 페이지 이동은 page.goto('/...') 처럼 상대 경로를 쓴다(baseURL 은 config 가 주입한다).
+- 셀렉터는 제공된 접근성 트리에 실제로 존재하는 role/name 만 getByRole(role, { name }) 로 쓴다.
+  트리에 없는 role/name/텍스트를 추측해서 만들지 않는다. 트리에 row role 이 없으면 getByText().first() 등으로 스코프한다.
+- 같은 이름이 여러 번 나오면 .first() 등으로 단일 요소로 좁힌다.
+- 첫 단언(또는 첫 상호작용 직전 대기)은 데이터 로딩 스켈레톤을 대비해 timeout 을 30000ms 로 넉넉히 준다.
+- 자연어 단계의 검증 의도를 expect 단언으로 옮긴다.`;
+
+export class SpecGenerationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SpecGenerationError';
+  }
+}
+
+/** 혹시 모델이 펜스를 붙여 반환하면 제거한다(프롬프트로 금지하지만 안전망). */
+function stripCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const fenced = trimmed.match(/^```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```$/);
+  return (fenced ? fenced[1] : trimmed).trim();
+}
+
+export async function generateSpec(input: {
+  steps: string;
+  snapshot: string;
+  caseTitle: string;
+  /** 케이스가 가리키는 경로(상대). 없으면 모델이 트리 기준으로 판단. */
+  path?: string;
+}): Promise<string> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new SpecGenerationError('GEMINI_API_KEY is not set.');
+  }
+
+  const userPrompt = [
+    `케이스 제목: ${input.caseTitle}`,
+    input.path ? `대상 경로: ${input.path}` : '',
+    '',
+    '자연어 단계:',
+    input.steps,
+    '',
+    '대상 페이지 접근성 트리:',
+    input.snapshot,
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+
+  let res: Response;
+  try {
+    res = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          system_instruction: { parts: [{ text: SPEC_SYSTEM_PROMPT }] },
+          contents: [{ parts: [{ text: userPrompt }] }],
+          generationConfig: { temperature: 0.1, maxOutputTokens: 2048 },
+        }),
+        cache: 'no-store',
+      }
+    );
+  } catch (error) {
+    throw new SpecGenerationError(
+      `Gemini request failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!res.ok) {
+    throw new SpecGenerationError(`Gemini responded ${res.status}.`);
+  }
+
+  const data = await res.json();
+  const text: string | undefined = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+  if (!text || !text.trim()) {
+    throw new SpecGenerationError('Gemini returned empty spec.');
+  }
+
+  const spec = stripCodeFence(text);
+  if (!spec.includes('@playwright/test')) {
+    throw new SpecGenerationError('Generated spec does not look like a Playwright spec.');
+  }
+  return spec;
+}

--- a/apps/web/src/features/auto-run/lib/generate-spec.ts
+++ b/apps/web/src/features/auto-run/lib/generate-spec.ts
@@ -3,9 +3,7 @@ import 'server-only';
 /**
  * 케이스 자연어 steps + 대상 페이지 접근성 트리 → Playwright spec 코드 LLM 생성.
  *
- * PoC(2026-06-04)에서 확정한 레시피를 그대로 쓴다:
- * - 모델: gemini-2.5-flash-lite (REST generateContent). gemini-2.0-flash 는 이 키에서
- *   free quota 0(429) 이라 사용 금지. runs-share 의 요약과 동일 모델.
+ * - 모델: OpenAI gpt-4o-mini (chat completions). 기존 Gemini 키 만료로 전환했다.
  * - 입력: steps + 실시간 접근성 트리(role/name/level).
  * - 규칙 프롬프트: 트리에 있는 role/name 만 getByRole, 추측 금지, 로딩 대비 첫 단언
  *   timeout 30s, 마크다운 펜스 금지.
@@ -47,9 +45,9 @@ export async function generateSpec(input: {
   /** 케이스가 가리키는 경로(상대). 없으면 모델이 트리 기준으로 판단. */
   path?: string;
 }): Promise<string> {
-  const apiKey = process.env.GEMINI_API_KEY;
+  const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
-    throw new SpecGenerationError('GEMINI_API_KEY is not set.');
+    throw new SpecGenerationError('OPENAI_API_KEY is not set.');
   }
 
   const userPrompt = [
@@ -67,33 +65,34 @@ export async function generateSpec(input: {
 
   let res: Response;
   try {
-    res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent?key=${apiKey}`,
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          system_instruction: { parts: [{ text: SPEC_SYSTEM_PROMPT }] },
-          contents: [{ parts: [{ text: userPrompt }] }],
-          generationConfig: { temperature: 0.1, maxOutputTokens: 2048 },
-        }),
-        cache: 'no-store',
-      }
-    );
+    res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: SPEC_SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.1,
+        max_tokens: 2048,
+      }),
+      cache: 'no-store',
+    });
   } catch (error) {
     throw new SpecGenerationError(
-      `Gemini request failed: ${error instanceof Error ? error.message : String(error)}`
+      `OpenAI request failed: ${error instanceof Error ? error.message : String(error)}`
     );
   }
 
   if (!res.ok) {
-    throw new SpecGenerationError(`Gemini responded ${res.status}.`);
+    throw new SpecGenerationError(`OpenAI responded ${res.status}.`);
   }
 
   const data = await res.json();
-  const text: string | undefined = data?.candidates?.[0]?.content?.parts?.[0]?.text;
+  const text: string | undefined = data?.choices?.[0]?.message?.content;
   if (!text || !text.trim()) {
-    throw new SpecGenerationError('Gemini returned empty spec.');
+    throw new SpecGenerationError('OpenAI returned empty spec.');
   }
 
   const spec = stripCodeFence(text);

--- a/apps/web/src/view/project/runs/_components/auto-run-dialog.tsx
+++ b/apps/web/src/view/project/runs/_components/auto-run-dialog.tsx
@@ -102,8 +102,12 @@ export const AutoRunDialog = ({
       }}
     >
       <Dialog.Portal>
-        <Dialog.Overlay />
-        <Dialog.Content className="bg-bg-1 rounded-8 max-h-[85vh] w-full max-w-lg overflow-y-auto p-6 shadow-xl">
+        {/* 자동 실행 중 실수로 바깥을 클릭해 실행이 끊기지 않도록 오버레이 클릭 닫힘을 막는다. */}
+        <Dialog.Overlay onClick={(e) => e.stopPropagation()} />
+        <Dialog.Content
+          closeOnEscape={false}
+          className="bg-bg-1 rounded-8 max-h-[85vh] w-full max-w-lg overflow-y-auto p-6 shadow-xl"
+        >
           <Dialog.Title className="text-text-1 text-lg font-semibold">자동 실행</Dialog.Title>
           <Dialog.Description className="text-text-3 mt-2 text-sm">
             등록된 테스트 대상에 대해 케이스 단계를 자동으로 실행하고 결과를 이 실행에 기록합니다.

--- a/apps/web/src/view/project/runs/_components/auto-run-dialog.tsx
+++ b/apps/web/src/view/project/runs/_components/auto-run-dialog.tsx
@@ -1,0 +1,265 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+
+import Link from 'next/link';
+
+import { type RunAutomatedTestData } from '@/features/auto-run';
+import { useRunAutomatedTest } from '@/features/auto-run';
+import { useTargetSites } from '@/features/target-sites';
+import { DSButton, Dialog, DsInput, DsSelect } from '@testea/ui';
+import { cn } from '@testea/util';
+import { AlertTriangle, CheckCircle2, ChevronDown, Loader2, XCircle } from 'lucide-react';
+import { toast } from 'sonner';
+
+interface AutoRunCaseOption {
+  /** testCaseRun 의 원본 케이스 id (= caseId, runAutomatedTest 입력). */
+  testCaseId: string;
+  code: string;
+  title: string;
+}
+
+interface AutoRunDialogProps {
+  projectId: string | undefined;
+  projectSlug: string;
+  runId: string;
+  cases: AutoRunCaseOption[];
+  /** 단건 트리거(행 액션)로 진입 시 미리 선택된 케이스. */
+  initialCaseId?: string;
+  onClose: () => void;
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  passed: '통과',
+  failed: '실패',
+  timedOut: '시간 초과',
+};
+
+export const AutoRunDialog = ({
+  projectId,
+  projectSlug,
+  runId,
+  cases,
+  initialCaseId,
+  onClose,
+}: AutoRunDialogProps) => {
+  const { data: targetSitesData, isLoading: isLoadingTargets } = useTargetSites(projectId);
+  const targetSites = useMemo(
+    () => (targetSitesData?.success ? targetSitesData.data : []),
+    [targetSitesData]
+  );
+
+  const runAutomatedTest = useRunAutomatedTest(projectId);
+
+  const [targetSiteId, setTargetSiteId] = useState('');
+  const [caseId, setCaseId] = useState(initialCaseId ?? cases[0]?.testCaseId ?? '');
+  const [path, setPath] = useState('');
+  const [result, setResult] = useState<RunAutomatedTestData | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showSpec, setShowSpec] = useState(false);
+
+  const targetOptions = useMemo(
+    () => targetSites.map((site) => ({ value: site.id, label: `${site.name} (${site.baseUrl})` })),
+    [targetSites]
+  );
+
+  const caseOptions = useMemo(
+    () => cases.map((c) => ({ value: c.testCaseId, label: `${c.code}  ${c.title}` })),
+    [cases]
+  );
+
+  const noTargets = !isLoadingTargets && targetSites.length === 0;
+  const isPending = runAutomatedTest.isPending;
+  const canSubmit = !!projectId && !!targetSiteId && !!caseId && !isPending;
+
+  const handleSubmit = () => {
+    if (!projectId || !targetSiteId || !caseId) return;
+    setResult(null);
+    setErrorMessage(null);
+    setShowSpec(false);
+    runAutomatedTest.mutate(
+      { projectId, runId, caseId, targetSiteId, path: path.trim() || undefined },
+      {
+        onSuccess: (data) => {
+          setResult(data);
+          if (data.status === 'passed') {
+            toast.success('자동 실행이 통과했습니다.');
+          } else {
+            toast.error(`자동 실행 결과: ${STATUS_LABEL[data.status] ?? data.status}`);
+          }
+        },
+        onError: (error) =>
+          setErrorMessage(error instanceof Error ? error.message : '자동 실행에 실패했습니다.'),
+      }
+    );
+  };
+
+  return (
+    <Dialog.Root
+      defaultOpen
+      onOpenChange={(open) => {
+        if (!open && !isPending) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay />
+        <Dialog.Content className="bg-bg-1 rounded-8 max-h-[85vh] w-full max-w-lg overflow-y-auto p-6 shadow-xl">
+          <Dialog.Title className="text-text-1 text-lg font-semibold">자동 실행</Dialog.Title>
+          <Dialog.Description className="text-text-3 mt-2 text-sm">
+            등록된 테스트 대상에 대해 케이스 단계를 자동으로 실행하고 결과를 이 실행에 기록합니다.
+            대상 페이지 캡처와 실행에 수 초에서 수십 초가 걸릴 수 있습니다.
+          </Dialog.Description>
+
+          {noTargets ? (
+            <div className="border-line-2 bg-bg-2 rounded-4 mt-5 border p-4">
+              <div className="text-text-2 flex items-start gap-2 text-sm">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-400" />
+                <p>등록된 테스트 대상이 없습니다. 설정에서 테스트 대상을 먼저 등록하세요.</p>
+              </div>
+              <div className="mt-4 flex justify-end gap-3">
+                <DSButton variant="ghost" onClick={onClose}>
+                  닫기
+                </DSButton>
+                <Link href={`/projects/${projectSlug}/settings`}>
+                  <DSButton variant="solid">설정으로 이동</DSButton>
+                </Link>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-5 space-y-4">
+              {/* 대상 사이트 */}
+              <div className="space-y-1.5">
+                <label className="text-text-2 text-sm font-medium">대상 사이트</label>
+                <DsSelect
+                  value={targetSiteId}
+                  onChange={setTargetSiteId}
+                  options={targetOptions}
+                  placeholder={isLoadingTargets ? '불러오는 중...' : '대상 사이트를 선택하세요'}
+                  disabled={isLoadingTargets || isPending}
+                />
+              </div>
+
+              {/* 케이스 */}
+              <div className="space-y-1.5">
+                <label className="text-text-2 text-sm font-medium">실행할 케이스</label>
+                <DsSelect
+                  value={caseId}
+                  onChange={setCaseId}
+                  options={caseOptions}
+                  placeholder="케이스를 선택하세요"
+                  disabled={isPending}
+                />
+              </div>
+
+              {/* 경로 (선택) */}
+              <div className="space-y-1.5">
+                <label className="text-text-2 text-sm font-medium">
+                  경로 <span className="text-text-4 font-normal">(선택)</span>
+                </label>
+                <DsInput
+                  value={path}
+                  onChange={(e) => setPath(e.target.value)}
+                  placeholder="/dashboard (비우면 대상 URL 루트)"
+                  disabled={isPending}
+                />
+              </div>
+
+              {/* 진행 중 안내 */}
+              {isPending && (
+                <div className="text-text-3 flex items-center gap-2 text-sm">
+                  <Loader2 className="text-primary h-4 w-4 animate-spin" />
+                  <span>자동 실행 중입니다. 페이지를 벗어나지 마세요...</span>
+                </div>
+              )}
+
+              {/* 에러 결과 */}
+              {errorMessage && (
+                <div className="rounded-4 border border-red-500/30 bg-red-500/10 p-3">
+                  <div className="flex items-start gap-2 text-sm text-red-400">
+                    <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                    <p className="break-words">{errorMessage}</p>
+                  </div>
+                </div>
+              )}
+
+              {/* 성공/실행 결과 */}
+              {result && (
+                <div className="border-line-2 bg-bg-2 rounded-4 space-y-3 border p-3">
+                  <ResultStatus status={result.status} durationMs={result.durationMs} />
+
+                  {result.status !== 'passed' && result.errorMessage && (
+                    <div className="border-line-2 bg-bg-1 rounded-2 border p-2">
+                      <p className="text-text-4 text-xs font-medium">실패 메시지</p>
+                      <p className="text-text-2 mt-1 text-xs break-words whitespace-pre-wrap">
+                        {result.errorMessage}
+                      </p>
+                    </div>
+                  )}
+
+                  {!result.recorded && (
+                    <div className="text-text-3 flex items-start gap-1.5 text-xs">
+                      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-400" />
+                      <span>
+                        case_key &quot;{result.caseKey}&quot; 가 이 실행의 케이스와 매칭되지 않아
+                        결과가 기록되지 않았습니다.
+                      </span>
+                    </div>
+                  )}
+
+                  {/* spec 미리보기 (접기/펼치기) */}
+                  {result.specPreview && (
+                    <div>
+                      <button
+                        type="button"
+                        onClick={() => setShowSpec((prev) => !prev)}
+                        className="text-text-3 hover:text-text-1 flex items-center gap-1 text-xs transition-colors"
+                      >
+                        <ChevronDown
+                          className={cn(
+                            'h-3.5 w-3.5 transition-transform',
+                            showSpec && 'rotate-180'
+                          )}
+                        />
+                        생성된 spec 미리보기
+                      </button>
+                      {showSpec && (
+                        <pre className="border-line-2 bg-bg-1 rounded-2 text-text-2 mt-2 max-h-48 overflow-auto border p-2 text-[11px] leading-relaxed">
+                          {result.specPreview}
+                        </pre>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className="flex justify-end gap-3 pt-1">
+                <DSButton variant="ghost" onClick={onClose} disabled={isPending}>
+                  {result || errorMessage ? '닫기' : '취소'}
+                </DSButton>
+                <DSButton variant="solid" onClick={handleSubmit} disabled={!canSubmit}>
+                  {isPending ? '실행 중...' : result || errorMessage ? '다시 실행' : '자동 실행'}
+                </DSButton>
+              </div>
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+const ResultStatus = ({ status, durationMs }: { status: string; durationMs: number }) => {
+  const passed = status === 'passed';
+  const label = STATUS_LABEL[status] ?? status;
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      {passed ? (
+        <CheckCircle2 className="h-4 w-4 shrink-0 text-green-400" />
+      ) : (
+        <XCircle className="h-4 w-4 shrink-0 text-red-400" />
+      )}
+      <span className={cn('font-medium', passed ? 'text-green-400' : 'text-red-400')}>{label}</span>
+      <span className="text-text-4 text-xs">· {(durationMs / 1000).toFixed(1)}초</span>
+    </div>
+  );
+};

--- a/apps/web/src/view/project/runs/_components/index.ts
+++ b/apps/web/src/view/project/runs/_components/index.ts
@@ -25,4 +25,5 @@ export { RunsListToolbar } from './runs-list-toolbar';
 export { RunsListTable } from './runs-list-table';
 export { DeleteRunDialog } from './delete-run-dialog';
 export { RerunRunDialog } from './rerun-run-dialog';
+export { AutoRunDialog } from './auto-run-dialog';
 export { SuiteSourceName } from './suite-source-name';

--- a/apps/web/src/view/project/runs/_components/run-detail-header.tsx
+++ b/apps/web/src/view/project/runs/_components/run-detail-header.tsx
@@ -20,6 +20,7 @@ import {
   Pencil,
   RotateCcw,
   X,
+  Zap,
 } from 'lucide-react';
 
 import { SOURCE_TYPE_CONFIG } from './run-detail-constants';
@@ -35,6 +36,7 @@ interface RunDetailHeaderProps {
   onToggleCharts: () => void;
   onRerun: () => void;
   isRerunning: boolean;
+  onAutoRun: () => void;
 }
 
 export const RunDetailHeader = ({
@@ -48,6 +50,7 @@ export const RunDetailHeader = ({
   onToggleCharts,
   onRerun,
   isRerunning,
+  onAutoRun,
 }: RunDetailHeaderProps) => {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editTitle, setEditTitle] = useState('');
@@ -161,6 +164,14 @@ export const RunDetailHeader = ({
 
         {/* Actions */}
         <div className="flex shrink-0 items-center gap-1.5">
+          <button
+            onClick={onAutoRun}
+            className="rounded-1 text-text-3 hover:text-text-1 hover:bg-bg-2 p-1.5 transition-colors"
+            aria-label="자동 실행"
+            title="자동 실행"
+          >
+            <Zap className="h-4 w-4" />
+          </button>
           <button
             onClick={onRerun}
             disabled={isRerunning}

--- a/apps/web/src/view/project/runs/test-run-detail-view.tsx
+++ b/apps/web/src/view/project/runs/test-run-detail-view.tsx
@@ -22,6 +22,7 @@ import { MainContainer } from '@testea/ui';
 import { toast } from 'sonner';
 
 import {
+  AutoRunDialog,
   type GroupedCases,
   KeyboardShortcutsModal,
   RemoveSuiteDialog,
@@ -98,6 +99,7 @@ export const TestRunDetailView = () => {
     null
   );
   const [showRerunDialog, setShowRerunDialog] = useState(false);
+  const [showAutoRunDialog, setShowAutoRunDialog] = useState(false);
   const [showStatusFilterDropdown, setShowStatusFilterDropdown] = useState(false);
   const [showSuiteFilterDropdown, setShowSuiteFilterDropdown] = useState(false);
   const statusFilterRef = React.useRef<HTMLDivElement>(null);
@@ -367,6 +369,7 @@ export const TestRunDetailView = () => {
         onToggleCharts={() => setShowCharts((prev) => !prev)}
         onRerun={() => setShowRerunDialog(true)}
         isRerunning={rerunMutation.isPending}
+        onAutoRun={() => setShowAutoRunDialog(true)}
       />
 
       <RunSummaryBar stats={testRun.stats} />
@@ -442,6 +445,21 @@ export const TestRunDetailView = () => {
           isPending={rerunMutation.isPending}
           onConfirm={handleRerunConfirm}
           onCancel={() => setShowRerunDialog(false)}
+        />
+      )}
+
+      {showAutoRunDialog && (
+        <AutoRunDialog
+          projectId={projectId}
+          projectSlug={projectSlug}
+          runId={testRunId}
+          cases={testRun.testCaseRuns.map((tc) => ({
+            testCaseId: tc.testCaseId,
+            code: tc.code,
+            title: tc.title,
+          }))}
+          initialCaseId={selectedCaseId ?? undefined}
+          onClose={() => setShowAutoRunDialog(false)}
         />
       )}
     </MainContainer>

--- a/packages/ui/src/primitives/dialog/dialog.tsx
+++ b/packages/ui/src/primitives/dialog/dialog.tsx
@@ -122,8 +122,10 @@ const DialogOverlay = ({ className, ...props }: DialogOverlayProps) => {
 interface DialogContentProps extends React.HTMLAttributes<HTMLDivElement> {
   className?: string;
   ref?: React.Ref<HTMLDivElement>;
+  /** ESC 키로 닫기 허용 여부. 기본 true. 실행 중 실수 종료를 막아야 하는 모달은 false. */
+  closeOnEscape?: boolean;
 }
-const DialogContent = ({ className, ref, ...props }: DialogContentProps) => {
+const DialogContent = ({ className, ref, closeOnEscape = true, ...props }: DialogContentProps) => {
   const { titleId, descriptionId, onClose } = useDialogContext();
   const contentRef = React.useRef<HTMLDivElement>(null);
 
@@ -139,8 +141,10 @@ const DialogContent = ({ className, ref, ...props }: DialogContentProps) => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // ESC 키로 닫기
       if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
+        if (closeOnEscape) {
+          e.preventDefault();
+          onClose();
+        }
         return;
       }
 
@@ -174,7 +178,7 @@ const DialogContent = ({ className, ref, ...props }: DialogContentProps) => {
       // 다이얼로그 닫힐 때 이전 포커스로 복원
       previousActiveElement?.focus();
     };
-  }, [onClose]);
+  }, [onClose, closeOnEscape]);
 
   return (
     <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,7 +125,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.10
-        version: 16.0.10(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.10(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -141,6 +141,28 @@ importers:
       vitest:
         specifier: ^4.1.5
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@27.4.0)(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
+  apps/runner:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.23)
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.23
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.2
+        version: 25.6.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
 
   apps/web:
     dependencies:
@@ -333,7 +355,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.10
-        version: 16.0.10(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.10(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -1744,6 +1766,12 @@ packages:
 
   '@formatjs/intl-localematcher@0.8.9':
     resolution: {integrity: sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw==}
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -5153,6 +5181,10 @@ packages:
 
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
+
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+    engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -8958,6 +8990,10 @@ snapshots:
     dependencies:
       '@formatjs/fast-memoize': 3.1.5
 
+  '@hono/node-server@1.19.14(hono@4.12.23)':
+    dependencies:
+      hono: 4.12.23
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.3))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -12015,7 +12051,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.0.10
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
@@ -12062,7 +12098,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -12077,11 +12113,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.4(jiti@2.6.1)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
@@ -12099,7 +12160,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12128,7 +12189,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12632,6 +12693,8 @@ snapshots:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+
+  hono@4.12.23: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:


### PR DESCRIPTION
## 개요
FDD-TR10(수동 테스트케이스 자동 실행)의 실행 엔진과 UI입니다. 회귀 자산을 자동으로 실행해 결과를 도출하는 폐루프의 실행 단계로, 케이스를 코드로 변환해 Testea 소유 러너에서 돌리고 결과를 실행에 기록합니다.

스택 PR입니다. 대상 등록·시크릿 관리(#188, PR #190) 위에 쌓여 있어 base 를 그 브랜치로 둡니다. #190 머지 후 이 PR 을 dev 로 머지하면 됩니다.

## 변경 사항
- 자동 실행 러너 서비스를 모노레포 앱으로 추가한다. 스펙을 받아 격리 환경에서 실행하고 결과를 돌려주는 순수 실행기로, 대상 페이지 접근성 캡처와 실행을 담당한다. 컨테이너 배포 설정을 포함한다.
- Testea 서버가 러너를 호출해 한 흐름을 오케스트레이션한다. 대상 페이지를 캡처하고, 케이스 단계와 캡처 결과로 실행 코드를 생성하고, 러너에서 실행한 뒤 결과를 해당 실행에 자동으로 기록한다.
- 테스트 실행 상세 화면에 자동 실행 동선을 추가한다. 대상 사이트와 케이스를 고르면 실행이 진행되고 통과 또는 실패 결과와 생성된 코드 미리보기를 보여준다.

## 검증
- 러너는 로컬에서 상태 확인과 인증, 캡처, 실행 응답을 확인했다. 전체 흐름은 UI에서 버튼을 눌러 캡처와 러너 연동까지 실제 작동을 확인했다.
- 실행 인프라(러너)는 외부 컨테이너 호스팅에 배포해야 운영에서 동작한다. 코드 생성에 쓰는 외부 AI 키와 러너 접속 정보는 환경 변수로 주입한다.

## 배포 전 확인
- [ ] 러너 컨테이너 배포 및 접속 정보(주소·시크릿) 환경 변수 주입
- [ ] 코드 생성용 외부 AI 키 유효성 확인

Closes #186