### PR TITLE
fix(back-office): 모노레포 워크스페이스 루트 고정 (CF 빌드 실패 해결)

### DIFF
--- a/apps/back-office/next.config.ts
+++ b/apps/back-office/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from 'next';
 
+import path from 'node:path';
+
+// pnpm 모노레포 루트 고정.
+// - Turbopack 이 워크스페이스 루트를 잘못 추론해 next 패키지·@testea/* 워크스페이스
+//   패키지를 못 잡는 빌드 에러(inferred workspace root)를 막는다.
+// - OpenNext 파일 트레이싱이 워크스페이스 의존성까지 포함하도록 트레이싱 루트도 맞춘다.
+// apps/back-office 기준 두 단계 위가 저장소 최상위.
+const repoRoot = path.join(__dirname, '..', '..');
+
 const nextConfig: NextConfig = {
+  turbopack: {
+    root: repoRoot,
+  },
+  outputFileTracingRoot: repoRoot,
   transpilePackages: [
     '@testea/db',
     '@testea/fetch-kit',


### PR DESCRIPTION
## 작업 유형

- [x] fix — 빌드/배포 수정

## 요약
Cloudflare 빌드에서 Next.js가 모노레포의 워크스페이스 루트를 잘못 추론해 빌드가 실패하던 문제를, 백오피스 설정에서 루트를 저장소 최상위로 고정해 해결합니다.

## 배경 / 동기
백오피스를 Cloudflare에서 빌드할 때, 빌드 도구가 앱 디렉터리만 루트로 보고 상위에 있는 공용 워크스페이스 패키지와 프레임워크 패키지를 찾지 못해 빌드가 중단됐습니다.

## 변경 사항
- 백오피스 빌드 설정에서 작업 공간 루트를 저장소 최상위로 명시 고정. 빌드 도구가 공용 워크스페이스 패키지를 정상적으로 해석하도록 함
- 서버 파일 추적 루트도 동일하게 맞춰, 배포 어댑터가 워크스페이스 의존성을 빠뜨리지 않도록 함

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- 백오피스 한정 변경이며 사용자 앱 빌드에는 영향 없음

## 테스트 방법
1. 백오피스 프로덕션 빌드가 로컬에서 정상 통과하는지 확인 (완료)
