### PR TITLE
fix(security): 클라이언트 노출 에러 메시지 정적화 (내부 정보 누출 차단)

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -5,6 +5,10 @@ import { eq, sql } from 'drizzle-orm';
 
 export const dynamic = 'force-dynamic';
 
+// 운영에서는 내부 에러 메시지·스택·DB 설정을 응답에 노출하지 않는다 (정보 누출 방지).
+// 상세 진단은 비운영(dev/preview)에서만 반환한다.
+const isProd = process.env.VERCEL_ENV === 'production';
+
 export async function GET() {
   const results: Record<string, unknown> = {};
 
@@ -31,15 +35,25 @@ export async function GET() {
         .where(eq(testCaseRuns.test_run_id, runList[0].id));
       results.testCaseRuns = { ok: true, count: caseRuns.length };
     }
-  } catch (e: any) {
-    results.error = { message: e.message, stack: e.stack?.split('\n').slice(0, 3) };
+  } catch (e) {
+    results.ok = false;
+    // 상세는 서버 로그에만 남기고, 운영 응답에는 노출하지 않는다.
+    console.error('[health] check failed:', e);
+    if (!isProd) {
+      results.error = {
+        message: e instanceof Error ? e.message : String(e),
+        stack: e instanceof Error ? e.stack?.split('\n').slice(0, 3) : undefined,
+      };
+    }
   }
 
-  results.env = {
-    nodeEnv: process.env.NODE_ENV,
-    hasDbUrl: !!process.env.SUPABASE_DB_URL,
-    dbUrlPort: process.env.SUPABASE_DB_URL?.match(/:(\d+)\//)?.[1] || 'unknown',
-  };
+  if (!isProd) {
+    results.env = {
+      nodeEnv: process.env.NODE_ENV,
+      hasDbUrl: !!process.env.SUPABASE_DB_URL,
+      dbUrlPort: process.env.SUPABASE_DB_URL?.match(/:(\d+)\//)?.[1] || 'unknown',
+    };
+  }
 
   return NextResponse.json(results);
 }

--- a/apps/web/src/features/auto-run/api/run-automated-test.ts
+++ b/apps/web/src/features/auto-run/api/run-automated-test.ts
@@ -161,7 +161,6 @@ export async function runAutomatedTest(
     };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'runAutomatedTest' } });
-    const message = error instanceof Error ? error.message : String(error);
-    return fail(`자동 실행 중 오류가 발생했습니다: ${message}`);
+    return fail('자동 실행 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
   }
 }

--- a/apps/web/src/features/milestones/api/get-milestone-by-id.ts
+++ b/apps/web/src/features/milestones/api/get-milestone-by-id.ts
@@ -184,10 +184,11 @@ export async function getMilestoneById(
     return { success: true, data: result };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'getMilestoneById' } });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      errors: { _general: [`마일스톤을 불러오는 중 오류가 발생했습니다: ${errorMessage}`] },
+      errors: {
+        _general: ['마일스톤을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'],
+      },
     };
   }
 }

--- a/apps/web/src/features/runs-create/model/server-action.ts
+++ b/apps/web/src/features/runs-create/model/server-action.ts
@@ -162,11 +162,10 @@ export const createTestRunAction = async (input: CreateRunInput) => {
     Sentry.captureException(error, {
       extra: { action: 'createTestRunAction', project_id, milestone_id, name },
     });
-    const message = error instanceof Error ? error.message : '알 수 없는 오류';
     return {
       success: false,
       errors: {
-        formErrors: [`테스트 실행 생성에 실패했습니다: ${message}`],
+        formErrors: ['테스트 실행 생성에 실패했습니다. 잠시 후 다시 시도해주세요.'],
         fieldErrors: {},
       } as FlatErrors,
     };

--- a/apps/web/src/features/runs-edit/model/add-cases-to-run.ts
+++ b/apps/web/src/features/runs-edit/model/add-cases-to-run.ts
@@ -71,7 +71,6 @@ export async function addCasesToRunAction(
     return { success: true, addedCount: result };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'addCasesToRunAction' } });
-    const message = error instanceof Error ? error.message : String(error);
-    return { success: false, error: `케이스 추가에 실패했습니다: ${message}` };
+    return { success: false, error: '케이스 추가에 실패했습니다. 잠시 후 다시 시도해주세요.' };
   }
 }

--- a/apps/web/src/features/runs-edit/model/add-milestones-to-run.ts
+++ b/apps/web/src/features/runs-edit/model/add-milestones-to-run.ts
@@ -90,7 +90,6 @@ export async function addMilestonesToRunAction(
     return { success: true, addedCount: result };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'addMilestonesToRunAction' } });
-    const message = error instanceof Error ? error.message : String(error);
-    return { success: false, error: `마일스톤 추가에 실패했습니다: ${message}` };
+    return { success: false, error: '마일스톤 추가에 실패했습니다. 잠시 후 다시 시도해주세요.' };
   }
 }

--- a/apps/web/src/features/runs-edit/model/add-suites-to-run.ts
+++ b/apps/web/src/features/runs-edit/model/add-suites-to-run.ts
@@ -92,7 +92,6 @@ export async function addSuitesToRunAction(
     return { success: true, addedCount: result };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'addSuitesToRunAction' } });
-    const message = error instanceof Error ? error.message : String(error);
-    return { success: false, error: `스위트 추가에 실패했습니다: ${message}` };
+    return { success: false, error: '스위트 추가에 실패했습니다. 잠시 후 다시 시도해주세요.' };
   }
 }

--- a/apps/web/src/features/runs-edit/model/rerun-test-run.ts
+++ b/apps/web/src/features/runs-edit/model/rerun-test-run.ts
@@ -211,8 +211,7 @@ export async function rerunTestRunAction(runId: string): Promise<RerunTestRunRes
     Sentry.captureException(error, {
       extra: { action: 'rerunTestRunAction', runId, project_id: projectId },
     });
-    const message = error instanceof Error ? error.message : '알 수 없는 오류';
-    return { success: false, error: `회귀 재실행 생성에 실패했습니다: ${message}` };
+    return { success: false, error: '회귀 재실행 생성에 실패했습니다. 잠시 후 다시 시도해주세요.' };
   }
 }
 

--- a/apps/web/src/features/runs-share/api/share-actions.ts
+++ b/apps/web/src/features/runs-share/api/share-actions.ts
@@ -276,10 +276,9 @@ export async function generateShareLink(
   } catch (error) {
     console.error('[generateShareLink] error:', error);
     Sentry.captureException(error, { extra: { action: 'generateShareLink' } });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      errors: { _general: [`공유 링크 생성 중 오류가 발생했습니다: ${errorMessage}`] },
+      errors: { _general: ['공유 링크 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'] },
     };
   }
 }
@@ -313,10 +312,9 @@ export async function revokeShareLink(
   } catch (error) {
     console.error('[revokeShareLink] error:', error);
     Sentry.captureException(error, { extra: { action: 'revokeShareLink' } });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      errors: { _general: [`공유 해제 중 오류가 발생했습니다: ${errorMessage}`] },
+      errors: { _general: ['공유 해제 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'] },
     };
   }
 }
@@ -454,10 +452,11 @@ export async function getSharedReport(token: string): Promise<ActionResult<Share
   } catch (error) {
     console.error('[getSharedReport] error:', error);
     Sentry.captureException(error, { extra: { action: 'getSharedReport' } });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      errors: { _general: [`리포트를 불러오는 중 오류가 발생했습니다: ${errorMessage}`] },
+      errors: {
+        _general: ['리포트를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'],
+      },
     };
   }
 }

--- a/apps/web/src/features/runs/api/get-test-run-by-id.ts
+++ b/apps/web/src/features/runs/api/get-test-run-by-id.ts
@@ -296,10 +296,11 @@ export async function getTestRunById(testRunId: string): Promise<ActionResult<Te
     return { success: true, data: result };
   } catch (error) {
     Sentry.captureException(error, { extra: { action: 'getTestRunById' } });
-    const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       success: false,
-      errors: { _general: [`테스트 실행을 불러오는 중 오류가 발생했습니다: ${errorMessage}`] },
+      errors: {
+        _general: ['테스트 실행을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.'],
+      },
     };
   }
 }


### PR DESCRIPTION
## 작업 유형

- [x] fix — 보안 수정

## 요약
서버에서 발생한 내부 오류의 원문 메시지와 스택이 클라이언트로 새어 나가던 지점을 정적 안내 문구로 바꿉니다. 실제 오류는 기존대로 서버(Sentry) 로그에만 남겨 디버깅 능력은 그대로 유지합니다.

## 배경 / 동기
일부 서버 액션과 진단용 라우트가 catch 블록에서 원본 오류 메시지를 그대로 사용자 응답에 담고 있었습니다. DB 예외, 시스템 메시지, 스택 같은 내부 정보가 노출될 수 있어 정리합니다.

## 변경 사항
- 진단용 상태 점검 라우트에서 오류 메시지·스택·실행 환경 정보를 운영에서는 응답에 노출하지 않도록 하고, 상세는 비운영 환경에서만 반환하도록 변경. 실패 시 서버 로그 기록 추가
- 여러 서버 액션(테스트 실행 생성·자동 실행, 마일스톤·테스트 실행 조회, 케이스·마일스톤·스위트 추가, 회귀 재실행, 공유 링크 생성·해제·리포트 조회)에서 원본 오류 메시지를 사용자 문구에 붙이던 것을 일관된 정적 안내로 교체
- 실제 오류는 모두 서버 측 로깅으로만 남기도록 유지

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- AI 생성 라우트는 이미 안전한 오류 분류 체계를 쓰고 있어 변경 대상 아님

## 테스트 방법
1. 사용자 앱 타입체크 통과 확인
2. 의도적으로 오류를 유발했을 때 응답에 원본 메시지/스택이 보이지 않고 일반 안내만 나오는지 확인
