### PR TITLE
fix(back-office): 모노레포 워크스페이스 루트 고정 (main CF 빌드 실패 해결)

### DIFF
--- a/apps/back-office/next.config.ts
+++ b/apps/back-office/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from 'next';
 
+import path from 'node:path';
+
+// pnpm 모노레포 루트 고정.
+// - Turbopack 이 워크스페이스 루트를 잘못 추론해 next 패키지·@testea/* 워크스페이스
+//   패키지를 못 잡는 빌드 에러(inferred workspace root)를 막는다.
+// - OpenNext 파일 트레이싱이 워크스페이스 의존성까지 포함하도록 트레이싱 루트도 맞춘다.
+// apps/back-office 기준 두 단계 위가 저장소 최상위.
+const repoRoot = path.join(__dirname, '..', '..');
+
 const nextConfig: NextConfig = {
+  turbopack: {
+    root: repoRoot,
+  },
+  outputFileTracingRoot: repoRoot,
   transpilePackages: [
     '@testea/db',
     '@testea/fetch-kit',


### PR DESCRIPTION
## 작업 유형

- [x] fix — 빌드/배포 수정

## 요약
Cloudflare 백오피스 빌드가 모노레포 워크스페이스 루트를 잘못 추론해 실패하던 문제를, 백오피스 설정에서 루트를 저장소 최상위로 고정해 해결합니다. 현재 배포가 main 브랜치를 빌드하고 있어, 같은 수정을 main에도 반영합니다.

## 배경 / 동기
백오피스 Cloudflare 배포가 빌드 단계에서 워크스페이스 루트를 앱 디렉터리로만 인식해, 상위에 있는 프레임워크 패키지와 공용 워크스페이스 패키지를 찾지 못하고 중단됐습니다. 동일 수정이 개발 브랜치에는 반영됐으나, 실제 배포가 빌드하는 브랜치(main)에는 없어 계속 실패했습니다.

## 변경 사항
- 백오피스 빌드 설정에서 작업 공간 루트를 저장소 최상위로 명시 고정해, 빌드 도구가 공용 패키지를 정상 해석하도록 함
- 서버 파일 추적 루트도 동일하게 맞춤

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- 백오피스 한정 변경이며 사용자 앱 빌드에는 영향 없음
- 이 변경은 빌드 실패만 해소합니다. 백오피스가 데이터까지 정상 동작하려면 별도로 배포 어댑터를 OpenNext로 전환하고 DB 연결(Hyperdrive)을 구성해야 합니다. 그 설정은 개발 브랜치에 준비돼 있습니다.

## 테스트 방법
1. 백오피스 프로덕션 빌드가 로컬에서 통과하는지 확인 (완료, 빌드 성공)
