### PR TITLE
fix(back-office): pg-cloudflare 의존 추가 (OpenNext 번들 실패 해결)

### DIFF
--- a/apps/back-office/package.json
+++ b/apps/back-office/package.json
@@ -27,6 +27,7 @@
     "lucide-react": "^0.561.0",
     "next": "16.2.9",
     "pg": "^8.21.0",
+    "pg-cloudflare": "^1.4.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.8.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       pg:
         specifier: ^8.21.0
         version: 8.21.0
+      pg-cloudflare:
+        specifier: ^1.4.0
+        version: 1.4.0
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -16542,8 +16545,7 @@ snapshots:
       sha.js: 2.4.12
       to-buffer: 1.2.2
 
-  pg-cloudflare@1.4.0:
-    optional: true
+  pg-cloudflare@1.4.0: {}
 
   pg-connection-string@2.13.0: {}
 


### PR DESCRIPTION
## 작업 유형

- [x] fix — 빌드/배포 수정

## 요약
Cloudflare(OpenNext) 빌드의 마지막 번들 단계에서 데이터베이스 드라이버가 참조하는 Cloudflare 소켓 모듈을 해석하지 못해 실패하던 문제를, 해당 모듈을 명시적 의존성으로 추가해 해결합니다.

## 배경 / 동기
OpenNext 빌드는 Next 빌드까지 정상 통과한 뒤, 서버 함수를 번들링하는 단계에서 데이터베이스 드라이버가 조건부로 참조하는 Cloudflare 전용 소켓 모듈의 컴파일 산출물을 찾지 못해 중단됐습니다. 그 모듈이 간접 의존으로만 들어가 산출물이 추적·포함되지 않은 것이 원인입니다.

## 변경 사항
- 데이터베이스 드라이버가 Cloudflare 환경에서 참조하는 소켓 모듈을 백오피스의 명시적 의존성으로 추가해, 번들러가 정상 해석하도록 함

## 영향 범위 / 주의사항

- [x] 의존성 추가(백오피스 한정)
- 런타임에서는 Hyperdrive 경유 연결이라 이 소켓 경로가 실제로 호출되지는 않으며, 번들 해석만 충족시키는 목적
- 로컬은 OpenNext 빌드를 끝까지 돌릴 수 없어(윈도우 제약) 의존성·산출물 동반만 확인했고, 최종 검증은 Cloudflare 빌드에서 이뤄짐

## 테스트 방법
1. Cloudflare(OpenNext) 빌드가 번들링 단계를 통과하는지 확인
