### PR TITLE
fix(back-office): wrangler 워커 이름을 배포 프로젝트명에 맞춤

### DIFF
--- a/apps/back-office/wrangler.jsonc
+++ b/apps/back-office/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "testea-back-office",
+  "name": "back-web-mvp-front",
   "main": ".open-next/worker.js",
   "compatibility_date": "2025-09-23",
   // nodejs_compat: node:crypto·node:net(postgres.js) 등 Node API 사용에 필요
@@ -13,7 +13,7 @@
   "services": [
     {
       "binding": "WORKER_SELF_REFERENCE",
-      "service": "testea-back-office",
+      "service": "back-web-mvp-front",
     },
   ],
   // DB 연결: Hyperdrive 대신 SUPABASE_DB_URL 시크릿으로 직결한다.


### PR DESCRIPTION
Workers Builds 프로젝트명이 back-web-mvp-front인데 wrangler.jsonc는 testea-back-office라, WORKER_SELF_REFERENCE 서비스 바인딩이 존재하지 않는 워커를 가리켜 배포 실패(code 10143). name과 자기참조 service를 실제 배포명(back-web-mvp-front)으로 통일.