### PR TITLE
fix(back-office): Cloudflare DB 드라이버 postgres.js 전환 (pg-cloudflare 번들 문제 제거)

### DIFF
--- a/apps/back-office/package.json
+++ b/apps/back-office/package.json
@@ -26,8 +26,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^0.561.0",
     "next": "16.2.9",
-    "pg": "^8.21.0",
-    "pg-cloudflare": "^1.4.0",
+    "postgres": "^3.4.7",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.8.1"
@@ -38,7 +37,6 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/node": "^25.0.2",
-    "@types/pg": "^8.20.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19",
     "eslint": "^9.39.2",

--- a/apps/back-office/src/shared/db/cloudflare-db.ts
+++ b/apps/back-office/src/shared/db/cloudflare-db.ts
@@ -1,14 +1,15 @@
 import { getCloudflareContext } from '@opennextjs/cloudflare';
 import { type Database, schema, setDatabase } from '@testea/db';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
 
 /**
  * Cloudflare Workers 런타임에서 DB 를 초기화해 주입한다.
  *
- * Workers 에서는 외부 Postgres 로 직접 TCP 를 열 수 없으므로 postgres-js 직결
- * (`@testea/db` 기본 경로)이 동작하지 않는다. 대신 Cloudflare Hyperdrive 바인딩이 주는
- * 커넥션 문자열로 node-postgres 풀을 만들어 drizzle 을 구성하고 `setDatabase` 로 주입한다.
+ * Cloudflare Hyperdrive 바인딩이 주는 커넥션 문자열로 postgres-js 클라이언트를 만들어
+ * drizzle 을 구성하고 `setDatabase` 로 주입한다. Hyperdrive + nodejs_compat 조합에서는
+ * postgres-js 가 Workers 에서도 동작하며, `@testea/db` 기본 드라이버와 동일해 일관적이다.
+ * (node-postgres `pg` 는 Workers 번들 시 `pg-cloudflare` 해석 문제가 있어 사용하지 않는다.)
  *
  * Workers 가 아니거나(로컬 Node·다른 호스팅) HYPERDRIVE 바인딩이 없으면 아무 것도 하지
  * 않아 기본 postgres-js 경로를 그대로 사용한다. DB 를 쓰는 요청 진입부에서 호출한다.
@@ -32,8 +33,13 @@ export function initCloudflareDb(): void {
   const connectionString = env?.HYPERDRIVE?.connectionString;
   if (!connectionString) return;
 
-  // Hyperdrive 가 커넥션 풀링을 담당하므로 워커 측 풀은 커넥션을 재사용하지 않는다.
-  const pool = new Pool({ connectionString, maxUses: 1 });
-  setDatabase(drizzle(pool, { schema }) as unknown as Database);
+  // Hyperdrive 가 풀링·원본 TLS 를 담당한다. Workers 의 풀러 경유 연결이라
+  // prepared statement 와 startup 타입 조회(fetch_types)는 비활성화한다.
+  const client = postgres(connectionString, {
+    max: 5,
+    fetch_types: false,
+    prepare: false,
+  });
+  setDatabase(drizzle(client, { schema }) as unknown as Database);
   injected = true;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,12 +98,9 @@ importers:
       next:
         specifier: 16.2.9
         version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      pg:
-        specifier: ^8.21.0
-        version: 8.21.0
-      pg-cloudflare:
-        specifier: ^1.4.0
-        version: 1.4.0
+      postgres:
+        specifier: ^3.4.7
+        version: 3.4.9
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -129,9 +126,6 @@ importers:
       '@types/node':
         specifier: ^25.0.2
         version: 25.6.0
-      '@types/pg':
-        specifier: ^8.20.0
-        version: 8.20.0
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.14
@@ -143,7 +137,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.10
-        version: 16.0.10(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.10(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -351,7 +345,7 @@ importers:
         version: 9.39.4(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.10
-        version: 16.0.10(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+        version: 16.0.10(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
@@ -16545,19 +16539,23 @@ snapshots:
       sha.js: 2.4.12
       to-buffer: 1.2.2
 
-  pg-cloudflare@1.4.0: {}
+  pg-cloudflare@1.4.0:
+    optional: true
 
-  pg-connection-string@2.13.0: {}
+  pg-connection-string@2.13.0:
+    optional: true
 
   pg-int8@1.0.1: {}
 
   pg-pool@3.14.0(pg@8.21.0):
     dependencies:
       pg: 8.21.0
+    optional: true
 
   pg-protocol@1.13.0: {}
 
-  pg-protocol@1.14.0: {}
+  pg-protocol@1.14.0:
+    optional: true
 
   pg-types@2.2.0:
     dependencies:
@@ -16576,10 +16574,12 @@ snapshots:
       pgpass: 1.0.5
     optionalDependencies:
       pg-cloudflare: 1.4.0
+    optional: true
 
   pgpass@1.0.5:
     dependencies:
       split2: 4.2.0
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -17341,7 +17341,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  split2@4.2.0: {}
+  split2@4.2.0:
+    optional: true
 
   stable-hash@0.0.5: {}
 


### PR DESCRIPTION
## 작업 유형

- [x] fix — 빌드/배포 수정

## 요약
Cloudflare(OpenNext) 번들 단계에서 데이터베이스 드라이버가 참조하는 Cloudflare 소켓 모듈을 해석하지 못해 빌드가 실패하던 문제를, 백오피스의 Cloudflare 전용 DB 클라이언트를 사용자 앱과 동일한 드라이버로 전환해 근본적으로 제거합니다.

## 배경 / 동기
백오피스 Cloudflare 빌드가 서버 함수 번들링 단계에서 node 기반 드라이버가 조건부로 참조하는 Cloudflare 소켓 모듈의 컴파일 산출물을 찾지 못해 중단됐습니다. 해당 모듈을 의존성으로 추가해도 빌드 도구의 추적이 그 산출물을 포함하지 않아 해결되지 않았습니다. 그래서 그 드라이버 자체를 쓰지 않는 방향으로 바꿉니다.

## 변경 사항
- 백오피스의 Cloudflare 런타임 DB 클라이언트를 데이터 패키지 기본 드라이버와 동일한 방식으로 통일. Hyperdrive 커넥션 문자열로 클라이언트를 구성하며, 풀러 경유 연결 특성에 맞춰 준비된 구문과 시작 시 타입 조회를 비활성화
- 더 이상 쓰지 않는 node 기반 드라이버와 관련 타입 의존성을 제거하고, 통일된 드라이버를 명시적 의존성으로 추가

## 영향 범위 / 주의사항

- [x] 의존성 변경(백오피스 한정): node 기반 드라이버 제거, 통일 드라이버 추가
- 런타임 연결은 Hyperdrive 경유이며, 데이터 패키지의 기본 동작과 동일한 드라이버를 사용하게 되어 일관성이 높아짐
- 로컬은 Cloudflare 빌드를 끝까지 돌릴 수 없어(윈도우 제약) 프로덕션 빌드 통과와 타입 정합만 확인했고, 최종 검증은 Cloudflare 빌드에서 이뤄짐

## 테스트 방법
1. 백오피스 프로덕션 빌드 통과 확인 (완료)
2. Cloudflare(OpenNext) 빌드가 번들링 단계를 통과하는지 확인
