### PR TITLE
feat: 백오피스 인증 강화 (브루트포스 방어 + Cloudflare Access)

### DIFF
--- a/apps/back-office/DEPLOY_CLOUDFLARE.md
+++ b/apps/back-office/DEPLOY_CLOUDFLARE.md
@@ -32,6 +32,15 @@ web 앱(Vercel)과 달리 백오피스는 Cloudflare 로 따로 배포한다.
 3. **커스텀 도메인** 연결: Workers 설정에서 `dev.back.gettestea.com`(dev) 등 라우트 추가.
    DNS 가 Cloudflare 라 바로 붙는다.
 
+4. **Cloudflare Access (인증)**: Zero Trust → Access → Applications 에서 백오피스 도메인을
+   Self-hosted 앱으로 추가하고, 정책(허용 이메일·구글 그룹 등)을 건다. 그러면 엣지에서
+   신원 확인이 끝난 사람만 도달하고, 앱은 키 입력 없이 인증된다.
+   - JWT 검증을 켜려면 워커 변수에 `CF_ACCESS_TEAM_DOMAIN`(예: `your-team.cloudflareaccess.com`)
+     과 `CF_ACCESS_AUD`(Access 앱의 Application Audience 태그)를 넣는다. 설정 시
+     `Cf-Access-Jwt-Assertion` 을 팀 JWKS 로 검증한다. 미설정이면 이메일 헤더만 신뢰.
+   - 인증 방식: CF Access 헤더가 있으면 그 이메일로 인증·행위자 기록. 없으면(로컬 등)
+     공유키 게이트로 폴백. 운영 도메인은 CF Access 로 보호하는 것을 전제로 한다.
+
 ## 빌드 / 배포
 
 ```

--- a/apps/back-office/app/logs/page.tsx
+++ b/apps/back-office/app/logs/page.tsx
@@ -1,5 +1,5 @@
 import { navItems } from '@/entities/admin-dashboard';
-import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
+import { getAdminInfo, requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { AdminLogView } from '@/view/admin-log/admin-log-view';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 import { listAdminActivity } from '@testea/db';
@@ -8,14 +8,10 @@ export const dynamic = 'force-dynamic';
 
 export default async function LogsPage() {
   await requireAdmin('/logs');
-  const logs = await listAdminActivity(100);
+  const [logs, admin] = await Promise.all([listAdminActivity(100), getAdminInfo()]);
 
   return (
-    <BackOfficeLayout
-      navItems={navItems}
-      activeHref="/logs"
-      admin={{ name: '관리자', email: 'admin@testea.com' }}
-    >
+    <BackOfficeLayout navItems={navItems} activeHref="/logs" admin={admin}>
       <AdminLogView logs={logs} />
     </BackOfficeLayout>
   );

--- a/apps/back-office/app/notices/[id]/edit/page.tsx
+++ b/apps/back-office/app/notices/[id]/edit/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { navItems } from '@/entities/admin-dashboard';
-import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
+import { getAdminInfo, requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { updateNoticeAction } from '@/features/notices/api/actions';
 import { NoticeForm } from '@/view/notices/notice-form';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
@@ -12,15 +12,11 @@ export default async function EditNoticePage({ params }: { params: Promise<{ id:
   const { id } = await params;
   await requireAdmin(`/notices/${id}/edit`);
 
-  const notice = await getAnnouncementById(id);
+  const [notice, admin] = await Promise.all([getAnnouncementById(id), getAdminInfo()]);
   if (!notice) notFound();
 
   return (
-    <BackOfficeLayout
-      navItems={navItems}
-      activeHref="/notices"
-      admin={{ name: '관리자', email: 'admin@testea.com' }}
-    >
+    <BackOfficeLayout navItems={navItems} activeHref="/notices" admin={admin}>
       <div className="mx-auto flex max-w-2xl flex-col gap-6 px-8 py-8">
         <div className="flex flex-col gap-1">
           <Link href="/notices" className="text-text-secondary hover:text-text-primary text-sm">

--- a/apps/back-office/app/notices/new/page.tsx
+++ b/apps/back-office/app/notices/new/page.tsx
@@ -1,20 +1,17 @@
 import Link from 'next/link';
 
 import { navItems } from '@/entities/admin-dashboard';
-import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
+import { getAdminInfo, requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { createNoticeAction } from '@/features/notices/api/actions';
 import { NoticeForm } from '@/view/notices/notice-form';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 
 export default async function NewNoticePage() {
   await requireAdmin('/notices/new');
+  const admin = await getAdminInfo();
 
   return (
-    <BackOfficeLayout
-      navItems={navItems}
-      activeHref="/notices"
-      admin={{ name: '관리자', email: 'admin@testea.com' }}
-    >
+    <BackOfficeLayout navItems={navItems} activeHref="/notices" admin={admin}>
       <div className="mx-auto flex max-w-2xl flex-col gap-6 px-8 py-8">
         <div className="flex flex-col gap-1">
           <Link href="/notices" className="text-text-secondary hover:text-text-primary text-sm">

--- a/apps/back-office/app/notices/page.tsx
+++ b/apps/back-office/app/notices/page.tsx
@@ -1,5 +1,5 @@
 import { navItems } from '@/entities/admin-dashboard';
-import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
+import { getAdminInfo, requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { NoticesView } from '@/view/notices/notices-view';
 import { BackOfficeLayout } from '@/widgets/back-office-layout';
 import { listAnnouncements } from '@testea/db';
@@ -8,14 +8,10 @@ export const dynamic = 'force-dynamic';
 
 export default async function NoticesPage() {
   await requireAdmin('/notices');
-  const items = await listAnnouncements();
+  const [items, admin] = await Promise.all([listAnnouncements(), getAdminInfo()]);
 
   return (
-    <BackOfficeLayout
-      navItems={navItems}
-      activeHref="/notices"
-      admin={{ name: '관리자', email: 'admin@testea.com' }}
-    >
+    <BackOfficeLayout navItems={navItems} activeHref="/notices" admin={admin}>
       <NoticesView items={items} />
     </BackOfficeLayout>
   );

--- a/apps/back-office/package.json
+++ b/apps/back-office/package.json
@@ -24,6 +24,7 @@
     "@testea/ui": "workspace:*",
     "@testea/util": "workspace:*",
     "drizzle-orm": "^0.45.2",
+    "jose": "^6.2.3",
     "lucide-react": "^0.561.0",
     "next": "16.2.9",
     "pg": "^8.21.0",

--- a/apps/back-office/src/features/admin-log/log.ts
+++ b/apps/back-office/src/features/admin-log/log.ts
@@ -2,16 +2,23 @@ import { headers } from 'next/headers';
 
 import { type AdminActivityInput, recordAdminActivity } from '@testea/db';
 
+/** 신뢰 헤더에서 클라이언트 IP 를 추출한다. 추출 실패 시 null. */
+export async function getClientIp(): Promise<string | null> {
+  try {
+    const h = await headers();
+    return h.get('x-forwarded-for')?.split(',')[0]?.trim() || h.get('x-real-ip')?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * 관리자 활동을 기록한다. 신뢰 헤더에서 클라이언트 IP 를 추출해 함께 남긴다.
+ * 관리자 활동을 기록한다. 클라이언트 IP 를 함께 남긴다.
  * 로깅 실패가 주 동작(로그인·공지 변경)을 막지 않도록 내부에서 swallow 한다.
  */
 export async function logAdminActivity(input: Omit<AdminActivityInput, 'ip'>): Promise<void> {
   try {
-    const h = await headers();
-    const ip =
-      h.get('x-forwarded-for')?.split(',')[0]?.trim() || h.get('x-real-ip')?.trim() || null;
-    await recordAdminActivity({ ...input, ip });
+    await recordAdminActivity({ ...input, ip: await getClientIp() });
   } catch (error) {
     console.error('[admin-log] 활동 기록 실패', error);
   }

--- a/apps/back-office/src/features/admin-log/log.ts
+++ b/apps/back-office/src/features/admin-log/log.ts
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers';
 
+import { getCfAccessEmail } from '@/features/auth-gate/lib/cf-access';
 import { type AdminActivityInput, recordAdminActivity } from '@testea/db';
 
 /** 신뢰 헤더에서 클라이언트 IP 를 추출한다. 추출 실패 시 null. */
@@ -16,9 +17,12 @@ export async function getClientIp(): Promise<string | null> {
  * 관리자 활동을 기록한다. 클라이언트 IP 를 함께 남긴다.
  * 로깅 실패가 주 동작(로그인·공지 변경)을 막지 않도록 내부에서 swallow 한다.
  */
-export async function logAdminActivity(input: Omit<AdminActivityInput, 'ip'>): Promise<void> {
+export async function logAdminActivity(
+  input: Omit<AdminActivityInput, 'ip' | 'actor'>
+): Promise<void> {
   try {
-    await recordAdminActivity({ ...input, ip: await getClientIp() });
+    const [ip, actor] = await Promise.all([getClientIp(), getCfAccessEmail()]);
+    await recordAdminActivity({ ...input, ip, actor });
   } catch (error) {
     console.error('[admin-log] 활동 기록 실패', error);
   }

--- a/apps/back-office/src/features/auth-gate/api/gate-actions.ts
+++ b/apps/back-office/src/features/auth-gate/api/gate-actions.ts
@@ -3,12 +3,18 @@
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { logAdminActivity } from '@/features/admin-log/log';
+import { getClientIp, logAdminActivity } from '@/features/admin-log/log';
 import { initCloudflareDb } from '@/shared/db/cloudflare-db';
+import { countRecentFailedLogins } from '@testea/db';
 
 import { ADMIN_COOKIE, isValidSecret } from '../lib/admin-gate';
 
 export type GateState = { error?: string };
+
+// 브루트포스 방어: 같은 IP 가 최근 LOCK_WINDOW_MIN 분 내 LOCK_THRESHOLD 회 실패하면 잠근다.
+// 인메모리가 아니라 admin_activity_logs(DB) 기반이라 Cloudflare Workers 다중 isolate 에서도 동작한다.
+const LOCK_THRESHOLD = 5;
+const LOCK_WINDOW_MIN = 15;
 
 /** 게이트 폼 제출 후 안전한 내부 경로만 허용 (open redirect 차단). */
 function safeRedirect(raw: FormDataEntryValue | null): string {
@@ -21,10 +27,21 @@ function safeRedirect(raw: FormDataEntryValue | null): string {
  * useActionState 시그니처: (prevState, formData) => state.
  */
 export async function signInAdminAction(_prev: GateState, formData: FormData): Promise<GateState> {
+  // 런타임에 맞는 DB 준비(Workers=Hyperdrive, 그 외 no-op). 락아웃 조회·기록에 필요.
+  initCloudflareDb();
+
   const secret = formData.get('secret');
   const candidate = typeof secret === 'string' ? secret : '';
+  const ip = await getClientIp();
+
+  // 락아웃: 최근 실패가 임계치 이상이면 키 검증 전에 차단
+  const recentFailures = await countRecentFailedLogins(ip, LOCK_WINDOW_MIN);
+  if (recentFailures >= LOCK_THRESHOLD) {
+    return { error: `시도가 너무 많습니다. 약 ${LOCK_WINDOW_MIN}분 후 다시 시도해주세요.` };
+  }
 
   if (!isValidSecret(candidate)) {
+    await logAdminActivity({ action: 'login.failed' });
     return { error: '키가 올바르지 않습니다.' };
   }
 
@@ -37,7 +54,6 @@ export async function signInAdminAction(_prev: GateState, formData: FormData): P
     maxAge: 60 * 60 * 8, // 8시간
   });
 
-  initCloudflareDb();
   await logAdminActivity({ action: 'login' });
 
   redirect(safeRedirect(formData.get('redirect')));

--- a/apps/back-office/src/features/auth-gate/lib/admin-gate.ts
+++ b/apps/back-office/src/features/auth-gate/lib/admin-gate.ts
@@ -4,15 +4,17 @@ import { redirect } from 'next/navigation';
 import { initCloudflareDb } from '@/shared/db/cloudflare-db';
 import { timingSafeEqual } from 'node:crypto';
 
+import { getCfAccessEmail } from './cf-access';
+
 /**
- * 백오피스 v1 임시 인증 게이트 (환경변수 공유키).
+ * 백오피스 인증.
  *
- * 정식 Supabase Auth + RBAC 는 [BO12] 로 분리. 그전까지 사이트 전역 공지 발행 같은
- * 위험 액션을 무인증으로 두지 않기 위한 최소 안전장치다.
+ * 운영(Cloudflare): **Cloudflare Access** 가 엣지에서 신원(이메일)을 확인한다.
+ * CF Access 가 통과시킨 요청은 키 입력 없이 인증으로 본다. 행위자는 그 이메일.
  *
- * - 운영자가 `/notices/gate` 에서 공유키를 입력하면 httpOnly 쿠키로 보관한다.
- * - 모든 페이지/서버 액션은 이 쿠키를 `BACKOFFICE_ADMIN_SECRET` 과 상수시간 비교한다.
- * - 시크릿 미설정(fail-closed) 이면 누구도 통과하지 못한다.
+ * 로컬·CF Access 미적용: **공유키 게이트** 로 폴백. 운영자가 `/notices/gate` 에서
+ * 공유키를 입력하면 httpOnly 쿠키로 보관하고, `BACKOFFICE_ADMIN_SECRET` 과 상수시간 비교한다.
+ * 시크릿·CF Access 둘 다 없으면 누구도 통과하지 못한다(fail-closed).
  */
 export const ADMIN_COOKIE = 'bo_admin_session';
 const GATE_PATH = '/notices/gate';
@@ -32,10 +34,27 @@ export function isValidSecret(candidate: string | undefined | null): boolean {
   return safeEqual(candidate, secret);
 }
 
-/** 현재 요청이 인증된 운영자 세션인지. */
-export async function isAdminAuthed(): Promise<boolean> {
+/**
+ * 현재 행위자(관리자) 식별자를 반환한다. 우선순위: Cloudflare Access 이메일 → 공유키 세션.
+ * 인증 안 됐으면 null. 공유키 세션이면 이메일이 없으므로 'shared-key' 를 돌려준다.
+ */
+export async function getAdminActor(): Promise<string | null> {
+  const email = await getCfAccessEmail();
+  if (email) return email;
   const store = await cookies();
-  return isValidSecret(store.get(ADMIN_COOKIE)?.value);
+  return isValidSecret(store.get(ADMIN_COOKIE)?.value) ? 'shared-key' : null;
+}
+
+/** 현재 요청이 인증된 운영자인지 (Cloudflare Access 또는 공유키 세션). */
+export async function isAdminAuthed(): Promise<boolean> {
+  return (await getAdminActor()) !== null;
+}
+
+/** 사이드바 표시용 관리자 정보. CF Access 이메일이 있으면 그걸, 없으면 공유키 세션 표기. */
+export async function getAdminInfo(): Promise<{ name: string; email: string }> {
+  const email = await getCfAccessEmail();
+  if (email) return { name: email.split('@')[0] || '관리자', email };
+  return { name: '관리자', email: '공유키 세션' };
 }
 
 /**

--- a/apps/back-office/src/features/auth-gate/lib/cf-access.ts
+++ b/apps/back-office/src/features/auth-gate/lib/cf-access.ts
@@ -1,0 +1,47 @@
+import { headers } from 'next/headers';
+
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+/**
+ * Cloudflare Access 신원 확인.
+ *
+ * CF Access 는 엣지에서 인증을 마친 뒤 요청에 다음 헤더를 주입한다:
+ * - `Cf-Access-Authenticated-User-Email`: 인증된 이메일
+ * - `Cf-Access-Jwt-Assertion`: 서명된 JWT (위변조 검증용)
+ *
+ * `CF_ACCESS_TEAM_DOMAIN` + `CF_ACCESS_AUD` 가 설정되면 JWT 를 팀 JWKS 로 검증한다(운영 권장).
+ * 미설정이면 헤더만 신뢰한다(로컬·초기). CF Access 가 워커 라우트를 보호하면 헤더는 신뢰 가능.
+ *
+ * 반환: 인증 이메일 또는 null(헤더 없음·검증 실패).
+ */
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+export async function getCfAccessEmail(): Promise<string | null> {
+  let email: string | null;
+  let token: string | null;
+  try {
+    const h = await headers();
+    email = h.get('cf-access-authenticated-user-email');
+    token = h.get('cf-access-jwt-assertion');
+  } catch {
+    return null;
+  }
+
+  if (!email) return null;
+
+  const teamDomain = process.env.CF_ACCESS_TEAM_DOMAIN;
+  const aud = process.env.CF_ACCESS_AUD;
+
+  // 검증 미설정: 헤더 신뢰 (CF Access 가 라우트를 보호한다는 전제)
+  if (!teamDomain || !aud) return email;
+
+  if (!token) return null;
+  try {
+    jwks ??= createRemoteJWKSet(new URL(`https://${teamDomain}/cdn-cgi/access/certs`));
+    const { payload } = await jwtVerify(token, jwks, { audience: aud });
+    return (typeof payload.email === 'string' ? payload.email : null) ?? email;
+  } catch {
+    return null;
+  }
+}

--- a/apps/back-office/src/view/admin-log/admin-log-view.tsx
+++ b/apps/back-office/src/view/admin-log/admin-log-view.tsx
@@ -3,6 +3,7 @@ import { Inbox } from 'lucide-react';
 
 const ACTION_LABEL: Record<string, { label: string; cls: string }> = {
   login: { label: '접속', cls: 'bg-blue-100 text-blue-700' },
+  'login.failed': { label: '로그인 실패', cls: 'bg-red-100 text-red-700' },
   'notice.create': { label: '공지 생성', cls: 'bg-green-100 text-green-700' },
   'notice.update': { label: '공지 수정', cls: 'bg-gray-100 text-gray-600' },
   'notice.activate': { label: '공지 활성화', cls: 'bg-green-100 text-green-700' },

--- a/apps/back-office/src/view/admin-log/admin-log-view.tsx
+++ b/apps/back-office/src/view/admin-log/admin-log-view.tsx
@@ -34,6 +34,7 @@ export function AdminLogView({ logs }: { logs: AdminActivityLog[] }) {
             <thead className="border-border text-text-secondary border-b bg-[#f9fafb] text-xs">
               <tr>
                 <th className="px-4 py-3 font-semibold">시각</th>
+                <th className="px-4 py-3 font-semibold">관리자</th>
                 <th className="px-4 py-3 font-semibold">액션</th>
                 <th className="px-4 py-3 font-semibold">대상</th>
                 <th className="px-4 py-3 font-semibold">IP</th>
@@ -49,6 +50,9 @@ export function AdminLogView({ logs }: { logs: AdminActivityLog[] }) {
                   <tr key={log.id} className="border-border border-b last:border-0">
                     <td className="text-text-secondary px-4 py-3 text-sm whitespace-nowrap">
                       {formatDateTime(log.createdAt)}
+                    </td>
+                    <td className="text-text-primary px-4 py-3 text-sm">
+                      {log.actor ?? <span className="text-text-secondary">공유키</span>}
                     </td>
                     <td className="px-4 py-3">
                       <span className={`rounded-md px-2.5 py-1 text-xs font-medium ${action.cls}`}>
@@ -66,7 +70,7 @@ export function AdminLogView({ logs }: { logs: AdminActivityLog[] }) {
               })}
               {logs.length === 0 && (
                 <tr>
-                  <td colSpan={4}>
+                  <td colSpan={5}>
                     <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
                       <div
                         className="flex h-14 w-14 items-center justify-center rounded-full bg-gray-100 text-gray-400"

--- a/packages/db/drizzle/0017_funny_enchantress.sql
+++ b/packages/db/drizzle/0017_funny_enchantress.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "admin_activity_logs" ADD COLUMN "actor" text;

--- a/packages/db/drizzle/meta/0017_snapshot.json
+++ b/packages/db/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2920 @@
+{
+  "id": "ddb54f54-4d98-45a4-9fe2-e922d617d46b",
+  "prevId": "166724bc-6512-4d89-878b-77f1fec91b54",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_scenario_id": {
+          "name": "test_scenario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "test_suites_active_scenario_unq": {
+          "name": "test_suites_active_scenario_unq",
+          "columns": [
+            {
+              "expression": "test_scenario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"test_suites\".\"lifecycle_status\" = 'ACTIVE' AND \"test_suites\".\"test_scenario_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suites_test_scenario_id_test_scenarios_id_fk": {
+          "name": "test_suites_test_scenario_id_test_scenarios_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "test_scenarios",
+          "columnsFrom": [
+            "test_scenario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_key": {
+          "name": "case_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[10]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "automation_status": {
+          "name": "automation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_test_suite_id_test_suites_id_fk": {
+          "name": "test_cases_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_cases_section_id_test_suite_sections_id_fk": {
+          "name": "test_cases_section_id_test_suite_sections_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suite_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_cases_project_id_name_unique": {
+          "name": "test_cases_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        },
+        "test_cases_project_id_display_id_unique": {
+          "name": "test_cases_project_id_display_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "display_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_cases_automation_status_check": {
+          "name": "test_cases_automation_status_check",
+          "value": "\"test_cases\".\"automation_status\" in ('manual', 'candidate', 'automated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_STARTED'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_ai_summary": {
+          "name": "share_ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_milestone_id_milestones_id_fk": {
+          "name": "test_runs_milestone_id_milestones_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_runs_share_token_unique": {
+          "name": "test_runs_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_project_id_projects_id_fk": {
+          "name": "milestones_project_id_projects_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_runs": {
+      "name": "test_case_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'adhoc'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_source": {
+          "name": "result_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "automation_meta": {
+          "name": "automation_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_runs_test_run_id_test_runs_id_fk": {
+          "name": "test_case_runs_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_runs_test_case_id_test_cases_id_fk": {
+          "name": "test_case_runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_case_runs_result_source_check": {
+          "name": "test_case_runs_result_source_check",
+          "value": "\"test_case_runs\".\"result_source\" in ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_run_milestones": {
+      "name": "test_run_milestones",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_milestones_test_run_id_test_runs_id_fk": {
+          "name": "test_run_milestones_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_milestones_milestone_id_milestones_id_fk": {
+          "name": "test_run_milestones_milestone_id_milestones_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_milestones_test_run_id_milestone_id_pk": {
+          "name": "test_run_milestones_test_run_id_milestone_id_pk",
+          "columns": [
+            "test_run_id",
+            "milestone_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_run_suites": {
+      "name": "test_run_suites",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_suites_test_run_id_test_runs_id_fk": {
+          "name": "test_run_suites_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_suites_test_suite_id_test_suites_id_fk": {
+          "name": "test_run_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_suites_test_run_id_test_suite_id_pk": {
+          "name": "test_run_suites_test_run_id_test_suite_id_pk",
+          "columns": [
+            "test_run_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suite_test_cases": {
+      "name": "suite_test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suite_test_cases_suite_id_test_suites_id_fk": {
+          "name": "suite_test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suite_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "suite_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_cases": {
+      "name": "milestone_test_cases",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_cases_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_cases_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "milestone_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_cases_milestone_id_test_case_id_pk": {
+          "name": "milestone_test_cases_milestone_id_test_case_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_case_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_suites": {
+      "name": "milestone_test_suites",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_suites_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_suites_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_suites_test_suite_id_test_suites_id_fk": {
+          "name": "milestone_test_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_suites_milestone_id_test_suite_id_pk": {
+          "name": "milestone_test_suites_milestone_id_test_suite_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_preferences": {
+      "name": "project_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_preferences_project_id_projects_id_fk": {
+          "name": "project_preferences_project_id_projects_id_fk",
+          "tableFrom": "project_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_preferences_project_id_key_unique": {
+          "name": "project_preferences_project_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_project_id_projects_id_fk": {
+          "name": "audit_logs_project_id_projects_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_activity_logs": {
+      "name": "admin_activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_label": {
+          "name": "target_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_activity_logs_created_idx": {
+          "name": "admin_activity_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_attachments": {
+      "name": "test_case_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_attachments_test_case_id_test_cases_id_fk": {
+          "name": "test_case_attachments_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_attachments_project_id_projects_id_fk": {
+          "name": "test_case_attachments_project_id_projects_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_templates": {
+      "name": "test_case_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_steps": {
+          "name": "test_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_templates_project_id_projects_id_fk": {
+          "name": "test_case_templates_project_id_projects_id_fk",
+          "tableFrom": "test_case_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_templates_project_id_name_unique": {
+          "name": "test_case_templates_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_versions": {
+      "name": "test_case_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_versions_test_case_id_test_cases_id_fk": {
+          "name": "test_case_versions_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_versions",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_versions_test_case_id_version_number_unique": {
+          "name": "test_case_versions_test_case_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_case_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suite_sections": {
+      "name": "test_suite_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suite_sections_suite_id_test_suites_id_fk": {
+          "name": "test_suite_sections_suite_id_test_suites_id_fk",
+          "tableFrom": "test_suite_sections",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_sections_suite_id_name_unique": {
+          "name": "test_suite_sections_suite_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suite_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklists_project_id_projects_id_fk": {
+          "name": "checklists_project_id_projects_id_fk",
+          "tableFrom": "checklists",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_checklist_id_checklists_id_fk": {
+          "name": "checklist_items_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_connections_project_id_projects_id_fk": {
+          "name": "github_connections_project_id_projects_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_project_id_unique": {
+          "name": "github_connections_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_external_links": {
+      "name": "test_case_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tc_ext_links_case": {
+          "name": "idx_tc_ext_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tc_ext_links_external": {
+          "name": "idx_tc_ext_links_external",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_case_external_links_test_case_id_test_cases_id_fk": {
+          "name": "test_case_external_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_external_links",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ai_configs": {
+      "name": "project_ai_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_ai_configs_project_id_projects_id_fk": {
+          "name": "project_ai_configs_project_id_projects_id_fk",
+          "tableFrom": "project_ai_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_ai_configs_project_id_unique": {
+          "name": "project_ai_configs_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generated_count": {
+          "name": "generated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_size_bytes": {
+          "name": "attached_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_page_count": {
+          "name": "attached_file_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_project_id_projects_id_fk": {
+          "name": "ai_usage_logs_project_id_projects_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_logs_attached_file_type_check": {
+          "name": "ai_usage_logs_attached_file_type_check",
+          "value": "\"ai_usage_logs\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_as_popup": {
+          "name": "show_as_popup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_active_idx": {
+          "name": "announcements_active_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_category_idx": {
+          "name": "announcements_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reads": {
+      "name": "notification_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_reads_user_idx": {
+          "name": "notification_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_reads_announcement_idx": {
+          "name": "notification_reads_announcement_idx",
+          "columns": [
+            {
+              "expression": "announcement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reads_announcement_id_announcements_id_fk": {
+          "name": "notification_reads_announcement_id_announcements_id_fk",
+          "tableFrom": "notification_reads",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reads_user_announcement_unq": {
+          "name": "notification_reads_user_announcement_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "announcement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_tokens": {
+      "name": "project_automation_tokens",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_tokens_token_hash_unq": {
+          "name": "project_automation_tokens_token_hash_unq",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_tokens_project_id_projects_id_fk": {
+          "name": "project_automation_tokens_project_id_projects_id_fk",
+          "tableFrom": "project_automation_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_requirement_analyses": {
+      "name": "ai_requirement_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_input": {
+          "name": "source_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko'"
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_requirement_analyses_project_id_projects_id_fk": {
+          "name": "ai_requirement_analyses_project_id_projects_id_fk",
+          "tableFrom": "ai_requirement_analyses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_requirement_analyses_attached_file_type_check": {
+          "name": "ai_requirement_analyses_attached_file_type_check",
+          "value": "\"ai_requirement_analyses\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_scenarios": {
+      "name": "test_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "related_requirement_ids": {
+          "name": "related_requirement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_scenarios_project_id_projects_id_fk": {
+          "name": "test_scenarios_project_id_projects_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_scenarios_type_check": {
+          "name": "test_scenarios_type_check",
+          "value": "\"test_scenarios\".\"type\" in ('positive', 'negative', 'edge_case')"
+        },
+        "test_scenarios_status_check": {
+          "name": "test_scenarios_status_check",
+          "value": "\"test_scenarios\".\"status\" in ('DRAFT', 'REVIEW', 'CONFIRMED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.target_sites": {
+      "name": "target_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_secret_encrypted": {
+          "name": "auth_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_sites_project_id_projects_id_fk": {
+          "name": "target_sites_project_id_projects_id_fk",
+          "tableFrom": "target_sites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1781539835761,
       "tag": "0016_magenta_thunderbolts",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1781583348019,
+      "tag": "0017_funny_enchantress",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -36,6 +36,7 @@ export {
 export {
   recordAdminActivity,
   listAdminActivity,
+  countRecentFailedLogins,
   type AdminActivityInput,
   type AdminActivityLog,
 } from './queries/admin-activity';

--- a/packages/db/src/queries/admin-activity.ts
+++ b/packages/db/src/queries/admin-activity.ts
@@ -1,4 +1,4 @@
-import { desc } from 'drizzle-orm';
+import { and, desc, eq, gt, sql } from 'drizzle-orm';
 
 import { getDatabase } from '../client/drizzle';
 import { type AdminActivityAction, adminActivityLogs } from '../schema/admin-activity-logs';
@@ -40,6 +40,30 @@ export type AdminActivityLog = {
   ip: string | null;
   createdAt: string;
 };
+
+/**
+ * 특정 IP 의 최근 N 분 내 로그인 실패 횟수. 게이트 락아웃 판단에 쓴다.
+ * ip 가 없으면(추출 실패) 0 을 반환해 잠그지 않는다.
+ */
+export async function countRecentFailedLogins(
+  ip: string | null,
+  withinMinutes: number
+): Promise<number> {
+  if (!ip) return 0;
+  const db = getDatabase();
+  const since = sql`now() - (${withinMinutes} * interval '1 minute')`;
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(adminActivityLogs)
+    .where(
+      and(
+        eq(adminActivityLogs.action, 'login.failed'),
+        eq(adminActivityLogs.ip, ip),
+        gt(adminActivityLogs.created_at, since)
+      )
+    );
+  return Number(row?.count ?? 0);
+}
 
 /** 최신순 활동 로그를 반환한다. */
 export async function listAdminActivity(limit = 100): Promise<AdminActivityLog[]> {

--- a/packages/db/src/queries/admin-activity.ts
+++ b/packages/db/src/queries/admin-activity.ts
@@ -10,6 +10,8 @@ import { type AdminActivityAction, adminActivityLogs } from '../schema/admin-act
 
 export type AdminActivityInput = {
   action: AdminActivityAction;
+  /** 행위자(Cloudflare Access 인증 이메일). 공유키 게이트면 생략. */
+  actor?: string | null;
   targetType?: string | null;
   targetId?: string | null;
   targetLabel?: string | null;
@@ -22,6 +24,7 @@ export async function recordAdminActivity(input: AdminActivityInput): Promise<vo
   const db = getDatabase();
   await db.insert(adminActivityLogs).values({
     action: input.action,
+    actor: input.actor ?? null,
     target_type: input.targetType ?? null,
     target_id: input.targetId ?? null,
     target_label: input.targetLabel ?? null,
@@ -33,6 +36,7 @@ export async function recordAdminActivity(input: AdminActivityInput): Promise<vo
 export type AdminActivityLog = {
   id: string;
   action: AdminActivityAction;
+  actor: string | null;
   targetType: string | null;
   targetId: string | null;
   targetLabel: string | null;
@@ -77,6 +81,7 @@ export async function listAdminActivity(limit = 100): Promise<AdminActivityLog[]
   return rows.map((row) => ({
     id: row.id,
     action: row.action,
+    actor: row.actor,
     targetType: row.target_type,
     targetId: row.target_id,
     targetLabel: row.target_label,

--- a/packages/db/src/schema/admin-activity-logs.ts
+++ b/packages/db/src/schema/admin-activity-logs.ts
@@ -30,6 +30,8 @@ export const adminActivityLogs = pgTable(
   'admin_activity_logs',
   (t) => ({
     id: t.uuid('id').primaryKey().defaultRandom(),
+    /** 행위자 식별(Cloudflare Access 인증 이메일). 공유키 게이트(로컬)면 NULL. */
+    actor: t.text('actor'),
     action: t.varchar('action', { length: 40 }).$type<AdminActivityAction>().notNull(),
     target_type: t.varchar('target_type', { length: 50 }),
     target_id: t.uuid('target_id'),

--- a/packages/db/src/schema/admin-activity-logs.ts
+++ b/packages/db/src/schema/admin-activity-logs.ts
@@ -4,10 +4,12 @@ import { index, jsonb, pgTable, text, timestamp, uuid, varchar } from 'drizzle-o
  * 백오피스 관리자 활동 로그 액션.
  *
  * - login: 운영자 게이트 통과(접속)
+ * - login.failed: 게이트 인증 실패(브루트포스 추적·락아웃 판단용)
  * - notice.*: 공지 생성·수정·활성/비활성·삭제
  */
 export const adminActivityActionEnum = [
   'login',
+  'login.failed',
   'notice.create',
   'notice.update',
   'notice.activate',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(pg@8.21.0)(postgres@3.4.9)
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
       lucide-react:
         specifier: ^0.561.0
         version: 0.561.0(react@19.2.3)
@@ -6653,6 +6656,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -15835,6 +15841,8 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
 


### PR DESCRIPTION
## 작업 유형

- [x] feat — 새 기능

## 요약
백오피스 인증을 강화했습니다. (1) 게이트 브루트포스 방어, (2) Cloudflare Access 기반 신원 인증. 운영 도메인에서는 키 입력 없이 엣지 신원확인으로 들어가고, 누가 무엇을 했는지 활동 로그에 기록됩니다.

## 배경 / 동기
기존 진입은 공유키 하나뿐이고 시도 횟수 제한도, 행위자 식별도 없었습니다. 백오피스를 Cloudflare 로 배포·공개하기 전에 인증을 단단히 할 필요가 있었습니다.

## 변경 사항
- 게이트 로그인 실패를 기록하고, 같은 IP 의 최근 15분 내 실패가 일정 횟수 이상이면 잠금
- 잠금 판단을 활동 로그(DB) 기준으로 처리 — 인스턴스가 여럿인 Cloudflare 환경에서도 일관 동작
- Cloudflare Access 가 엣지에서 확인한 신원(이메일)으로 인증 — 운영에서는 키 입력창 없이 통과
- Access JWT 검증(팀 도메인·Audience 설정 시)으로 헤더 위변조 방지
- 활동 로그에 행위자(관리자 이메일) 기록 + 관리자 로그 화면에 관리자 컬럼 추가
- 사이드바에 현재 관리자 이메일 표시
- 로컬·Access 미적용 환경은 기존 공유키 게이트로 폴백

## 영향 범위 / 주의사항

- [x] DB 스키마 / 마이그레이션 변경 있음 — 활동 로그에 행위자 컬럼 추가(dev 적용 완료, prod 미적용)
- [x] 환경 변수 추가·변경 있음 — Cloudflare Access 검증용 팀 도메인·Audience(설정 시), 운영자 공유키(폴백)
- [x] 인프라 / 배포 설정 변경 있음 — 운영 도메인에 Cloudflare Access 정책 적용 전제(배포 문서에 절차 정리)

## 테스트 방법
1. 게이트에서 틀린 키로 반복 시도 → 일정 횟수 후 잠금, 관리자 로그에 실패 기록
2. Cloudflare Access 인증 헤더가 있으면 키 입력 없이 진입, 사이드바·로그에 그 이메일 표시
