### PR TITLE
fix(security): 러너 타임아웃 강제종료 시 브라우저 손자 프로세스 누수 차단

### DIFF
--- a/apps/runner/src/run-spec.ts
+++ b/apps/runner/src/run-spec.ts
@@ -194,11 +194,24 @@ export async function runSpec(input: RunSpecInput): Promise<RunSpecResult> {
         // 임의 코드(spec)에 전체 env 를 상속하지 않는다. RUNNER_SHARED_SECRET 등
         // 시크릿 유출 방지를 위해 Playwright 실행에 필요한 키만 allowlist 로 전달한다.
         env: buildChildEnv(),
+        // 자체 프로세스 그룹으로 띄운다. 타임아웃 강제 종료 시 @playwright/test 가
+        // 띄운 Chromium 손자 프로세스까지 그룹 단위로 회수하기 위함이다. detached 는
+        // unref 가 아니므로 부모는 아래 close 까지 그대로 대기한다. (러너는 Linux 컨테이너 전제)
+        detached: true,
       });
 
-      const killer = setTimeout(() => {
-        child.kill('SIGKILL');
-      }, timeoutMs);
+      // 직접 자식(node CLI)만 죽이면 Chromium 손자 프로세스가 고아로 남아
+      // 메모리/CPU 를 누수한다. child.pid 를 음수로 넘겨 프로세스 그룹 전체를 종료한다.
+      const killGroup = () => {
+        if (child.pid === undefined) return;
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+        } catch {
+          // 이미 종료됐거나(ESRCH) 그룹이 없으면 무시한다.
+        }
+      };
+
+      const killer = setTimeout(killGroup, timeoutMs);
 
       child.on('error', () => {
         clearTimeout(killer);


### PR DESCRIPTION
## 작업 유형

- [x] fix — 보안/안정성 수정

## 요약
테스트 러너가 실행 시간을 초과해 강제 종료할 때, 직접 띄운 프로세스만 죽이고 그 아래 브라우저 프로세스는 고아로 남던 문제를 고칩니다. 이제 프로세스 그룹 전체를 한 번에 정리합니다.

## 배경 / 동기
러너는 요청마다 격리된 자식 프로세스로 테스트를 실행하고, 하드 타임아웃이 지나면 강제 종료합니다. 기존에는 직접 자식만 종료해, 그 자식이 띄운 브라우저 손자 프로세스가 컨테이너에 남아 메모리와 CPU를 계속 점유했습니다. 실행이 쌓일수록 리소스가 누수됩니다.

## 변경 사항
- 자식 실행을 자체 프로세스 그룹으로 격리해, 타임아웃 강제 종료 시 브라우저 손자 프로세스까지 그룹 단위로 함께 회수
- 이미 종료된 경우는 조용히 무시해 정상 흐름에 영향 없음
- 정상 종료 대기 동작은 그대로 유지

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- 러너는 Linux 컨테이너에서 동작하며, 프로세스 그룹 종료는 그 환경 전제의 동작입니다.

## 테스트 방법
1. 러너 타입체크 통과 확인
2. 리눅스 환경에서 의도적으로 타임아웃을 유발했을 때, 종료 후 잔여 브라우저 프로세스가 남지 않는지 확인
