### PR TITLE
fix(back-office): DB 연결을 SUPABASE_DB_URL 시크릿 직결로 전환 (Hyperdrive 제거)

### DIFF
--- a/apps/back-office/src/shared/db/cloudflare-db.ts
+++ b/apps/back-office/src/shared/db/cloudflare-db.ts
@@ -6,39 +6,41 @@ import postgres from 'postgres';
 /**
  * Cloudflare Workers 런타임에서 DB 를 초기화해 주입한다.
  *
- * Cloudflare Hyperdrive 바인딩이 주는 커넥션 문자열로 postgres-js 클라이언트를 만들어
- * drizzle 을 구성하고 `setDatabase` 로 주입한다. Hyperdrive + nodejs_compat 조합에서는
- * postgres-js 가 Workers 에서도 동작하며, `@testea/db` 기본 드라이버와 동일해 일관적이다.
- * (node-postgres `pg` 는 Workers 번들 시 `pg-cloudflare` 해석 문제가 있어 사용하지 않는다.)
+ * 배포 시 주입한 `SUPABASE_DB_URL` 시크릿(해당 환경의 Supabase 연결 문자열)으로
+ * postgres-js 클라이언트를 만들어 drizzle 을 구성하고 `setDatabase` 로 주입한다.
+ * Hyperdrive 를 거치지 않고 nodejs_compat 위에서 Supabase 에 직접 연결한다
+ * (백오피스는 관리자 전용 저트래픽이라 엣지 풀링 없이도 충분). 서버리스 특성상
+ * 트랜잭션 풀러(Supavisor) 연결 문자열 + prepared statement 비활성을 전제로 한다.
  *
- * Workers 가 아니거나(로컬 Node·다른 호스팅) HYPERDRIVE 바인딩이 없으면 아무 것도 하지
- * 않아 기본 postgres-js 경로를 그대로 사용한다. DB 를 쓰는 요청 진입부에서 호출한다.
+ * Workers 가 아니거나(로컬 Node·다른 호스팅) 시크릿이 없으면 아무 것도 하지 않아
+ * `@testea/db` 기본 경로(process.env.SUPABASE_DB_URL)를 그대로 쓴다. DB 를 쓰는
+ * 요청 진입부에서 호출한다.
  */
 let injected = false;
 
 export function initCloudflareDb(): void {
   if (injected) return;
 
-  // wrangler.jsonc 의 HYPERDRIVE 바인딩. 정식 타입은 `wrangler types` 로 생성되지만,
-  // 여기서는 바인딩 부재 환경(로컬·Vercel)도 안전하도록 직접 좁혀 읽는다.
-  type HyperdriveEnv = { HYPERDRIVE?: { connectionString?: string } };
-  let env: HyperdriveEnv | undefined;
+  // 워커 바인딩(시크릿)을 읽는다. 바인딩 부재 환경(로컬·Vercel)도 안전하도록 좁혀 읽는다.
+  type CfEnv = { SUPABASE_DB_URL?: string };
+  let env: CfEnv | undefined;
   try {
-    env = getCloudflareContext().env as unknown as HyperdriveEnv;
+    env = getCloudflareContext().env as unknown as CfEnv;
   } catch {
     // Cloudflare 컨텍스트 없음 → 기본 경로 사용
     return;
   }
 
-  const connectionString = env?.HYPERDRIVE?.connectionString;
+  const connectionString = env?.SUPABASE_DB_URL;
   if (!connectionString) return;
 
-  // Hyperdrive 가 풀링·원본 TLS 를 담당한다. Workers 의 풀러 경유 연결이라
-  // prepared statement 와 startup 타입 조회(fetch_types)는 비활성화한다.
+  // Supabase 트랜잭션 풀러 경유 + Workers 직결이라 prepared statement·startup 타입 조회는
+  // 비활성하고, 연결은 SSL 필수.
   const client = postgres(connectionString, {
     max: 5,
-    fetch_types: false,
+    ssl: 'require',
     prepare: false,
+    fetch_types: false,
   });
   setDatabase(drizzle(client, { schema }) as unknown as Database);
   injected = true;

--- a/apps/back-office/wrangler.jsonc
+++ b/apps/back-office/wrangler.jsonc
@@ -8,23 +8,16 @@
   "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "assets": {
     "directory": ".open-next/assets",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
   },
   "services": [
     {
       "binding": "WORKER_SELF_REFERENCE",
-      "service": "testea-back-office"
-    }
+      "service": "testea-back-office",
+    },
   ],
-  // Supabase Postgres 앞단 Hyperdrive. CF 대시보드/`wrangler hyperdrive create` 로 만든 뒤
-  // 그 id 를 채운다. localConnectionString 은 `wrangler dev` 로컬 미리보기에서만 사용.
-  "hyperdrive": [
-    {
-      "binding": "HYPERDRIVE",
-      "id": "<HYPERDRIVE_ID_을_채우세요>",
-      "localConnectionString": "postgresql://user:pass@localhost:5432/postgres"
-    }
-  ]
-  // 이미지 최적화가 필요하면 아래 바인딩 추가 (https://opennext.js.org/cloudflare/howtos/image)
-  // "images": { "binding": "IMAGES" }
+  // DB 연결: Hyperdrive 대신 SUPABASE_DB_URL 시크릿으로 직결한다.
+  // 배포 환경에서 `wrangler secret put SUPABASE_DB_URL` (값=해당 환경 Supabase 연결 문자열,
+  // 서버리스엔 Supavisor 트랜잭션 풀러 URL 권장). postgres.js + nodejs_compat 로 직접 연결.
+  // 이미지 최적화가 필요하면 바인딩 추가 (https://opennext.js.org/cloudflare/howtos/image)
 }


### PR DESCRIPTION
Cloudflare 백오피스 DB 연결을 Hyperdrive 경유에서 SUPABASE_DB_URL 시크릿 직결로 변경. cloudflare-db는 워커 env의 SUPABASE_DB_URL을 읽어 postgres.js로 연결(ssl require, prepare false). wrangler.jsonc의 Hyperdrive 바인딩 제거. 배포 시 'wrangler secret put SUPABASE_DB_URL'(값=해당 환경 Supabase 연결 문자열, Supavisor 풀러 권장)만 넣으면 됨. 관리자 전용 저트래픽이라 엣지 풀링 불필요.