### PR TITLE
fix(back-office): 대시보드 루트 무인증 접근 차단 (requireAdmin 가드)

### DIFF
--- a/apps/back-office/app/page.tsx
+++ b/apps/back-office/app/page.tsx
@@ -2,11 +2,14 @@ import {
   type RealDashboardData,
   getDashboardData,
 } from '@/entities/admin-dashboard/api/get-dashboard-data';
+import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { DashboardPage } from '@/pages/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
+  await requireAdmin('/');
+
   let data: RealDashboardData | null = null;
   try {
     data = await getDashboardData();


### PR DESCRIPTION
백오피스 루트(/) 대시보드가 requireAdmin 가드 없이 운영 지표를 무인증 노출하던 보안 구멍을 막음. /notices·/logs와 동일하게 진입부에서 requireAdmin 호출(미인증 시 게이트로 리다이렉트). /dev/components는 prod에서 notFound 처리라 안전. 게이트가 실제 동작하려면 워커에 BACKOFFICE_ADMIN_SECRET 시크릿 설정 필요.