### PR TITLE
feat: 백오피스 대시보드 실데이터 연동 및 빈 상태/실패 UI

### DIFF
--- a/apps/back-office/app/page.tsx
+++ b/apps/back-office/app/page.tsx
@@ -1,9 +1,18 @@
-import { getDashboardData } from '@/entities/admin-dashboard/api/get-dashboard-data';
+import {
+  type RealDashboardData,
+  getDashboardData,
+} from '@/entities/admin-dashboard/api/get-dashboard-data';
 import { DashboardPage } from '@/pages/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
-  const data = await getDashboardData();
+  let data: RealDashboardData | null = null;
+  try {
+    data = await getDashboardData();
+  } catch (error) {
+    // DB 불통/지연 시 페이지를 깨뜨리지 않고 실패 UI 로 처리한다.
+    console.error('[dashboard] 실데이터 조회 실패', error);
+  }
   return <DashboardPage data={data} />;
 }

--- a/apps/back-office/app/page.tsx
+++ b/apps/back-office/app/page.tsx
@@ -1,1 +1,9 @@
-export { DashboardPage as default } from '@/pages/dashboard';
+import { getDashboardData } from '@/entities/admin-dashboard/api/get-dashboard-data';
+import { DashboardPage } from '@/pages/dashboard';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Home() {
+  const data = await getDashboardData();
+  return <DashboardPage data={data} />;
+}

--- a/apps/back-office/src/entities/admin-dashboard/api/get-dashboard-data.ts
+++ b/apps/back-office/src/entities/admin-dashboard/api/get-dashboard-data.ts
@@ -1,0 +1,263 @@
+import { getDatabase, sql } from '@testea/db';
+
+import type {
+  CostProject,
+  FunnelStep,
+  Metric,
+  ProjectActivity,
+  StorageProject,
+  StorageSummary,
+  TrendPoint,
+} from '../model/types';
+
+/**
+ * 백오피스 대시보드(BO02) 실데이터 조회.
+ *
+ * 이 제품은 사용자 계정이 없으므로(프로젝트 비밀번호 인증) DAU/WAU/MAU·가입·어뷰징 같은
+ * 사용자 분석 지표는 데이터 원천이 없다. 받칠 수 있는 프로젝트·테스트·AI·스토리지 지표만
+ * 실데이터로 계산하고, 나머지는 호출부에서 예시 데이터로 둔다.
+ *
+ * AI 비용은 ai_usage_logs 에 토큰만 있어 단가 가정으로 추정한다(Gemini Flash 기준 근사).
+ */
+const AI_INPUT_USD_PER_1M = 0.075;
+const AI_OUTPUT_USD_PER_1M = 0.3;
+const aiCostExpr = sql`COALESCE(SUM(input_tokens), 0) * ${AI_INPUT_USD_PER_1M} / 1000000 + COALESCE(SUM(output_tokens), 0) * ${AI_OUTPUT_USD_PER_1M} / 1000000`;
+
+function usd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function gb(bytes: number): string {
+  return `${(bytes / 1024 ** 3).toFixed(2)} GB`;
+}
+
+function intl(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+type Row = Record<string, unknown>;
+const num = (v: unknown): number => Number(v ?? 0);
+const str = (v: unknown): string => String(v ?? '');
+
+export type RealDashboardData = {
+  metrics: Metric[];
+  projectTrend: TrendPoint[];
+  productivityTrend: TrendPoint[];
+  activeProjects: ProjectActivity[];
+  costProjects: CostProject[];
+  funnel: FunnelStep[];
+  storageProjects: StorageProject[];
+  storageSummary: StorageSummary;
+};
+
+export async function getDashboardData(): Promise<RealDashboardData> {
+  const db = getDatabase();
+
+  // 1) 핵심 지표
+  const [m] = (await db.execute(sql`
+    SELECT
+      (SELECT COUNT(*) FROM projects)::int AS total_projects,
+      (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '7 days')::int AS new_week,
+      (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '14 days' AND created_at < now() - interval '7 days')::int AS new_prev,
+      (SELECT COUNT(*) FROM test_cases)::int AS total_tcs,
+      (SELECT COUNT(*) FROM test_case_runs)::int AS total_runs,
+      (SELECT COUNT(*) FROM test_case_runs WHERE status <> 'untested')::int AS executed_runs
+  `)) as unknown as Row[];
+
+  const newWeek = num(m.new_week);
+  const newPrev = num(m.new_prev);
+  const growth = newPrev > 0 ? Math.round(((newWeek - newPrev) / newPrev) * 100) : 0;
+  const totalRuns = num(m.total_runs);
+  const executed = num(m.executed_runs);
+  const execRate = totalRuns > 0 ? ((executed / totalRuns) * 100).toFixed(1) : '0.0';
+
+  const metrics: Metric[] = [
+    {
+      label: '전체 프로젝트',
+      value: intl(num(m.total_projects)),
+      unit: '',
+      helper: `최근 7일 신규: ${newWeek}개`,
+    },
+    {
+      label: '신규 프로젝트 (주간)',
+      value: intl(newWeek),
+      unit: growth >= 0 ? `+${growth}%` : `${growth}%`,
+      helper: `이전 주: ${newPrev}개`,
+    },
+    {
+      label: '테스트 케이스',
+      value: intl(num(m.total_tcs)),
+      unit: '',
+      helper: `실행 기록: ${intl(totalRuns)}건`,
+    },
+    {
+      label: '테스트 실행률',
+      value: `${execRate}%`,
+      unit: '',
+      helper: `실행: ${intl(executed)} / 전체: ${intl(totalRuns)}`,
+    },
+  ];
+
+  // 2) 프로젝트 생성 추이 (최근 14일, 일별)
+  const projectTrendRows = (await db.execute(sql`
+    WITH days AS (
+      SELECT generate_series(date_trunc('day', now()) - interval '13 days', date_trunc('day', now()), interval '1 day')::date AS d
+    )
+    SELECT to_char(d, 'FMMM/FMDD') AS date,
+      (SELECT COUNT(*) FROM projects WHERE created_at::date = days.d)::int AS projects
+    FROM days ORDER BY d
+  `)) as unknown as Row[];
+  const projectTrend: TrendPoint[] = projectTrendRows.map((r) => ({
+    date: str(r.date),
+    projects: num(r.projects),
+  }));
+
+  // 3) 콘텐츠 생산량 추이 (최근 14일, 누적)
+  const productivityRows = (await db.execute(sql`
+    WITH days AS (
+      SELECT generate_series(date_trunc('day', now()) - interval '13 days', date_trunc('day', now()), interval '1 day')::date AS d
+    )
+    SELECT to_char(d, 'FMMM/FMDD') AS date,
+      (SELECT COUNT(*) FROM test_cases WHERE created_at::date <= days.d)::int AS tc,
+      (SELECT COUNT(*) FROM test_suites WHERE created_at::date <= days.d)::int AS suite,
+      (SELECT COUNT(*) FROM test_runs WHERE created_at::date <= days.d)::int AS run,
+      (SELECT COUNT(*) FROM milestones WHERE created_at::date <= days.d)::int AS milestone
+    FROM days ORDER BY d
+  `)) as unknown as Row[];
+  const productivityTrend: TrendPoint[] = productivityRows.map((r) => ({
+    date: str(r.date),
+    tc: num(r.tc),
+    suite: num(r.suite),
+    run: num(r.run),
+    milestone: num(r.milestone),
+  }));
+
+  // 4) 활성 프로젝트 Top 10 (실행 기록 수 기준)
+  const activeRows = (await db.execute(sql`
+    SELECT p.name,
+      COUNT(DISTINCT tcr.id)::int AS runs,
+      (SELECT COUNT(*) FROM test_cases tc WHERE tc.project_id = p.id)::int AS tcs,
+      COALESCE((SELECT SUM(input_tokens) * ${AI_INPUT_USD_PER_1M} / 1000000 + SUM(output_tokens) * ${AI_OUTPUT_USD_PER_1M} / 1000000 FROM ai_usage_logs WHERE project_id = p.id), 0) AS ai_cost
+    FROM projects p
+    LEFT JOIN test_runs tr ON tr.project_id = p.id
+    LEFT JOIN test_case_runs tcr ON tcr.test_run_id = tr.id
+    GROUP BY p.id, p.name
+    ORDER BY runs DESC, tcs DESC
+    LIMIT 10
+  `)) as unknown as Row[];
+  const activeProjects: ProjectActivity[] = activeRows.map((r) => [
+    str(r.name),
+    intl(num(r.runs)),
+    intl(num(r.tcs)),
+    usd(num(r.ai_cost)),
+  ]);
+
+  // 5) 비용 급증 프로젝트 (AI 비용 오늘 vs 어제, ai_usage_logs)
+  const costRows = (await db.execute(sql`
+    SELECT p.name,
+      COALESCE(SUM(CASE WHEN l.created_at::date = current_date THEN l.input_tokens END) * ${AI_INPUT_USD_PER_1M} / 1000000
+        + SUM(CASE WHEN l.created_at::date = current_date THEN l.output_tokens END) * ${AI_OUTPUT_USD_PER_1M} / 1000000, 0) AS today,
+      COALESCE(SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.input_tokens END) * ${AI_INPUT_USD_PER_1M} / 1000000
+        + SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.output_tokens END) * ${AI_OUTPUT_USD_PER_1M} / 1000000, 0) AS yesterday,
+      (${aiCostExpr}) AS cumulative
+    FROM projects p
+    JOIN ai_usage_logs l ON l.project_id = p.id
+    GROUP BY p.id, p.name
+    ORDER BY cumulative DESC
+    LIMIT 5
+  `)) as unknown as Row[];
+  const costProjects: CostProject[] = costRows.map((r) => {
+    const today = num(r.today);
+    const yesterday = num(r.yesterday);
+    const growthRate = yesterday > 0 ? Math.round(((today - yesterday) / yesterday) * 100) : 0;
+    return [
+      str(r.name),
+      usd(today),
+      usd(yesterday),
+      growthRate >= 0 ? `+${growthRate}%` : `${growthRate}%`,
+      usd(num(r.cumulative)),
+    ];
+  });
+
+  // 6) 퍼널 (사용자 가입 대신 프로젝트 단계로 재정의)
+  const [f] = (await db.execute(sql`
+    SELECT
+      (SELECT COUNT(*) FROM projects)::int AS created,
+      (SELECT COUNT(DISTINCT project_id) FROM test_cases)::int AS with_tc,
+      (SELECT COUNT(DISTINCT project_id) FROM test_runs)::int AS with_run,
+      (SELECT COUNT(DISTINCT tr.project_id) FROM test_runs tr
+        JOIN test_case_runs tcr ON tcr.test_run_id = tr.id WHERE tcr.status <> 'untested')::int AS with_result
+  `)) as unknown as Row[];
+  const created = Math.max(1, num(f.created));
+  const funnelRaw = [
+    { label: '프로젝트 생성', count: num(f.created) },
+    { label: '첫 TC 작성', count: num(f.with_tc) },
+    { label: '첫 Run 실행', count: num(f.with_run) },
+    { label: '결과 확인', count: num(f.with_result) },
+  ];
+  const funnel: FunnelStep[] = funnelRaw.map((step, i) => {
+    const percent = Math.round((step.count / created) * 1000) / 10;
+    const prev = i > 0 ? funnelRaw[i - 1].count : step.count;
+    const churn =
+      i > 0 && prev > 0 ? `${(((prev - step.count) / prev) * 100).toFixed(1)}% 이탈` : '';
+    return {
+      label: step.label,
+      count: intl(step.count),
+      rate: `${percent.toFixed(1)}%`,
+      percent,
+      churn,
+    };
+  });
+
+  // 7) 스토리지 사용량 (프로젝트별 근사: 주요 콘텐츠 테이블 pg_column_size 합)
+  // 후보를 TC 수로 먼저 5개 추린 뒤(저렴), 그 5개만 pg_column_size 합산(전체 134개 스캔 회피).
+  const storageRows = (await db.execute(sql`
+    WITH top AS (
+      SELECT p.id, p.name, COUNT(tc.id) AS tc_count
+      FROM projects p LEFT JOIN test_cases tc ON tc.project_id = p.id
+      GROUP BY p.id, p.name
+      ORDER BY tc_count DESC
+      LIMIT 5
+    )
+    SELECT t.name,
+      COALESCE((SELECT SUM(pg_column_size(tc.*)) FROM test_cases tc WHERE tc.project_id = t.id), 0)
+      + COALESCE((SELECT SUM(pg_column_size(tr.*)) FROM test_runs tr WHERE tr.project_id = t.id), 0)
+      + COALESCE((SELECT SUM(pg_column_size(tcr.*)) FROM test_case_runs tcr
+          JOIN test_runs tr2 ON tcr.test_run_id = tr2.id WHERE tr2.project_id = t.id), 0)
+      + COALESCE((SELECT SUM(pg_column_size(ts.*)) FROM test_suites ts WHERE ts.project_id = t.id), 0) AS bytes
+    FROM top t
+    ORDER BY bytes DESC
+  `)) as unknown as Row[];
+  const maxBytes = Math.max(1, ...storageRows.map((r) => num(r.bytes)));
+  const storageProjects: StorageProject[] = storageRows.map((r) => ({
+    name: str(r.name),
+    usage: gb(num(r.bytes)),
+    percent: Math.round((num(r.bytes) / maxBytes) * 100),
+  }));
+
+  const [s] = (await db.execute(sql`
+    SELECT
+      COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_cases t), 0)
+      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_runs t), 0)
+      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_case_runs t), 0)
+      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_suites t), 0) AS total_bytes,
+      ((SELECT COUNT(*) FROM test_cases) + (SELECT COUNT(*) FROM test_suites)
+        + (SELECT COUNT(*) FROM test_runs) + (SELECT COUNT(*) FROM test_case_runs)
+        + (SELECT COUNT(*) FROM milestones))::int AS total_rows
+  `)) as unknown as Row[];
+  const storageSummary: StorageSummary = {
+    totalSize: gb(num(s.total_bytes)),
+    totalRows: intl(num(s.total_rows)),
+  };
+
+  return {
+    metrics,
+    projectTrend,
+    productivityTrend,
+    activeProjects,
+    costProjects,
+    funnel,
+    storageProjects,
+    storageSummary,
+  };
+}

--- a/apps/back-office/src/entities/admin-dashboard/api/get-dashboard-data.ts
+++ b/apps/back-office/src/entities/admin-dashboard/api/get-dashboard-data.ts
@@ -17,27 +17,56 @@ import type {
  * 사용자 분석 지표는 데이터 원천이 없다. 받칠 수 있는 프로젝트·테스트·AI·스토리지 지표만
  * 실데이터로 계산하고, 나머지는 호출부에서 예시 데이터로 둔다.
  *
+ * 성능: 모든 집계를 단일 쿼리(JSON 반환)로 합쳐 DB 라운드트립을 1회로 줄인다.
+ * (force-dynamic 페이지가 매 요청 7회 왕복하면 원격 DB 지연에 그대로 노출됨)
+ *
  * AI 비용은 ai_usage_logs 에 토큰만 있어 단가 가정으로 추정한다(Gemini Flash 기준 근사).
  */
-const AI_INPUT_USD_PER_1M = 0.075;
-const AI_OUTPUT_USD_PER_1M = 0.3;
-const aiCostExpr = sql`COALESCE(SUM(input_tokens), 0) * ${AI_INPUT_USD_PER_1M} / 1000000 + COALESCE(SUM(output_tokens), 0) * ${AI_OUTPUT_USD_PER_1M} / 1000000`;
+// 원격 DB 가 느리거나 불통일 때 페이지가 무한정 매달리지 않도록 조기 실패시킨다.
+// (운영 동일 리전에서는 1초 미만이라 영향 없음. 실패 시 호출부가 실패 UI 로 처리한다.)
+const QUERY_TIMEOUT_MS = 8000;
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error('dashboard query timeout')), ms)
+    ),
+  ]);
+}
 
 function usd(n: number): string {
   return `$${n.toFixed(2)}`;
 }
-
 function gb(bytes: number): string {
   return `${(bytes / 1024 ** 3).toFixed(2)} GB`;
 }
-
 function intl(n: number): string {
   return n.toLocaleString('en-US');
 }
-
-type Row = Record<string, unknown>;
 const num = (v: unknown): number => Number(v ?? 0);
-const str = (v: unknown): string => String(v ?? '');
+
+type RawData = {
+  totalProjects: number;
+  newWeek: number;
+  newPrev: number;
+  totalTcs: number;
+  totalRuns: number;
+  executedRuns: number;
+  funnelCreated: number;
+  funnelWithTc: number;
+  funnelWithRun: number;
+  funnelWithResult: number;
+  totalBytes: number;
+  totalRows: number;
+  projectTrend: { date: string; projects: number }[] | null;
+  productivityTrend:
+    | { date: string; tc: number; suite: number; run: number; milestone: number }[]
+    | null;
+  activeProjects: { name: string; runs: number; tcs: number; aiCost: number }[] | null;
+  costProjects: { name: string; today: number; yesterday: number; cumulative: number }[] | null;
+  storageProjects: { name: string; bytes: number }[] | null;
+};
 
 export type RealDashboardData = {
   metrics: Metric[];
@@ -53,147 +82,171 @@ export type RealDashboardData = {
 export async function getDashboardData(): Promise<RealDashboardData> {
   const db = getDatabase();
 
-  // 1) 핵심 지표
-  const [m] = (await db.execute(sql`
-    SELECT
-      (SELECT COUNT(*) FROM projects)::int AS total_projects,
-      (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '7 days')::int AS new_week,
-      (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '14 days' AND created_at < now() - interval '7 days')::int AS new_prev,
-      (SELECT COUNT(*) FROM test_cases)::int AS total_tcs,
-      (SELECT COUNT(*) FROM test_case_runs)::int AS total_runs,
-      (SELECT COUNT(*) FROM test_case_runs WHERE status <> 'untested')::int AS executed_runs
-  `)) as unknown as Row[];
+  const rows = (await withTimeout(
+    db.execute(sql`
+    WITH days AS (
+      SELECT generate_series(date_trunc('day', now()) - interval '13 days', date_trunc('day', now()), interval '1 day')::date AS d
+    ),
+    active_top AS (
+      SELECT p.name,
+        COUNT(DISTINCT tcr.id) AS runs,
+        (SELECT COUNT(*) FROM test_cases tc WHERE tc.project_id = p.id) AS tcs,
+        COALESCE((SELECT SUM(input_tokens) * 0.075 / 1000000 + SUM(output_tokens) * 0.3 / 1000000 FROM ai_usage_logs WHERE project_id = p.id), 0) AS ai_cost
+      FROM projects p
+      LEFT JOIN test_runs tr ON tr.project_id = p.id
+      LEFT JOIN test_case_runs tcr ON tcr.test_run_id = tr.id
+      GROUP BY p.id, p.name
+      ORDER BY runs DESC, tcs DESC
+      LIMIT 10
+    ),
+    cost_top AS (
+      SELECT p.name,
+        COALESCE(SUM(CASE WHEN l.created_at::date = current_date THEN l.input_tokens END) * 0.075 / 1000000
+          + SUM(CASE WHEN l.created_at::date = current_date THEN l.output_tokens END) * 0.3 / 1000000, 0) AS today,
+        COALESCE(SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.input_tokens END) * 0.075 / 1000000
+          + SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.output_tokens END) * 0.3 / 1000000, 0) AS yesterday,
+        COALESCE(SUM(l.input_tokens) * 0.075 / 1000000 + SUM(l.output_tokens) * 0.3 / 1000000, 0) AS cumulative
+      FROM projects p JOIN ai_usage_logs l ON l.project_id = p.id
+      GROUP BY p.id, p.name
+      ORDER BY cumulative DESC
+      LIMIT 5
+    ),
+    storage_cand AS (
+      SELECT p.id, p.name, COUNT(tc.id) AS tc_count
+      FROM projects p LEFT JOIN test_cases tc ON tc.project_id = p.id
+      GROUP BY p.id, p.name
+      ORDER BY tc_count DESC
+      LIMIT 5
+    ),
+    storage_top AS (
+      SELECT t.name,
+        COALESCE((SELECT SUM(pg_column_size(tc.*)) FROM test_cases tc WHERE tc.project_id = t.id), 0)
+        + COALESCE((SELECT SUM(pg_column_size(tr.*)) FROM test_runs tr WHERE tr.project_id = t.id), 0)
+        + COALESCE((SELECT SUM(pg_column_size(tcr.*)) FROM test_case_runs tcr
+            JOIN test_runs tr2 ON tcr.test_run_id = tr2.id WHERE tr2.project_id = t.id), 0)
+        + COALESCE((SELECT SUM(pg_column_size(ts.*)) FROM test_suites ts WHERE ts.project_id = t.id), 0) AS bytes
+      FROM storage_cand t
+    )
+    SELECT json_build_object(
+      'totalProjects', (SELECT COUNT(*) FROM projects),
+      'newWeek', (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '7 days'),
+      'newPrev', (SELECT COUNT(*) FROM projects WHERE created_at >= now() - interval '14 days' AND created_at < now() - interval '7 days'),
+      'totalTcs', (SELECT COUNT(*) FROM test_cases),
+      'totalRuns', (SELECT COUNT(*) FROM test_case_runs),
+      'executedRuns', (SELECT COUNT(*) FROM test_case_runs WHERE status <> 'untested'),
+      'funnelCreated', (SELECT COUNT(*) FROM projects),
+      'funnelWithTc', (SELECT COUNT(DISTINCT project_id) FROM test_cases),
+      'funnelWithRun', (SELECT COUNT(DISTINCT project_id) FROM test_runs),
+      'funnelWithResult', (SELECT COUNT(DISTINCT tr.project_id) FROM test_runs tr JOIN test_case_runs tcr ON tcr.test_run_id = tr.id WHERE tcr.status <> 'untested'),
+      'totalBytes', (
+        COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_cases t), 0)
+        + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_runs t), 0)
+        + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_case_runs t), 0)
+        + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_suites t), 0)
+      ),
+      'totalRows', (
+        (SELECT COUNT(*) FROM test_cases) + (SELECT COUNT(*) FROM test_suites)
+        + (SELECT COUNT(*) FROM test_runs) + (SELECT COUNT(*) FROM test_case_runs)
+        + (SELECT COUNT(*) FROM milestones)
+      ),
+      'projectTrend', (
+        SELECT json_agg(json_build_object('date', to_char(d, 'FMMM/FMDD'),
+          'projects', (SELECT COUNT(*) FROM projects WHERE created_at::date = days.d)) ORDER BY d) FROM days
+      ),
+      'productivityTrend', (
+        SELECT json_agg(json_build_object('date', to_char(d, 'FMMM/FMDD'),
+          'tc', (SELECT COUNT(*) FROM test_cases WHERE created_at::date <= days.d),
+          'suite', (SELECT COUNT(*) FROM test_suites WHERE created_at::date <= days.d),
+          'run', (SELECT COUNT(*) FROM test_runs WHERE created_at::date <= days.d),
+          'milestone', (SELECT COUNT(*) FROM milestones WHERE created_at::date <= days.d)) ORDER BY d) FROM days
+      ),
+      'activeProjects', (
+        SELECT json_agg(json_build_object('name', name, 'runs', runs, 'tcs', tcs, 'aiCost', ai_cost)
+          ORDER BY runs DESC, tcs DESC) FROM active_top
+      ),
+      'costProjects', (
+        SELECT json_agg(json_build_object('name', name, 'today', today, 'yesterday', yesterday, 'cumulative', cumulative)
+          ORDER BY cumulative DESC) FROM cost_top
+      ),
+      'storageProjects', (
+        SELECT json_agg(json_build_object('name', name, 'bytes', bytes) ORDER BY bytes DESC) FROM storage_top
+      )
+    ) AS data
+  `),
+    QUERY_TIMEOUT_MS
+  )) as unknown as { data: RawData }[];
 
-  const newWeek = num(m.new_week);
-  const newPrev = num(m.new_prev);
-  const growth = newPrev > 0 ? Math.round(((newWeek - newPrev) / newPrev) * 100) : 0;
-  const totalRuns = num(m.total_runs);
-  const executed = num(m.executed_runs);
-  const execRate = totalRuns > 0 ? ((executed / totalRuns) * 100).toFixed(1) : '0.0';
+  const d = rows[0].data;
+
+  const growth = d.newPrev > 0 ? Math.round(((d.newWeek - d.newPrev) / d.newPrev) * 100) : 0;
+  const execRate = d.totalRuns > 0 ? ((d.executedRuns / d.totalRuns) * 100).toFixed(1) : '0.0';
 
   const metrics: Metric[] = [
     {
       label: '전체 프로젝트',
-      value: intl(num(m.total_projects)),
+      value: intl(d.totalProjects),
       unit: '',
-      helper: `최근 7일 신규: ${newWeek}개`,
+      helper: `최근 7일 신규: ${d.newWeek}개`,
     },
     {
       label: '신규 프로젝트 (주간)',
-      value: intl(newWeek),
+      value: intl(d.newWeek),
       unit: growth >= 0 ? `+${growth}%` : `${growth}%`,
-      helper: `이전 주: ${newPrev}개`,
+      helper: `이전 주: ${d.newPrev}개`,
     },
     {
       label: '테스트 케이스',
-      value: intl(num(m.total_tcs)),
+      value: intl(d.totalTcs),
       unit: '',
-      helper: `실행 기록: ${intl(totalRuns)}건`,
+      helper: `실행 기록: ${intl(d.totalRuns)}건`,
     },
     {
       label: '테스트 실행률',
       value: `${execRate}%`,
       unit: '',
-      helper: `실행: ${intl(executed)} / 전체: ${intl(totalRuns)}`,
+      helper: `실행: ${intl(d.executedRuns)} / 전체: ${intl(d.totalRuns)}`,
     },
   ];
 
-  // 2) 프로젝트 생성 추이 (최근 14일, 일별)
-  const projectTrendRows = (await db.execute(sql`
-    WITH days AS (
-      SELECT generate_series(date_trunc('day', now()) - interval '13 days', date_trunc('day', now()), interval '1 day')::date AS d
-    )
-    SELECT to_char(d, 'FMMM/FMDD') AS date,
-      (SELECT COUNT(*) FROM projects WHERE created_at::date = days.d)::int AS projects
-    FROM days ORDER BY d
-  `)) as unknown as Row[];
-  const projectTrend: TrendPoint[] = projectTrendRows.map((r) => ({
-    date: str(r.date),
+  const projectTrend: TrendPoint[] = (d.projectTrend ?? []).map((r) => ({
+    date: r.date,
     projects: num(r.projects),
   }));
 
-  // 3) 콘텐츠 생산량 추이 (최근 14일, 누적)
-  const productivityRows = (await db.execute(sql`
-    WITH days AS (
-      SELECT generate_series(date_trunc('day', now()) - interval '13 days', date_trunc('day', now()), interval '1 day')::date AS d
-    )
-    SELECT to_char(d, 'FMMM/FMDD') AS date,
-      (SELECT COUNT(*) FROM test_cases WHERE created_at::date <= days.d)::int AS tc,
-      (SELECT COUNT(*) FROM test_suites WHERE created_at::date <= days.d)::int AS suite,
-      (SELECT COUNT(*) FROM test_runs WHERE created_at::date <= days.d)::int AS run,
-      (SELECT COUNT(*) FROM milestones WHERE created_at::date <= days.d)::int AS milestone
-    FROM days ORDER BY d
-  `)) as unknown as Row[];
-  const productivityTrend: TrendPoint[] = productivityRows.map((r) => ({
-    date: str(r.date),
+  const productivityTrend: TrendPoint[] = (d.productivityTrend ?? []).map((r) => ({
+    date: r.date,
     tc: num(r.tc),
     suite: num(r.suite),
     run: num(r.run),
     milestone: num(r.milestone),
   }));
 
-  // 4) 활성 프로젝트 Top 10 (실행 기록 수 기준)
-  const activeRows = (await db.execute(sql`
-    SELECT p.name,
-      COUNT(DISTINCT tcr.id)::int AS runs,
-      (SELECT COUNT(*) FROM test_cases tc WHERE tc.project_id = p.id)::int AS tcs,
-      COALESCE((SELECT SUM(input_tokens) * ${AI_INPUT_USD_PER_1M} / 1000000 + SUM(output_tokens) * ${AI_OUTPUT_USD_PER_1M} / 1000000 FROM ai_usage_logs WHERE project_id = p.id), 0) AS ai_cost
-    FROM projects p
-    LEFT JOIN test_runs tr ON tr.project_id = p.id
-    LEFT JOIN test_case_runs tcr ON tcr.test_run_id = tr.id
-    GROUP BY p.id, p.name
-    ORDER BY runs DESC, tcs DESC
-    LIMIT 10
-  `)) as unknown as Row[];
-  const activeProjects: ProjectActivity[] = activeRows.map((r) => [
-    str(r.name),
+  const activeProjects: ProjectActivity[] = (d.activeProjects ?? []).map((r) => [
+    r.name,
     intl(num(r.runs)),
     intl(num(r.tcs)),
-    usd(num(r.ai_cost)),
+    usd(num(r.aiCost)),
   ]);
 
-  // 5) 비용 급증 프로젝트 (AI 비용 오늘 vs 어제, ai_usage_logs)
-  const costRows = (await db.execute(sql`
-    SELECT p.name,
-      COALESCE(SUM(CASE WHEN l.created_at::date = current_date THEN l.input_tokens END) * ${AI_INPUT_USD_PER_1M} / 1000000
-        + SUM(CASE WHEN l.created_at::date = current_date THEN l.output_tokens END) * ${AI_OUTPUT_USD_PER_1M} / 1000000, 0) AS today,
-      COALESCE(SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.input_tokens END) * ${AI_INPUT_USD_PER_1M} / 1000000
-        + SUM(CASE WHEN l.created_at::date = current_date - 1 THEN l.output_tokens END) * ${AI_OUTPUT_USD_PER_1M} / 1000000, 0) AS yesterday,
-      (${aiCostExpr}) AS cumulative
-    FROM projects p
-    JOIN ai_usage_logs l ON l.project_id = p.id
-    GROUP BY p.id, p.name
-    ORDER BY cumulative DESC
-    LIMIT 5
-  `)) as unknown as Row[];
-  const costProjects: CostProject[] = costRows.map((r) => {
+  const costProjects: CostProject[] = (d.costProjects ?? []).map((r) => {
     const today = num(r.today);
     const yesterday = num(r.yesterday);
-    const growthRate = yesterday > 0 ? Math.round(((today - yesterday) / yesterday) * 100) : 0;
+    const rate = yesterday > 0 ? Math.round(((today - yesterday) / yesterday) * 100) : 0;
     return [
-      str(r.name),
+      r.name,
       usd(today),
       usd(yesterday),
-      growthRate >= 0 ? `+${growthRate}%` : `${growthRate}%`,
+      rate >= 0 ? `+${rate}%` : `${rate}%`,
       usd(num(r.cumulative)),
     ];
   });
 
-  // 6) 퍼널 (사용자 가입 대신 프로젝트 단계로 재정의)
-  const [f] = (await db.execute(sql`
-    SELECT
-      (SELECT COUNT(*) FROM projects)::int AS created,
-      (SELECT COUNT(DISTINCT project_id) FROM test_cases)::int AS with_tc,
-      (SELECT COUNT(DISTINCT project_id) FROM test_runs)::int AS with_run,
-      (SELECT COUNT(DISTINCT tr.project_id) FROM test_runs tr
-        JOIN test_case_runs tcr ON tcr.test_run_id = tr.id WHERE tcr.status <> 'untested')::int AS with_result
-  `)) as unknown as Row[];
-  const created = Math.max(1, num(f.created));
+  const created = Math.max(1, num(d.funnelCreated));
   const funnelRaw = [
-    { label: '프로젝트 생성', count: num(f.created) },
-    { label: '첫 TC 작성', count: num(f.with_tc) },
-    { label: '첫 Run 실행', count: num(f.with_run) },
-    { label: '결과 확인', count: num(f.with_result) },
+    { label: '프로젝트 생성', count: num(d.funnelCreated) },
+    { label: '첫 TC 작성', count: num(d.funnelWithTc) },
+    { label: '첫 Run 실행', count: num(d.funnelWithRun) },
+    { label: '결과 확인', count: num(d.funnelWithResult) },
   ];
   const funnel: FunnelStep[] = funnelRaw.map((step, i) => {
     const percent = Math.round((step.count / created) * 1000) / 10;
@@ -209,45 +262,17 @@ export async function getDashboardData(): Promise<RealDashboardData> {
     };
   });
 
-  // 7) 스토리지 사용량 (프로젝트별 근사: 주요 콘텐츠 테이블 pg_column_size 합)
-  // 후보를 TC 수로 먼저 5개 추린 뒤(저렴), 그 5개만 pg_column_size 합산(전체 134개 스캔 회피).
-  const storageRows = (await db.execute(sql`
-    WITH top AS (
-      SELECT p.id, p.name, COUNT(tc.id) AS tc_count
-      FROM projects p LEFT JOIN test_cases tc ON tc.project_id = p.id
-      GROUP BY p.id, p.name
-      ORDER BY tc_count DESC
-      LIMIT 5
-    )
-    SELECT t.name,
-      COALESCE((SELECT SUM(pg_column_size(tc.*)) FROM test_cases tc WHERE tc.project_id = t.id), 0)
-      + COALESCE((SELECT SUM(pg_column_size(tr.*)) FROM test_runs tr WHERE tr.project_id = t.id), 0)
-      + COALESCE((SELECT SUM(pg_column_size(tcr.*)) FROM test_case_runs tcr
-          JOIN test_runs tr2 ON tcr.test_run_id = tr2.id WHERE tr2.project_id = t.id), 0)
-      + COALESCE((SELECT SUM(pg_column_size(ts.*)) FROM test_suites ts WHERE ts.project_id = t.id), 0) AS bytes
-    FROM top t
-    ORDER BY bytes DESC
-  `)) as unknown as Row[];
-  const maxBytes = Math.max(1, ...storageRows.map((r) => num(r.bytes)));
-  const storageProjects: StorageProject[] = storageRows.map((r) => ({
-    name: str(r.name),
+  const storageList = d.storageProjects ?? [];
+  const maxBytes = Math.max(1, ...storageList.map((r) => num(r.bytes)));
+  const storageProjects: StorageProject[] = storageList.map((r) => ({
+    name: r.name,
     usage: gb(num(r.bytes)),
     percent: Math.round((num(r.bytes) / maxBytes) * 100),
   }));
 
-  const [s] = (await db.execute(sql`
-    SELECT
-      COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_cases t), 0)
-      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_runs t), 0)
-      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_case_runs t), 0)
-      + COALESCE((SELECT SUM(pg_column_size(t.*)) FROM test_suites t), 0) AS total_bytes,
-      ((SELECT COUNT(*) FROM test_cases) + (SELECT COUNT(*) FROM test_suites)
-        + (SELECT COUNT(*) FROM test_runs) + (SELECT COUNT(*) FROM test_case_runs)
-        + (SELECT COUNT(*) FROM milestones))::int AS total_rows
-  `)) as unknown as Row[];
   const storageSummary: StorageSummary = {
-    totalSize: gb(num(s.total_bytes)),
-    totalRows: intl(num(s.total_rows)),
+    totalSize: gb(num(d.totalBytes)),
+    totalRows: intl(num(d.totalRows)),
   };
 
   return {

--- a/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
@@ -2,6 +2,7 @@
 
 import { navItems } from '@/entities/admin-dashboard';
 import type { RealDashboardData } from '@/entities/admin-dashboard/api/get-dashboard-data';
+import { EmptyState } from '@/shared/ui';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 import {
   AdditionalAnalysisSection,
@@ -21,7 +22,7 @@ function NoDataCard({ title }: { title: string }) {
   return (
     <section className="border-border grid gap-4 rounded-xl border bg-white p-6">
       <h2 className="tracking-zero text-lg font-bold">{title}</h2>
-      <p className="text-text-secondary py-8 text-center text-sm">없음</p>
+      <EmptyState message="데이터 없음" hint="연동 예정" />
     </section>
   );
 }

--- a/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
@@ -2,22 +2,15 @@
 
 import {
   abuseSignals,
-  activeProjects,
   activeUserTrend,
   alerts,
-  costProjects,
-  funnel,
-  metrics,
   navItems,
-  productivityTrend,
-  projectTrend,
   rateLimitViolation,
   resourceUsages,
   signupMonitoring,
-  storageProjects,
-  storageSummary,
   systemStatuses,
 } from '@/entities/admin-dashboard';
+import type { RealDashboardData } from '@/entities/admin-dashboard/api/get-dashboard-data';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 import {
   AbuseMonitoringSection,
@@ -30,30 +23,51 @@ import {
   TrendAnalysisSection,
 } from '@/widgets/dashboard';
 
-export function DashboardPage() {
+/**
+ * 일부 지표는 데이터 원천이 없어 예시로 둔다(정직 표기):
+ * - 활성 사용자 DAU/WAU/MAU, 가입·동일 IP, Rate Limit: 사용자/이벤트 추적 인프라 부재
+ * - 인프라 사용량·시스템 헬스: Supabase/Sentry/Vercel 외부 지표
+ */
+function SampleDataNotice() {
   return (
-    <BackOfficeLayout navItems={navItems}>
+    <p className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-700">
+      활성 사용자·인프라·시스템 헬스·어뷰징 지표는 <strong>예시 데이터</strong>입니다. 이 제품은
+      사용자 계정이 없어, 해당 지표는 사용자·이벤트 추적 인프라 도입 후 연동됩니다.
+    </p>
+  );
+}
+
+export function DashboardPage({ data }: { data: RealDashboardData }) {
+  return (
+    <BackOfficeLayout navItems={navItems} admin={{ name: '관리자', email: 'admin@testea.com' }}>
       <DashboardHeader />
       <div className="mx-auto flex max-w-[1440px] flex-col gap-6 px-5 py-6 lg:px-8">
+        <SampleDataNotice />
+        {/* 예시: 임계치 알림(연동 예정) */}
         <AlertsSection alerts={alerts} />
-        <MetricsSection metrics={metrics} />
+        {/* 실데이터 */}
+        <MetricsSection metrics={data.metrics} />
         <TrendAnalysisSection
-          projectTrend={projectTrend}
+          projectTrend={data.projectTrend}
           activeUserTrend={activeUserTrend}
-          productivityTrend={productivityTrend}
-          activeProjects={activeProjects}
+          productivityTrend={data.productivityTrend}
+          activeProjects={data.activeProjects}
         />
+        {/* 예시: 인프라·헬스(외부 지표) */}
         <CostSystemSection resourceUsages={resourceUsages} systemStatuses={systemStatuses} />
-        <CostSpikeSection costProjects={costProjects} />
+        {/* 실데이터 */}
+        <CostSpikeSection costProjects={data.costProjects} />
+        {/* 예시: 어뷰징·가입(추적 인프라 부재) */}
         <AbuseMonitoringSection
           abuseSignals={abuseSignals}
           signupMonitoring={signupMonitoring}
           rateLimitViolation={rateLimitViolation}
         />
+        {/* 실데이터 */}
         <AdditionalAnalysisSection
-          funnel={funnel}
-          storageProjects={storageProjects}
-          storageSummary={storageSummary}
+          funnel={data.funnel}
+          storageProjects={data.storageProjects}
+          storageSummary={data.storageSummary}
         />
       </div>
     </BackOfficeLayout>

--- a/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
@@ -22,6 +22,7 @@ import {
   MetricsSection,
   TrendAnalysisSection,
 } from '@/widgets/dashboard';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 
 /**
  * 일부 지표는 데이터 원천이 없어 예시로 둔다(정직 표기):
@@ -37,37 +38,58 @@ function SampleDataNotice() {
   );
 }
 
-export function DashboardPage({ data }: { data: RealDashboardData }) {
+/** 실시간 지표(DB) 조회 실패 시 표시. */
+function DataLoadFailed() {
+  return (
+    <section className="border-border flex flex-col items-center gap-3 rounded-xl border bg-white px-6 py-16 text-center">
+      <AlertTriangle className="h-8 w-8 text-amber-500" aria-hidden="true" />
+      <h2 className="text-text-primary text-lg font-bold">실시간 지표를 불러오지 못했습니다</h2>
+      <p className="text-text-secondary max-w-md text-sm">
+        데이터베이스 응답이 지연되거나 연결할 수 없습니다. 잠시 후 새로고침해 주세요.
+      </p>
+      <span className="text-text-secondary mt-1 inline-flex items-center gap-1.5 text-xs">
+        <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+        페이지를 새로고침하면 다시 시도합니다.
+      </span>
+    </section>
+  );
+}
+
+export function DashboardPage({ data }: { data: RealDashboardData | null }) {
   return (
     <BackOfficeLayout navItems={navItems} admin={{ name: '관리자', email: 'admin@testea.com' }}>
       <DashboardHeader />
       <div className="mx-auto flex max-w-[1440px] flex-col gap-6 px-5 py-6 lg:px-8">
         <SampleDataNotice />
-        {/* 예시: 임계치 알림(연동 예정) */}
+
+        {/* 실데이터(DB). 실패 시 실패 UI 로 대체. */}
+        {data ? (
+          <>
+            <MetricsSection metrics={data.metrics} />
+            <TrendAnalysisSection
+              projectTrend={data.projectTrend}
+              activeUserTrend={activeUserTrend}
+              productivityTrend={data.productivityTrend}
+              activeProjects={data.activeProjects}
+            />
+            <CostSpikeSection costProjects={data.costProjects} />
+            <AdditionalAnalysisSection
+              funnel={data.funnel}
+              storageProjects={data.storageProjects}
+              storageSummary={data.storageSummary}
+            />
+          </>
+        ) : (
+          <DataLoadFailed />
+        )}
+
+        {/* 예시(연동 예정) */}
         <AlertsSection alerts={alerts} />
-        {/* 실데이터 */}
-        <MetricsSection metrics={data.metrics} />
-        <TrendAnalysisSection
-          projectTrend={data.projectTrend}
-          activeUserTrend={activeUserTrend}
-          productivityTrend={data.productivityTrend}
-          activeProjects={data.activeProjects}
-        />
-        {/* 예시: 인프라·헬스(외부 지표) */}
         <CostSystemSection resourceUsages={resourceUsages} systemStatuses={systemStatuses} />
-        {/* 실데이터 */}
-        <CostSpikeSection costProjects={data.costProjects} />
-        {/* 예시: 어뷰징·가입(추적 인프라 부재) */}
         <AbuseMonitoringSection
           abuseSignals={abuseSignals}
           signupMonitoring={signupMonitoring}
           rateLimitViolation={rateLimitViolation}
-        />
-        {/* 실데이터 */}
-        <AdditionalAnalysisSection
-          funnel={data.funnel}
-          storageProjects={data.storageProjects}
-          storageSummary={data.storageSummary}
         />
       </div>
     </BackOfficeLayout>

--- a/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
+++ b/apps/back-office/src/pages/dashboard/ui/dashboard-page.tsx
@@ -1,23 +1,11 @@
 'use client';
 
-import {
-  abuseSignals,
-  activeUserTrend,
-  alerts,
-  navItems,
-  rateLimitViolation,
-  resourceUsages,
-  signupMonitoring,
-  systemStatuses,
-} from '@/entities/admin-dashboard';
+import { navItems } from '@/entities/admin-dashboard';
 import type { RealDashboardData } from '@/entities/admin-dashboard/api/get-dashboard-data';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 import {
-  AbuseMonitoringSection,
   AdditionalAnalysisSection,
-  AlertsSection,
   CostSpikeSection,
-  CostSystemSection,
   DashboardHeader,
   MetricsSection,
   TrendAnalysisSection,
@@ -25,16 +13,16 @@ import {
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 
 /**
- * 일부 지표는 데이터 원천이 없어 예시로 둔다(정직 표기):
- * - 활성 사용자 DAU/WAU/MAU, 가입·동일 IP, Rate Limit: 사용자/이벤트 추적 인프라 부재
- * - 인프라 사용량·시스템 헬스: Supabase/Sentry/Vercel 외부 지표
+ * 데이터 원천이 없는 지표는 가짜 예시 대신 "없음"으로 표기한다.
+ * - 활성 사용자 DAU/WAU/MAU·가입·어뷰징·Rate Limit: 사용자/이벤트 추적 인프라 부재
+ * - 인프라 사용량·시스템 헬스·임계치 알림: Supabase/Sentry/Vercel 외부 지표
  */
-function SampleDataNotice() {
+function NoDataCard({ title }: { title: string }) {
   return (
-    <p className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-700">
-      활성 사용자·인프라·시스템 헬스·어뷰징 지표는 <strong>예시 데이터</strong>입니다. 이 제품은
-      사용자 계정이 없어, 해당 지표는 사용자·이벤트 추적 인프라 도입 후 연동됩니다.
-    </p>
+    <section className="border-border grid gap-4 rounded-xl border bg-white p-6">
+      <h2 className="tracking-zero text-lg font-bold">{title}</h2>
+      <p className="text-text-secondary py-8 text-center text-sm">없음</p>
+    </section>
   );
 }
 
@@ -60,15 +48,13 @@ export function DashboardPage({ data }: { data: RealDashboardData | null }) {
     <BackOfficeLayout navItems={navItems} admin={{ name: '관리자', email: 'admin@testea.com' }}>
       <DashboardHeader />
       <div className="mx-auto flex max-w-[1440px] flex-col gap-6 px-5 py-6 lg:px-8">
-        <SampleDataNotice />
-
         {/* 실데이터(DB). 실패 시 실패 UI 로 대체. */}
         {data ? (
           <>
             <MetricsSection metrics={data.metrics} />
             <TrendAnalysisSection
               projectTrend={data.projectTrend}
-              activeUserTrend={activeUserTrend}
+              activeUserTrend={[]}
               productivityTrend={data.productivityTrend}
               activeProjects={data.activeProjects}
             />
@@ -83,14 +69,10 @@ export function DashboardPage({ data }: { data: RealDashboardData | null }) {
           <DataLoadFailed />
         )}
 
-        {/* 예시(연동 예정) */}
-        <AlertsSection alerts={alerts} />
-        <CostSystemSection resourceUsages={resourceUsages} systemStatuses={systemStatuses} />
-        <AbuseMonitoringSection
-          abuseSignals={abuseSignals}
-          signupMonitoring={signupMonitoring}
-          rateLimitViolation={rateLimitViolation}
-        />
+        {/* 데이터 원천 없음 → 가짜 대신 "없음" */}
+        <NoDataCard title="주의 알림" />
+        <NoDataCard title="비용 및 시스템 상태" />
+        <NoDataCard title="어뷰징 및 이상 행동 모니터링" />
       </div>
     </BackOfficeLayout>
   );

--- a/apps/back-office/src/shared/ui/empty-state/empty-state.tsx
+++ b/apps/back-office/src/shared/ui/empty-state/empty-state.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+
+import { Inbox } from 'lucide-react';
+
+type EmptyStateSize = 'sm' | 'md';
+
+type EmptyStateProps = {
+  /** 주 메시지. 기본값 '데이터 없음' */
+  message?: string;
+  /** 보조 설명 (선택) */
+  hint?: ReactNode;
+  /** 아이콘 교체 (선택) */
+  icon?: ReactNode;
+  size?: EmptyStateSize;
+  className?: string;
+};
+
+const sizeMap: Record<EmptyStateSize, { wrap: string; circle: string; icon: string; msg: string }> =
+  {
+    sm: { wrap: 'gap-2 py-8', circle: 'h-10 w-10', icon: 'h-5 w-5', msg: 'text-sm' },
+    md: { wrap: 'gap-3 py-12', circle: 'h-14 w-14', icon: 'h-7 w-7', msg: 'text-sm' },
+  };
+
+/**
+ * 빈 상태 표시. 데이터가 없거나 아직 연동되지 않은 영역에 일관되게 쓴다.
+ */
+export function EmptyState({
+  message = '데이터 없음',
+  hint,
+  icon,
+  size = 'md',
+  className,
+}: EmptyStateProps) {
+  const s = sizeMap[size];
+  return (
+    <div
+      className={['flex flex-col items-center justify-center text-center', s.wrap, className]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div
+        className={`flex items-center justify-center rounded-full bg-gray-100 text-gray-400 ${s.circle}`}
+        aria-hidden="true"
+      >
+        {icon ?? <Inbox className={s.icon} />}
+      </div>
+      <p className={`text-text-secondary font-medium ${s.msg}`}>{message}</p>
+      {hint ? <p className="text-xs text-gray-400">{hint}</p> : null}
+    </div>
+  );
+}

--- a/apps/back-office/src/shared/ui/empty-state/index.ts
+++ b/apps/back-office/src/shared/ui/empty-state/index.ts
@@ -1,0 +1,1 @@
+export { EmptyState } from './empty-state';

--- a/apps/back-office/src/shared/ui/index.ts
+++ b/apps/back-office/src/shared/ui/index.ts
@@ -1,3 +1,4 @@
 export { Button } from './button';
+export * from './empty-state';
 export * from './input';
 export * from './select';

--- a/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.tsx
@@ -83,6 +83,9 @@ export function AdditionalAnalysisSection({
             </div>
           </div>
           <div className="mt-5 space-y-4">
+            {storageProjects.length === 0 && (
+              <p className="text-text-secondary py-6 text-center text-sm">없음</p>
+            )}
             {storageProjects.map((project) => {
               const percent = clampPercent(project.percent);
               return (

--- a/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.tsx
@@ -1,4 +1,5 @@
 import type { FunnelStep, StorageProject, StorageSummary } from '@/entities/admin-dashboard';
+import { EmptyState } from '@/shared/ui';
 
 type AdditionalAnalysisSectionProps = {
   funnel: FunnelStep[];
@@ -83,9 +84,7 @@ export function AdditionalAnalysisSection({
             </div>
           </div>
           <div className="mt-5 space-y-4">
-            {storageProjects.length === 0 && (
-              <p className="text-text-secondary py-6 text-center text-sm">없음</p>
-            )}
+            {storageProjects.length === 0 && <EmptyState size="sm" />}
             {storageProjects.map((project) => {
               const percent = clampPercent(project.percent);
               return (

--- a/apps/back-office/src/widgets/dashboard/ui/cost-spike-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/cost-spike-section.tsx
@@ -51,6 +51,13 @@ export function CostSpikeSection({ costProjects }: CostSpikeSectionProps) {
                   ))}
                 </tr>
               ))}
+              {costProjects.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="text-text-secondary py-10 text-center">
+                    없음
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         </div>

--- a/apps/back-office/src/widgets/dashboard/ui/cost-spike-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/cost-spike-section.tsx
@@ -1,4 +1,5 @@
 import type { CostProject } from '@/entities/admin-dashboard';
+import { EmptyState } from '@/shared/ui';
 
 type CostSpikeSectionProps = {
   costProjects: CostProject[];
@@ -53,8 +54,8 @@ export function CostSpikeSection({ costProjects }: CostSpikeSectionProps) {
               ))}
               {costProjects.length === 0 && (
                 <tr>
-                  <td colSpan={5} className="text-text-secondary py-10 text-center">
-                    없음
+                  <td colSpan={5}>
+                    <EmptyState size="sm" />
                   </td>
                 </tr>
               )}

--- a/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
@@ -164,6 +164,13 @@ export function TrendAnalysisSection({
                     <td className="px-5 py-3">{project[3]}</td>
                   </tr>
                 ))}
+                {activeProjects.length === 0 && (
+                  <tr>
+                    <td colSpan={4} className="text-text-secondary px-5 py-10 text-center">
+                      없음
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>

--- a/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 
 import type { ProjectActivity, TrendPoint } from '@/entities/admin-dashboard';
-import { Select } from '@/shared/ui';
+import { EmptyState, Select } from '@/shared/ui';
 
 import {
   selectContentClassName,
@@ -78,8 +78,8 @@ export function TrendAnalysisSection({
           </div>
           <div className="h-72 w-full" role="img" aria-label="DAU, WAU, MAU 사용자 추이 차트">
             {activeUserTrend.length === 0 ? (
-              <div className="text-text-secondary flex h-full items-center justify-center text-sm">
-                없음
+              <div className="flex h-full items-center justify-center">
+                <EmptyState message="데이터 없음" hint="연동 예정" />
               </div>
             ) : (
               <ActiveUsersChart data={activeUserTrend} />
@@ -172,8 +172,8 @@ export function TrendAnalysisSection({
                 ))}
                 {activeProjects.length === 0 && (
                   <tr>
-                    <td colSpan={4} className="text-text-secondary px-5 py-10 text-center">
-                      없음
+                    <td colSpan={4} className="px-5">
+                      <EmptyState size="sm" />
                     </td>
                   </tr>
                 )}

--- a/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/trend-analysis-section.tsx
@@ -77,7 +77,13 @@ export function TrendAnalysisSection({
             </h3>
           </div>
           <div className="h-72 w-full" role="img" aria-label="DAU, WAU, MAU 사용자 추이 차트">
-            <ActiveUsersChart data={activeUserTrend} />
+            {activeUserTrend.length === 0 ? (
+              <div className="text-text-secondary flex h-full items-center justify-center text-sm">
+                없음
+              </div>
+            ) : (
+              <ActiveUsersChart data={activeUserTrend} />
+            )}
           </div>
         </section>
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,6 +1,9 @@
 export * from './schema';
 export * from './client/supabase';
 export { getDatabase, checkDatabaseHealth, closeDatabase, type Database } from './client/drizzle';
+// drizzle 의 sql 태그를 재노출해 소비 앱이 drizzle-orm 을 직접 의존하지 않고도
+// db.execute(sql`...`) 를 같은 인스턴스로 쓸 수 있게 한다.
+export { sql } from 'drizzle-orm';
 export { getProjectStorageBytes } from './queries/get-project-storage';
 export {
   getActiveAnnouncements,


### PR DESCRIPTION
## 작업 유형

- [x] feat — 새 기능

## 요약
백오피스 대시보드(BO02)를 목 데이터에서 실제 DB 데이터로 연동했습니다. 받칠 수 있는 지표는 실측으로 계산하고, 데이터 원천이 없는 지표는 가짜 예시 대신 빈 상태로 표기합니다.

## 배경 / 동기
기존 대시보드는 모든 수치가 하드코딩된 목 데이터였습니다. 운영자가 실제 사용 현황을 확인하려면 실데이터 연동이 필요했습니다. 다만 이 제품은 사용자 계정이 없어(프로젝트 비밀번호 인증) 사용자 분석 지표나 외부 인프라 지표는 데이터 원천이 없습니다.

## 변경 사항
- 주요 지표(전체 프로젝트, 신규 프로젝트 주간, 테스트 케이스, 테스트 실행률)를 실제 집계로 표시
- 신규 프로젝트 추이와 콘텐츠 생산량 추이 차트를 실데이터로 연결
- 활성 프로젝트 상위 목록, 비용 급증 프로젝트, 스토리지 사용량을 실데이터로 표시
- 사용자 가입 대신 프로젝트 진행 단계(생성 → 첫 케이스 → 첫 실행 → 결과 확인)로 퍼널을 재정의
- 데이터 원천이 없는 영역(활성 사용자 추이, 주의 알림, 인프라/시스템 헬스, 어뷰징 모니터링)은 가짜 수치 대신 빈 상태로 표기
- 모든 집계를 단일 쿼리로 합치고, 응답이 지연되거나 실패하면 실패 안내 화면으로 처리
- 재사용 가능한 빈 상태 컴포넌트를 추가해 빈 영역에 일관되게 적용

## 영향 범위 / 주의사항
- AI 비용은 토큰 사용량에 단가를 가정해 추정한 값입니다(실제 청구액 아님)
- 헤더의 기간 선택은 아직 지표에 반영되지 않습니다(전체 누적 기준)
- 사용자 분석·인프라 지표를 실데이터화하려면 이벤트 추적 또는 외부 모니터링 연동이 선행되어야 합니다

## 테스트 방법
1. 백오피스 빌드 통과 확인
2. 백오피스 실행 후 대시보드에서 실데이터·빈 상태·실패 처리 동작 확인
