### PR TITLE
fix: AI 월 사용 한도 TOCTOU 원자화(#167) + 시나리오 휴지통 통합(#166)

### DIFF
--- a/apps/web/app/api/ai/analyze-requirements/route.ts
+++ b/apps/web/app/api/ai/analyze-requirements/route.ts
@@ -236,14 +236,19 @@ export async function POST(req: NextRequest) {
 
     // 낙관적 사전 검사: 이미 한도를 다 쓴 경우 LLM 호출 전에 빠르게 거절한다.
     // 실제 한도 선점은 LLM 응답 후 recordUsageAtomic 이 원자적으로 처리한다.
+    // preRemaining 은 기록 트랜잭션이 실패했을 때 fail-open 을 막는 상한으로 쓴다.
+    let preRemaining = Number.POSITIVE_INFINITY;
     const usageResult = await getMonthlyUsage(input.projectId);
-    if (usageResult.success && usageResult.data.used >= usageResult.data.limit) {
-      return NextResponse.json(
-        {
-          error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
-        },
-        { status: 429 }
-      );
+    if (usageResult.success) {
+      if (usageResult.data.used >= usageResult.data.limit) {
+        return NextResponse.json(
+          {
+            error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+          },
+          { status: 429 }
+        );
+      }
+      preRemaining = usageResult.data.limit - usageResult.data.used;
     }
 
     let attachment: AttachmentExtractResult | undefined;
@@ -313,7 +318,10 @@ export async function POST(req: NextRequest) {
         { status: 429 }
       );
     }
-    const granted = usage.success ? usage.data.granted : result.scenarios.length;
+    // 기록 트랜잭션이 실패하면 사용량 미집계 상태이므로, 사전 잔여량을 넘겨 반환하지 않는다(fail-open 방지).
+    const granted = usage.success
+      ? usage.data.granted
+      : Math.min(result.scenarios.length, preRemaining);
     const limitedScenarios = result.scenarios.slice(0, granted);
 
     return NextResponse.json({

--- a/apps/web/app/api/ai/analyze-requirements/route.ts
+++ b/apps/web/app/api/ai/analyze-requirements/route.ts
@@ -6,7 +6,7 @@ import { AiError } from '@/entities/ai-config/model/ai-error';
 import {
   type AttachmentUsageMeta,
   getMonthlyUsage,
-  recordUsage,
+  recordUsageAtomic,
 } from '@/entities/ai-usage/api/server-actions';
 import {
   AnalyzeRequirementsMultipartSchema,
@@ -234,17 +234,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    let usageRemaining = Number.POSITIVE_INFINITY;
+    // 낙관적 사전 검사: 이미 한도를 다 쓴 경우 LLM 호출 전에 빠르게 거절한다.
+    // 실제 한도 선점은 LLM 응답 후 recordUsageAtomic 이 원자적으로 처리한다.
     const usageResult = await getMonthlyUsage(input.projectId);
-    if (usageResult.success) {
-      const { used, limit } = usageResult.data;
-      if (used >= limit) {
-        return NextResponse.json(
-          { error: `이번 달 사용 한도(${limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.` },
-          { status: 429 }
-        );
-      }
-      usageRemaining = limit - used;
+    if (usageResult.success && usageResult.data.used >= usageResult.data.limit) {
+      return NextResponse.json(
+        {
+          error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+        },
+        { status: 429 }
+      );
     }
 
     let attachment: AttachmentExtractResult | undefined;
@@ -299,14 +298,23 @@ export async function POST(req: NextRequest) {
       throw AiError.responseUnparsable(error);
     }
 
-    // 남은 월간 한도를 넘지 않도록 시나리오를 잘라 채택하고, 그만큼만 사용량에 집계한다.
-    const limitedScenarios = result.scenarios.slice(0, usageRemaining);
-    await recordUsage(
+    // 한도 검사·기록을 원자적으로 처리(TOCTOU 방지)하고, 채택된 만큼만 잘라 반환한다.
+    const usage = await recordUsageAtomic(
       input.projectId,
       'analyze_requirements',
-      limitedScenarios.length,
+      result.scenarios.length,
       attachment ? toAttachmentMeta(attachment) : undefined
     );
+    if (usage.success && usage.data.granted === 0 && result.scenarios.length > 0) {
+      return NextResponse.json(
+        {
+          error: `이번 달 사용 한도(${usage.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+        },
+        { status: 429 }
+      );
+    }
+    const granted = usage.success ? usage.data.granted : result.scenarios.length;
+    const limitedScenarios = result.scenarios.slice(0, granted);
 
     return NextResponse.json({
       analysis: result.analysis,

--- a/apps/web/app/api/ai/generate-cases/route.ts
+++ b/apps/web/app/api/ai/generate-cases/route.ts
@@ -247,7 +247,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 월간 사용량 체크
+    // 월간 사용량 체크 (preRemaining 은 기록 트랜잭션 실패 시 fail-open 을 막는 상한)
+    let preRemaining = Number.POSITIVE_INFINITY;
     const usageResult = await getMonthlyUsage(input.projectId);
     if (usageResult.success) {
       const { used, limit } = usageResult.data;
@@ -257,6 +258,7 @@ export async function POST(req: NextRequest) {
           { status: 429 }
         );
       }
+      preRemaining = limit - used;
     }
 
     // 한도/설정 가드 통과 후에 첨부 본문을 추출한다. 거부될 호출이 PDF 파싱 비용을 먼저 지불하지 않도록.
@@ -323,7 +325,10 @@ export async function POST(req: NextRequest) {
         { status: 429 }
       );
     }
-    const granted = usage.success ? usage.data.granted : limitedCases.length;
+    // 기록 트랜잭션이 실패하면 사용량 미집계 상태이므로, 사전 잔여량을 넘겨 반환하지 않는다(fail-open 방지).
+    const granted = usage.success
+      ? usage.data.granted
+      : Math.min(limitedCases.length, preRemaining);
     const acceptedCases = limitedCases.slice(0, granted);
 
     return NextResponse.json({

--- a/apps/web/app/api/ai/generate-cases/route.ts
+++ b/apps/web/app/api/ai/generate-cases/route.ts
@@ -11,7 +11,7 @@ import {
 import {
   type AttachmentUsageMeta,
   getMonthlyUsage,
-  recordUsage,
+  recordUsageAtomic,
 } from '@/entities/ai-usage/api/server-actions';
 import {
   type AttachmentExtractResult,
@@ -308,16 +308,26 @@ export async function POST(req: NextRequest) {
     // 1회 최대 건수 제한
     const limitedCases = cases.slice(0, MAX_CASES_PER_REQUEST);
 
-    // 사용량 기록 (첨부 메타 포함)
-    await recordUsage(
+    // 한도 검사·기록을 원자적으로 처리(TOCTOU 방지)하고, 남은 한도만큼만 채택해 반환한다.
+    const usage = await recordUsageAtomic(
       input.projectId,
       'generate_cases',
       limitedCases.length,
       attachment ? toAttachmentMeta(attachment) : undefined
     );
+    if (usage.success && usage.data.granted === 0 && limitedCases.length > 0) {
+      return NextResponse.json(
+        {
+          error: `이번 달 사용 한도(${usage.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+        },
+        { status: 429 }
+      );
+    }
+    const granted = usage.success ? usage.data.granted : limitedCases.length;
+    const acceptedCases = limitedCases.slice(0, granted);
 
     return NextResponse.json({
-      cases: limitedCases,
+      cases: acceptedCases,
       attachment: attachment
         ? {
             type: attachment.type,

--- a/apps/web/app/api/ai/generate-scenarios/route.ts
+++ b/apps/web/app/api/ai/generate-scenarios/route.ts
@@ -143,14 +143,19 @@ export async function POST(req: NextRequest) {
 
     // 낙관적 사전 검사: 이미 한도를 다 쓴 경우 LLM 호출 전에 빠르게 거절한다.
     // 실제 한도 선점은 LLM 응답 후 recordUsageAtomic 이 원자적으로 처리한다.
+    // preRemaining 은 기록 트랜잭션이 실패했을 때 fail-open 을 막는 상한으로 쓴다.
+    let preRemaining = Number.POSITIVE_INFINITY;
     const usageResult = await getMonthlyUsage(input.projectId);
-    if (usageResult.success && usageResult.data.used >= usageResult.data.limit) {
-      return NextResponse.json(
-        {
-          error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
-        },
-        { status: 429 }
-      );
+    if (usageResult.success) {
+      if (usageResult.data.used >= usageResult.data.limit) {
+        return NextResponse.json(
+          {
+            error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+          },
+          { status: 429 }
+        );
+      }
+      preRemaining = usageResult.data.limit - usageResult.data.used;
     }
 
     let attachment: AttachmentExtractResult | undefined;
@@ -197,7 +202,10 @@ export async function POST(req: NextRequest) {
         { status: 429 }
       );
     }
-    const granted = usage.success ? usage.data.granted : result.scenarios.length;
+    // 기록 트랜잭션이 실패하면 사용량 미집계 상태이므로, 사전 잔여량을 넘겨 반환하지 않는다(fail-open 방지).
+    const granted = usage.success
+      ? usage.data.granted
+      : Math.min(result.scenarios.length, preRemaining);
     const limitedScenarios = result.scenarios.slice(0, granted);
 
     return NextResponse.json({

--- a/apps/web/app/api/ai/generate-scenarios/route.ts
+++ b/apps/web/app/api/ai/generate-scenarios/route.ts
@@ -6,7 +6,7 @@ import { AiError } from '@/entities/ai-config/model/ai-error';
 import {
   type AttachmentUsageMeta,
   getMonthlyUsage,
-  recordUsage,
+  recordUsageAtomic,
 } from '@/entities/ai-usage/api/server-actions';
 import { callLlm, parseJsonResponse } from '@/features/ai-generate-scenarios/lib/llm-client';
 import {
@@ -141,17 +141,16 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    let usageRemaining = Number.POSITIVE_INFINITY;
+    // 낙관적 사전 검사: 이미 한도를 다 쓴 경우 LLM 호출 전에 빠르게 거절한다.
+    // 실제 한도 선점은 LLM 응답 후 recordUsageAtomic 이 원자적으로 처리한다.
     const usageResult = await getMonthlyUsage(input.projectId);
-    if (usageResult.success) {
-      const { used, limit } = usageResult.data;
-      if (used >= limit) {
-        return NextResponse.json(
-          { error: `이번 달 사용 한도(${limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.` },
-          { status: 429 }
-        );
-      }
-      usageRemaining = limit - used;
+    if (usageResult.success && usageResult.data.used >= usageResult.data.limit) {
+      return NextResponse.json(
+        {
+          error: `이번 달 사용 한도(${usageResult.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+        },
+        { status: 429 }
+      );
     }
 
     let attachment: AttachmentExtractResult | undefined;
@@ -183,14 +182,23 @@ export async function POST(req: NextRequest) {
       throw AiError.responseUnparsable(error);
     }
 
-    // 남은 월간 한도를 넘지 않게 잘라 채택하고 그만큼만 사용량에 집계한다.
-    const limitedScenarios = result.scenarios.slice(0, usageRemaining);
-    await recordUsage(
+    // 한도 검사·기록을 원자적으로 처리(TOCTOU 방지)하고, 채택된 만큼만 잘라 반환한다.
+    const usage = await recordUsageAtomic(
       input.projectId,
       'generate_scenarios',
-      limitedScenarios.length,
+      result.scenarios.length,
       attachment ? toAttachmentMeta(attachment) : undefined
     );
+    if (usage.success && usage.data.granted === 0 && result.scenarios.length > 0) {
+      return NextResponse.json(
+        {
+          error: `이번 달 사용 한도(${usage.data.limit}건)를 초과했습니다. 다음 달에 다시 이용해주세요.`,
+        },
+        { status: 429 }
+      );
+    }
+    const granted = usage.success ? usage.data.granted : result.scenarios.length;
+    const limitedScenarios = result.scenarios.slice(0, granted);
 
     return NextResponse.json({
       scenarios: limitedScenarios,

--- a/apps/web/src/entities/ai-usage/api/server-actions.ts
+++ b/apps/web/src/entities/ai-usage/api/server-actions.ts
@@ -7,12 +7,14 @@ import { and, eq, gte, sql } from 'drizzle-orm';
 
 const FREE_MONTHLY_LIMIT = 50;
 
-/** 이번 달 1일 00:00:00 (로컬). 사용량 합산의 하한 경계. 검사·기록이 같은 경계를 쓰도록 공유한다. */
+/**
+ * 이번 달 1일 00:00:00 UTC. 사용량 합산의 하한 경계. 검사·기록이 같은 경계를 쓰도록 공유한다.
+ * created_at 이 timestamptz(UTC) 이므로 경계도 UTC 로 잡아, 서버 로컬 타임존에 따라
+ * 월말 일부 기록이 누락/중복 집계되지 않게 한다.
+ */
 const startOfCurrentMonth = (): Date => {
-  const startOfMonth = new Date();
-  startOfMonth.setDate(1);
-  startOfMonth.setHours(0, 0, 0, 0);
-  return startOfMonth;
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 };
 
 export const getMonthlyUsage = async (

--- a/apps/web/src/entities/ai-usage/api/server-actions.ts
+++ b/apps/web/src/entities/ai-usage/api/server-actions.ts
@@ -7,15 +7,21 @@ import { and, eq, gte, sql } from 'drizzle-orm';
 
 const FREE_MONTHLY_LIMIT = 50;
 
+/** 이번 달 1일 00:00:00 (로컬). 사용량 합산의 하한 경계. 검사·기록이 같은 경계를 쓰도록 공유한다. */
+const startOfCurrentMonth = (): Date => {
+  const startOfMonth = new Date();
+  startOfMonth.setDate(1);
+  startOfMonth.setHours(0, 0, 0, 0);
+  return startOfMonth;
+};
+
 export const getMonthlyUsage = async (
   projectId: string
 ): Promise<ActionResult<{ used: number; limit: number }>> => {
   try {
     const db = getDatabase();
 
-    const startOfMonth = new Date();
-    startOfMonth.setDate(1);
-    startOfMonth.setHours(0, 0, 0, 0);
+    const startOfMonth = startOfCurrentMonth();
 
     const [result] = await db
       .select({
@@ -45,28 +51,72 @@ export interface AttachmentUsageMeta {
   charCount: number;
 }
 
-export const recordUsage = async (
+export interface UsageGrant {
+  /** 이번 요청에 실제 집계(채택)된 건수. 남은 한도를 넘지 않도록 잘린 값. */
+  granted: number;
+  /** 집계 반영 후 이번 달 누적 사용량. */
+  used: number;
+  limit: number;
+}
+
+/**
+ * 월 사용 한도를 원자적으로 선점하며 사용량을 기록한다.
+ *
+ * 사용량은 로그 합산 방식이라 선점할 단일 카운터 행이 없어, 검사(합산)와 기록(INSERT)이
+ * 분리되면 동시 요청이 같은 잔여량을 보고 각각 기록해 한도를 초과할 수 있다(TOCTOU).
+ * 트랜잭션 안에서 프로젝트 단위 advisory lock 으로 검사·기록 구간을 직렬화해 이를 막는다.
+ * (xact 레벨이라 트랜잭션 종료 시 자동 해제되고 pgBouncer transaction pooling 과도 호환)
+ *
+ * 잔여 한도보다 많이 요청하면 잔여분만 채택해 기록하고, 채택된 건수(`granted`)를 돌려준다.
+ * 호출부는 `granted` 만큼만 사용자에게 반환하면 된다.
+ */
+export const recordUsageAtomic = async (
   projectId: string,
   actionType: string,
-  generatedCount: number,
+  requestedCount: number,
   attachment?: AttachmentUsageMeta
-): Promise<ActionResult<null>> => {
+): Promise<ActionResult<UsageGrant>> => {
+  const requested = Math.max(0, Math.trunc(requestedCount));
   try {
     const db = getDatabase();
+    const startOfMonth = startOfCurrentMonth();
 
-    await db.insert(aiUsageLogs).values({
-      project_id: projectId,
-      action_type: actionType,
-      generated_count: generatedCount,
-      attached_file_type: attachment?.type ?? null,
-      attached_file_size_bytes: attachment?.sizeBytes ?? null,
-      attached_file_page_count: attachment?.pageCount ?? null,
-      attached_file_char_count: attachment?.charCount ?? null,
+    const grant = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(hashtext('ai_usage_monthly'), hashtext(${projectId}))`
+      );
+
+      const [row] = await tx
+        .select({
+          total: sql<number>`COALESCE(SUM(${aiUsageLogs.generated_count}), 0)`,
+        })
+        .from(aiUsageLogs)
+        .where(
+          and(eq(aiUsageLogs.project_id, projectId), gte(aiUsageLogs.created_at, startOfMonth))
+        );
+
+      const used = Number(row?.total ?? 0);
+      const remaining = Math.max(0, FREE_MONTHLY_LIMIT - used);
+      const granted = Math.min(requested, remaining);
+
+      if (granted > 0) {
+        await tx.insert(aiUsageLogs).values({
+          project_id: projectId,
+          action_type: actionType,
+          generated_count: granted,
+          attached_file_type: attachment?.type ?? null,
+          attached_file_size_bytes: attachment?.sizeBytes ?? null,
+          attached_file_page_count: attachment?.pageCount ?? null,
+          attached_file_char_count: attachment?.charCount ?? null,
+        });
+      }
+
+      return { granted, used: used + granted, limit: FREE_MONTHLY_LIMIT } satisfies UsageGrant;
     });
 
-    return { success: true, data: null };
+    return { success: true, data: grant };
   } catch (error) {
-    Sentry.captureException(error, { extra: { action: 'recordUsage' } });
+    Sentry.captureException(error, { extra: { action: 'recordUsageAtomic' } });
     return { success: false, errors: { _ai: ['사용량 기록에 실패했습니다.'] } };
   }
 };

--- a/apps/web/src/entities/test-scenario/api/server-actions.ts
+++ b/apps/web/src/entities/test-scenario/api/server-actions.ts
@@ -379,7 +379,7 @@ export const updateScenario = async (
   }
 };
 
-/** 시나리오 소프트 삭제(lifecycle_status='DELETED'). */
+/** 시나리오 소프트 삭제(lifecycle_status='DELETED'). archived_at 으로 휴지통 잔여일을 계산한다. */
 export const deleteScenario = async (
   projectId: string,
   id: string
@@ -388,10 +388,11 @@ export const deleteScenario = async (
     if (!(await requireProjectAccess(projectId))) return accessDenied();
 
     const db = getDatabase();
+    const now = new Date();
 
     const deleted = await db
       .update(testScenarios)
-      .set({ lifecycle_status: 'DELETED', updated_at: new Date() })
+      .set({ lifecycle_status: 'DELETED', archived_at: now, updated_at: now })
       .where(and(eq(testScenarios.id, id), eq(testScenarios.project_id, projectId)))
       .returning({ id: testScenarios.id });
 

--- a/apps/web/src/features/trash/api/trash-actions.ts
+++ b/apps/web/src/features/trash/api/trash-actions.ts
@@ -3,8 +3,15 @@
 import { requireProjectAccess } from '@/access/lib/require-access';
 import type { ActionResult } from '@/shared/types';
 import * as Sentry from '@sentry/nextjs';
-import { auditLogs, getDatabase, milestones, testCases, testSuites } from '@testea/db';
-import { and, eq, isNull, lt } from 'drizzle-orm';
+import {
+  auditLogs,
+  getDatabase,
+  milestones,
+  testCases,
+  testScenarios,
+  testSuites,
+} from '@testea/db';
+import { and, eq, lt } from 'drizzle-orm';
 import { v7 as uuidv7 } from 'uuid';
 
 import type { TrashItem, TrashItemType } from '../model/types';
@@ -62,7 +69,7 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
     const cutoff = new Date();
     cutoff.setDate(cutoff.getDate() - AUTO_DELETE_DAYS);
 
-    const [expiredCases, expiredSuites, expiredMilestones] = await Promise.all([
+    const [expiredCases, expiredSuites, expiredMilestones, expiredScenarios] = await Promise.all([
       db
         .select()
         .from(testCases)
@@ -93,6 +100,16 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
             lt(milestones.archived_at, cutoff)
           )
         ),
+      db
+        .select()
+        .from(testScenarios)
+        .where(
+          and(
+            eq(testScenarios.project_id, projectId),
+            eq(testScenarios.lifecycle_status, 'DELETED'),
+            lt(testScenarios.archived_at, cutoff)
+          )
+        ),
     ]);
 
     // audit log 기록
@@ -118,6 +135,15 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
       ...expiredMilestones.map((row) => ({
         projectId,
         entityType: 'milestone',
+        entityId: row.id,
+        entityName: row.name,
+        action: 'auto_cleanup' as AuditAction,
+        snapshot: row,
+        deletedAt: row.archived_at,
+      })),
+      ...expiredScenarios.map((row) => ({
+        projectId,
+        entityType: 'test_scenario',
         entityId: row.id,
         entityName: row.name,
         action: 'auto_cleanup' as AuditAction,
@@ -165,11 +191,22 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
                 lt(milestones.archived_at, cutoff)
               )
             ),
+        expiredScenarios.length > 0 &&
+          db
+            .update(testScenarios)
+            .set({ lifecycle_status: 'PURGED', updated_at: purgedAt })
+            .where(
+              and(
+                eq(testScenarios.project_id, projectId),
+                eq(testScenarios.lifecycle_status, 'DELETED'),
+                lt(testScenarios.archived_at, cutoff)
+              )
+            ),
       ]);
     }
 
     // 남은 휴지통 항목 조회
-    const [trashedCases, trashedSuites, trashedMilestones] = await Promise.all([
+    const [trashedCases, trashedSuites, trashedMilestones, trashedScenarios] = await Promise.all([
       db
         .select({
           id: testCases.id,
@@ -198,6 +235,19 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
         .where(
           and(eq(milestones.project_id, projectId), eq(milestones.lifecycle_status, 'DELETED'))
         ),
+      db
+        .select({
+          id: testScenarios.id,
+          title: testScenarios.name,
+          deletedAt: testScenarios.archived_at,
+        })
+        .from(testScenarios)
+        .where(
+          and(
+            eq(testScenarios.project_id, projectId),
+            eq(testScenarios.lifecycle_status, 'DELETED')
+          )
+        ),
     ]);
 
     const now = new Date();
@@ -225,6 +275,13 @@ export const getTrashedItems = async (projectId: string): Promise<ActionResult<T
       ...trashedMilestones.map((row) => ({
         id: row.id,
         type: 'milestone' as TrashItemType,
+        title: row.title,
+        deletedAt: row.deletedAt ?? now,
+        daysRemaining: toDaysRemaining(row.deletedAt),
+      })),
+      ...trashedScenarios.map((row) => ({
+        id: row.id,
+        type: 'scenario' as TrashItemType,
         title: row.title,
         deletedAt: row.deletedAt ?? now,
         daysRemaining: toDaysRemaining(row.deletedAt),
@@ -343,6 +400,19 @@ export const restoreItem = async (
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
         }
         return { success: true, data: { id: restored.id }, message: '마일스톤이 복원되었습니다.' };
+      }
+      case 'scenario': {
+        // 시나리오 삭제는 파생 스위트를 건드리지 않으므로(스위트는 독립적으로 휴지통 관리),
+        // 복원도 시나리오만 ACTIVE 로 되돌리면 된다. 파생 스위트 유니크 제약과도 충돌하지 않는다.
+        const [restored] = await db
+          .update(testScenarios)
+          .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })
+          .where(and(eq(testScenarios.id, targetId), eq(testScenarios.lifecycle_status, 'DELETED')))
+          .returning();
+        if (!restored) {
+          return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
+        }
+        return { success: true, data: { id: restored.id }, message: '시나리오가 복원되었습니다.' };
       }
       default:
         return { success: false, errors: { _trash: ['지원하지 않는 항목 유형입니다.'] } };
@@ -477,6 +547,32 @@ export const permanentDeleteItem = async (
         }
         break;
       }
+      case 'scenario': {
+        const [row] = await db
+          .select()
+          .from(testScenarios)
+          .where(
+            and(eq(testScenarios.id, targetId), eq(testScenarios.lifecycle_status, 'DELETED'))
+          );
+        if (row) {
+          await writeAuditLogs(db, [
+            {
+              projectId,
+              entityType: 'test_scenario',
+              entityId: row.id,
+              entityName: row.name,
+              action: 'permanent_delete',
+              snapshot: row,
+              deletedAt: row.archived_at,
+            },
+          ]);
+          await db
+            .update(testScenarios)
+            .set({ lifecycle_status: 'PURGED', updated_at: new Date() })
+            .where(eq(testScenarios.id, targetId));
+        }
+        break;
+      }
       default:
         return { success: false, errors: { _trash: ['지원하지 않는 항목 유형입니다.'] } };
     }
@@ -508,7 +604,7 @@ export const emptyTrash = async (projectId: string): Promise<ActionResult<{ coun
     const db = getDatabase();
 
     // 삭제 대상 전체 조회
-    const [allCases, allSuites, allMilestones] = await Promise.all([
+    const [allCases, allSuites, allMilestones, allScenarios] = await Promise.all([
       db
         .select()
         .from(testCases)
@@ -524,6 +620,15 @@ export const emptyTrash = async (projectId: string): Promise<ActionResult<{ coun
         .from(milestones)
         .where(
           and(eq(milestones.project_id, projectId), eq(milestones.lifecycle_status, 'DELETED'))
+        ),
+      db
+        .select()
+        .from(testScenarios)
+        .where(
+          and(
+            eq(testScenarios.project_id, projectId),
+            eq(testScenarios.lifecycle_status, 'DELETED')
+          )
         ),
     ]);
 
@@ -550,6 +655,15 @@ export const emptyTrash = async (projectId: string): Promise<ActionResult<{ coun
       ...allMilestones.map((row) => ({
         projectId,
         entityType: 'milestone',
+        entityId: row.id,
+        entityName: row.name,
+        action: 'empty_trash' as AuditAction,
+        snapshot: row,
+        deletedAt: row.archived_at,
+      })),
+      ...allScenarios.map((row) => ({
+        projectId,
+        entityType: 'test_scenario',
         entityId: row.id,
         entityName: row.name,
         action: 'empty_trash' as AuditAction,
@@ -586,9 +700,20 @@ export const emptyTrash = async (projectId: string): Promise<ActionResult<{ coun
           .where(
             and(eq(milestones.project_id, projectId), eq(milestones.lifecycle_status, 'DELETED'))
           ),
+      allScenarios.length > 0 &&
+        db
+          .update(testScenarios)
+          .set({ lifecycle_status: 'PURGED', updated_at: purgedAt })
+          .where(
+            and(
+              eq(testScenarios.project_id, projectId),
+              eq(testScenarios.lifecycle_status, 'DELETED')
+            )
+          ),
     ]);
 
-    const totalCount = allCases.length + allSuites.length + allMilestones.length;
+    const totalCount =
+      allCases.length + allSuites.length + allMilestones.length + allScenarios.length;
 
     return {
       success: true,

--- a/apps/web/src/features/trash/api/trash-actions.ts
+++ b/apps/web/src/features/trash/api/trash-actions.ts
@@ -323,7 +323,13 @@ export const restoreItem = async (
         const [restored] = await db
           .update(testCases)
           .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })
-          .where(and(eq(testCases.id, targetId), eq(testCases.lifecycle_status, 'DELETED')))
+          .where(
+            and(
+              eq(testCases.id, targetId),
+              eq(testCases.project_id, projectId),
+              eq(testCases.lifecycle_status, 'DELETED')
+            )
+          )
           .returning();
         if (!restored) {
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
@@ -341,7 +347,13 @@ export const restoreItem = async (
         const [target] = await db
           .select({ scenarioId: testSuites.test_scenario_id })
           .from(testSuites)
-          .where(and(eq(testSuites.id, targetId), eq(testSuites.lifecycle_status, 'DELETED')))
+          .where(
+            and(
+              eq(testSuites.id, targetId),
+              eq(testSuites.project_id, projectId),
+              eq(testSuites.lifecycle_status, 'DELETED')
+            )
+          )
           .limit(1);
         if (!target) {
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
@@ -372,7 +384,13 @@ export const restoreItem = async (
         const [restored] = await db
           .update(testSuites)
           .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })
-          .where(and(eq(testSuites.id, targetId), eq(testSuites.lifecycle_status, 'DELETED')))
+          .where(
+            and(
+              eq(testSuites.id, targetId),
+              eq(testSuites.project_id, projectId),
+              eq(testSuites.lifecycle_status, 'DELETED')
+            )
+          )
           .returning();
         if (!restored) {
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
@@ -394,7 +412,13 @@ export const restoreItem = async (
         const [restored] = await db
           .update(milestones)
           .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })
-          .where(and(eq(milestones.id, targetId), eq(milestones.lifecycle_status, 'DELETED')))
+          .where(
+            and(
+              eq(milestones.id, targetId),
+              eq(milestones.project_id, projectId),
+              eq(milestones.lifecycle_status, 'DELETED')
+            )
+          )
           .returning();
         if (!restored) {
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
@@ -407,7 +431,13 @@ export const restoreItem = async (
         const [restored] = await db
           .update(testScenarios)
           .set({ lifecycle_status: 'ACTIVE', archived_at: null, updated_at: now })
-          .where(and(eq(testScenarios.id, targetId), eq(testScenarios.lifecycle_status, 'DELETED')))
+          .where(
+            and(
+              eq(testScenarios.id, targetId),
+              eq(testScenarios.project_id, projectId),
+              eq(testScenarios.lifecycle_status, 'DELETED')
+            )
+          )
           .returning();
         if (!restored) {
           return { success: false, errors: { _trash: ['복원할 항목을 찾을 수 없습니다.'] } };
@@ -448,7 +478,13 @@ export const permanentDeleteItem = async (
         const [row] = await db
           .select()
           .from(testCases)
-          .where(and(eq(testCases.id, targetId), eq(testCases.lifecycle_status, 'DELETED')));
+          .where(
+            and(
+              eq(testCases.id, targetId),
+              eq(testCases.project_id, projectId),
+              eq(testCases.lifecycle_status, 'DELETED')
+            )
+          );
         if (row) {
           await writeAuditLogs(db, [
             {
@@ -464,16 +500,24 @@ export const permanentDeleteItem = async (
           await db
             .update(testCases)
             .set({ lifecycle_status: 'PURGED', updated_at: new Date() })
-            .where(eq(testCases.id, targetId));
+            .where(and(eq(testCases.id, targetId), eq(testCases.project_id, projectId)));
         }
         break;
       }
       case 'suite': {
-        // 스위트 + 하위 TC 모두 조회
+        // 스위트가 이 프로젝트 소속인지 먼저 확인한다. 아니면(부재/타 프로젝트) 하위 TC 까지 손대지 않는다.
         const [suiteRow] = await db
           .select()
           .from(testSuites)
-          .where(and(eq(testSuites.id, targetId), eq(testSuites.lifecycle_status, 'DELETED')));
+          .where(
+            and(
+              eq(testSuites.id, targetId),
+              eq(testSuites.project_id, projectId),
+              eq(testSuites.lifecycle_status, 'DELETED')
+            )
+          );
+        if (!suiteRow) break;
+
         const childCases = await db
           .select()
           .from(testCases)
@@ -481,9 +525,8 @@ export const permanentDeleteItem = async (
             and(eq(testCases.test_suite_id, targetId), eq(testCases.lifecycle_status, 'DELETED'))
           );
 
-        const entries = [];
-        if (suiteRow) {
-          entries.push({
+        const entries = [
+          {
             projectId,
             entityType: 'test_suite',
             entityId: suiteRow.id,
@@ -491,8 +534,8 @@ export const permanentDeleteItem = async (
             action: 'permanent_delete' as AuditAction,
             snapshot: suiteRow,
             deletedAt: suiteRow.archived_at,
-          });
-        }
+          },
+        ];
         for (const c of childCases) {
           entries.push({
             projectId,
@@ -505,11 +548,9 @@ export const permanentDeleteItem = async (
           });
         }
 
-        if (entries.length > 0) {
-          await writeAuditLogs(db, entries);
-        }
+        await writeAuditLogs(db, entries);
 
-        // 하위 TC + 스위트 PURGED 마킹
+        // 하위 TC + 스위트 PURGED 마킹 (스위트는 위에서 프로젝트 소속 확인됨)
         const purgedAt = new Date();
         await db
           .update(testCases)
@@ -520,14 +561,26 @@ export const permanentDeleteItem = async (
         await db
           .update(testSuites)
           .set({ lifecycle_status: 'PURGED', updated_at: purgedAt })
-          .where(and(eq(testSuites.id, targetId), eq(testSuites.lifecycle_status, 'DELETED')));
+          .where(
+            and(
+              eq(testSuites.id, targetId),
+              eq(testSuites.project_id, projectId),
+              eq(testSuites.lifecycle_status, 'DELETED')
+            )
+          );
         break;
       }
       case 'milestone': {
         const [row] = await db
           .select()
           .from(milestones)
-          .where(and(eq(milestones.id, targetId), eq(milestones.lifecycle_status, 'DELETED')));
+          .where(
+            and(
+              eq(milestones.id, targetId),
+              eq(milestones.project_id, projectId),
+              eq(milestones.lifecycle_status, 'DELETED')
+            )
+          );
         if (row) {
           await writeAuditLogs(db, [
             {
@@ -543,7 +596,7 @@ export const permanentDeleteItem = async (
           await db
             .update(milestones)
             .set({ lifecycle_status: 'PURGED', updated_at: new Date() })
-            .where(eq(milestones.id, targetId));
+            .where(and(eq(milestones.id, targetId), eq(milestones.project_id, projectId)));
         }
         break;
       }
@@ -552,7 +605,11 @@ export const permanentDeleteItem = async (
           .select()
           .from(testScenarios)
           .where(
-            and(eq(testScenarios.id, targetId), eq(testScenarios.lifecycle_status, 'DELETED'))
+            and(
+              eq(testScenarios.id, targetId),
+              eq(testScenarios.project_id, projectId),
+              eq(testScenarios.lifecycle_status, 'DELETED')
+            )
           );
         if (row) {
           await writeAuditLogs(db, [
@@ -569,7 +626,7 @@ export const permanentDeleteItem = async (
           await db
             .update(testScenarios)
             .set({ lifecycle_status: 'PURGED', updated_at: new Date() })
-            .where(eq(testScenarios.id, targetId));
+            .where(and(eq(testScenarios.id, targetId), eq(testScenarios.project_id, projectId)));
         }
         break;
       }

--- a/apps/web/src/features/trash/hooks/use-trash.ts
+++ b/apps/web/src/features/trash/hooks/use-trash.ts
@@ -38,6 +38,8 @@ export const useRestoreItem = (projectId: string) => {
         queryClient.invalidateQueries({ queryKey: ['testCases'] }),
         queryClient.invalidateQueries({ queryKey: ['testSuites'] }),
         queryClient.invalidateQueries({ queryKey: ['milestones'] }),
+        queryClient.invalidateQueries({ queryKey: ['scenarios'] }),
+        queryClient.invalidateQueries({ queryKey: ['scenarioFeatures'] }),
         queryClient.invalidateQueries({ queryKey: ['dashboard'] }),
       ]).catch(() => {});
     },

--- a/apps/web/src/features/trash/model/types.ts
+++ b/apps/web/src/features/trash/model/types.ts
@@ -1,4 +1,4 @@
-export type TrashItemType = 'case' | 'suite' | 'milestone';
+export type TrashItemType = 'case' | 'suite' | 'milestone' | 'scenario';
 
 export interface TrashItem {
   id: string;

--- a/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
+++ b/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
@@ -197,6 +197,8 @@ export const ScenarioFeatureDetailView = () => {
         toast.success('시나리오를 삭제했습니다.');
         queryClient.invalidateQueries({ queryKey: ['scenarios'] });
         queryClient.invalidateQueries({ queryKey: ['scenarioFeatures'] });
+        // 삭제된 시나리오는 휴지통에 노출되므로 trash 캐시도 갱신한다.
+        queryClient.invalidateQueries({ queryKey: ['trash'] });
       } else {
         toast.error(Object.values(result.errors).flat().join(', '));
       }

--- a/apps/web/src/view/project/trash/_components/trash-constants.ts
+++ b/apps/web/src/view/project/trash/_components/trash-constants.ts
@@ -1,5 +1,5 @@
 import type { TrashItemType } from '@/features/trash';
-import { FileText, Flag, FolderOpen } from 'lucide-react';
+import { FileText, Flag, FolderOpen, ListChecks } from 'lucide-react';
 
 export const TYPE_CONFIG: Record<
   TrashItemType,
@@ -23,6 +23,12 @@ export const TYPE_CONFIG: Record<
     color: 'text-amber-400',
     bgColor: 'bg-amber-500/10',
   },
+  scenario: {
+    label: '시나리오',
+    icon: ListChecks,
+    color: 'text-emerald-400',
+    bgColor: 'bg-emerald-500/10',
+  },
 };
 
 export const FILTER_OPTIONS: { value: 'all' | TrashItemType; label: string }[] = [
@@ -30,6 +36,7 @@ export const FILTER_OPTIONS: { value: 'all' | TrashItemType; label: string }[] =
   { value: 'case', label: '테스트 케이스' },
   { value: 'suite', label: '테스트 스위트' },
   { value: 'milestone', label: '마일스톤' },
+  { value: 'scenario', label: '시나리오' },
 ];
 
 export function formatDeletedDate(date: Date): string {

--- a/packages/db/drizzle/0018_kind_gideon.sql
+++ b/packages/db/drizzle/0018_kind_gideon.sql
@@ -1,1 +1,4 @@
-ALTER TABLE "test_scenarios" ADD COLUMN "archived_at" timestamp with time zone;
+ALTER TABLE "test_scenarios" ADD COLUMN "archived_at" timestamp with time zone;--> statement-breakpoint
+-- 컬럼 추가 전에 삭제된 시나리오는 archived_at 이 NULL 이라 휴지통 잔여일/30일 자동정리에서 누락된다.
+-- updated_at(마지막 삭제 시각 근사)으로 백필해 자동 정리 대상에 포함시킨다.
+UPDATE "test_scenarios" SET "archived_at" = "updated_at" WHERE "lifecycle_status" = 'DELETED' AND "archived_at" IS NULL;

--- a/packages/db/drizzle/0018_kind_gideon.sql
+++ b/packages/db/drizzle/0018_kind_gideon.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "test_scenarios" ADD COLUMN "archived_at" timestamp with time zone;

--- a/packages/db/drizzle/meta/0018_snapshot.json
+++ b/packages/db/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2926 @@
+{
+  "id": "9e36c353-0cbb-4597-b090-88feb37969b8",
+  "prevId": "ddb54f54-4d98-45a4-9fe2-e922d617d46b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_name": {
+          "name": "owner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suites": {
+      "name": "test_suites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_scenario_id": {
+          "name": "test_scenario_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {
+        "test_suites_active_scenario_unq": {
+          "name": "test_suites_active_scenario_unq",
+          "columns": [
+            {
+              "expression": "test_scenario_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"test_suites\".\"lifecycle_status\" = 'ACTIVE' AND \"test_suites\".\"test_scenario_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_suites_project_id_projects_id_fk": {
+          "name": "test_suites_project_id_projects_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_suites_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_suites_test_scenario_id_test_scenarios_id_fk": {
+          "name": "test_suites_test_scenario_id_test_scenarios_id_fk",
+          "tableFrom": "test_suites",
+          "tableTo": "test_scenarios",
+          "columnsFrom": [
+            "test_scenario_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_cases": {
+      "name": "test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_id": {
+          "name": "display_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "case_key": {
+          "name": "case_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[10]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "automation_status": {
+          "name": "automation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_cases_project_id_projects_id_fk": {
+          "name": "test_cases_project_id_projects_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_cases_test_suite_id_test_suites_id_fk": {
+          "name": "test_cases_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "test_cases_section_id_test_suite_sections_id_fk": {
+          "name": "test_cases_section_id_test_suite_sections_id_fk",
+          "tableFrom": "test_cases",
+          "tableTo": "test_suite_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_cases_project_id_name_unique": {
+          "name": "test_cases_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        },
+        "test_cases_project_id_display_id_unique": {
+          "name": "test_cases_project_id_display_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "display_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "test_cases_automation_status_check": {
+          "name": "test_cases_automation_status_check",
+          "value": "\"test_cases\".\"automation_status\" in ('manual', 'candidate', 'automated')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_runs": {
+      "name": "test_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_STARTED'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_expires_at": {
+          "name": "share_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_ai_summary": {
+          "name": "share_ai_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_runs_project_id_projects_id_fk": {
+          "name": "test_runs_project_id_projects_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_runs_milestone_id_milestones_id_fk": {
+          "name": "test_runs_milestone_id_milestones_id_fk",
+          "tableFrom": "test_runs",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_runs_share_token_unique": {
+          "name": "test_runs_share_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestones": {
+      "name": "milestones",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "progress_status": {
+          "name": "progress_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'planned'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestones_project_id_projects_id_fk": {
+          "name": "milestones_project_id_projects_id_fk",
+          "tableFrom": "milestones",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_runs": {
+      "name": "test_case_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'untested'"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executed_at": {
+          "name": "executed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'adhoc'"
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result_source": {
+          "name": "result_source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "automation_meta": {
+          "name": "automation_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_runs_test_run_id_test_runs_id_fk": {
+          "name": "test_case_runs_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_runs_test_case_id_test_cases_id_fk": {
+          "name": "test_case_runs_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_runs",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_case_runs_result_source_check": {
+          "name": "test_case_runs_result_source_check",
+          "value": "\"test_case_runs\".\"result_source\" in ('manual', 'auto')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_run_milestones": {
+      "name": "test_run_milestones",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_milestones_test_run_id_test_runs_id_fk": {
+          "name": "test_run_milestones_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_milestones_milestone_id_milestones_id_fk": {
+          "name": "test_run_milestones_milestone_id_milestones_id_fk",
+          "tableFrom": "test_run_milestones",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_milestones_test_run_id_milestone_id_pk": {
+          "name": "test_run_milestones_test_run_id_milestone_id_pk",
+          "columns": [
+            "test_run_id",
+            "milestone_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_run_suites": {
+      "name": "test_run_suites",
+      "schema": "",
+      "columns": {
+        "test_run_id": {
+          "name": "test_run_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "excluded_at": {
+          "name": "excluded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_run_suites_test_run_id_test_runs_id_fk": {
+          "name": "test_run_suites_test_run_id_test_runs_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_runs",
+          "columnsFrom": [
+            "test_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_run_suites_test_suite_id_test_suites_id_fk": {
+          "name": "test_run_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "test_run_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "test_run_suites_test_run_id_test_suite_id_pk": {
+          "name": "test_run_suites_test_run_id_test_suite_id_pk",
+          "columns": [
+            "test_run_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suite_test_cases": {
+      "name": "suite_test_cases",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "suite_test_cases_suite_id_test_suites_id_fk": {
+          "name": "suite_test_cases_suite_id_test_suites_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suite_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "suite_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "suite_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_cases": {
+      "name": "milestone_test_cases",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_cases_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_cases_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_cases_test_case_id_test_cases_id_fk": {
+          "name": "milestone_test_cases_test_case_id_test_cases_id_fk",
+          "tableFrom": "milestone_test_cases",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_cases_milestone_id_test_case_id_pk": {
+          "name": "milestone_test_cases_milestone_id_test_case_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_case_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.milestone_test_suites": {
+      "name": "milestone_test_suites",
+      "schema": "",
+      "columns": {
+        "milestone_id": {
+          "name": "milestone_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_suite_id": {
+          "name": "test_suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "milestone_test_suites_milestone_id_milestones_id_fk": {
+          "name": "milestone_test_suites_milestone_id_milestones_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "milestones",
+          "columnsFrom": [
+            "milestone_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "milestone_test_suites_test_suite_id_test_suites_id_fk": {
+          "name": "milestone_test_suites_test_suite_id_test_suites_id_fk",
+          "tableFrom": "milestone_test_suites",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "test_suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "milestone_test_suites_milestone_id_test_suite_id_pk": {
+          "name": "milestone_test_suites_milestone_id_test_suite_id_pk",
+          "columns": [
+            "milestone_id",
+            "test_suite_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_preferences": {
+      "name": "project_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_preferences_project_id_projects_id_fk": {
+          "name": "project_preferences_project_id_projects_id_fk",
+          "tableFrom": "project_preferences",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_preferences_project_id_key_unique": {
+          "name": "project_preferences_project_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_name": {
+          "name": "entity_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_project_id_projects_id_fk": {
+          "name": "audit_logs_project_id_projects_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_activity_logs": {
+      "name": "admin_activity_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_label": {
+          "name": "target_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_activity_logs_created_idx": {
+          "name": "admin_activity_logs_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_attachments": {
+      "name": "test_case_attachments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_path": {
+          "name": "storage_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_attachments_test_case_id_test_cases_id_fk": {
+          "name": "test_case_attachments_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_case_attachments_project_id_projects_id_fk": {
+          "name": "test_case_attachments_project_id_projects_id_fk",
+          "tableFrom": "test_case_attachments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_templates": {
+      "name": "test_case_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CUSTOM'"
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_tags": {
+          "name": "default_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "test_steps": {
+          "name": "test_steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_templates_project_id_projects_id_fk": {
+          "name": "test_case_templates_project_id_projects_id_fk",
+          "tableFrom": "test_case_templates",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_templates_project_id_name_unique": {
+          "name": "test_case_templates_project_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_versions": {
+      "name": "test_case_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_number": {
+          "name": "version_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "test_type": {
+          "name": "test_type",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pre_condition": {
+          "name": "pre_condition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steps": {
+          "name": "steps",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expected_result": {
+          "name": "expected_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_summary": {
+          "name": "change_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_fields": {
+          "name": "changed_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_case_versions_test_case_id_test_cases_id_fk": {
+          "name": "test_case_versions_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_versions",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_case_versions_test_case_id_version_number_unique": {
+          "name": "test_case_versions_test_case_id_version_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "test_case_id",
+            "version_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_suite_sections": {
+      "name": "test_suite_sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suite_id": {
+          "name": "suite_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_suite_sections_suite_id_test_suites_id_fk": {
+          "name": "test_suite_sections_suite_id_test_suites_id_fk",
+          "tableFrom": "test_suite_sections",
+          "tableTo": "test_suites",
+          "columnsFrom": [
+            "suite_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "test_suite_sections_suite_id_name_unique": {
+          "name": "test_suite_sections_suite_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suite_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklists": {
+      "name": "checklists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'open'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklists_project_id_projects_id_fk": {
+          "name": "checklists_project_id_projects_id_fk",
+          "tableFrom": "checklists",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.checklist_items": {
+      "name": "checklist_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "checklist_id": {
+          "name": "checklist_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_checked": {
+          "name": "is_checked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "checklist_items_checklist_id_checklists_id_fk": {
+          "name": "checklist_items_checklist_id_checklists_id_fk",
+          "tableFrom": "checklist_items",
+          "tableTo": "checklists",
+          "columnsFrom": [
+            "checklist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.github_connections": {
+      "name": "github_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "webhook_secret": {
+          "name": "webhook_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connected_at": {
+          "name": "connected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "github_connections_project_id_projects_id_fk": {
+          "name": "github_connections_project_id_projects_id_fk",
+          "tableFrom": "github_connections",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "github_connections_project_id_unique": {
+          "name": "github_connections_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.test_case_external_links": {
+      "name": "test_case_external_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "test_case_id": {
+          "name": "test_case_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link_type": {
+          "name": "link_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_url": {
+          "name": "external_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tc_ext_links_case": {
+          "name": "idx_tc_ext_links_case",
+          "columns": [
+            {
+              "expression": "test_case_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tc_ext_links_external": {
+          "name": "idx_tc_ext_links_external",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "test_case_external_links_test_case_id_test_cases_id_fk": {
+          "name": "test_case_external_links_test_case_id_test_cases_id_fk",
+          "tableFrom": "test_case_external_links",
+          "tableTo": "test_cases",
+          "columnsFrom": [
+            "test_case_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_ai_configs": {
+      "name": "project_ai_configs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_ai_configs_project_id_projects_id_fk": {
+          "name": "project_ai_configs_project_id_projects_id_fk",
+          "tableFrom": "project_ai_configs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_ai_configs_project_id_unique": {
+          "name": "project_ai_configs_project_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_usage_logs": {
+      "name": "ai_usage_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generated_count": {
+          "name": "generated_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_size_bytes": {
+          "name": "attached_file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_page_count": {
+          "name": "attached_file_page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_usage_logs_project_id_projects_id_fk": {
+          "name": "ai_usage_logs_project_id_projects_id_fk",
+          "tableFrom": "ai_usage_logs",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_usage_logs_attached_file_type_check": {
+          "name": "ai_usage_logs_attached_file_type_check",
+          "value": "\"ai_usage_logs\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.announcements": {
+      "name": "announcements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'info'"
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "show_as_popup": {
+          "name": "show_as_popup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "announcements_active_idx": {
+          "name": "announcements_active_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "announcements_category_idx": {
+          "name": "announcements_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_reads": {
+      "name": "notification_reads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "announcement_id": {
+          "name": "announcement_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_reads_user_idx": {
+          "name": "notification_reads_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notification_reads_announcement_idx": {
+          "name": "notification_reads_announcement_idx",
+          "columns": [
+            {
+              "expression": "announcement_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_reads_announcement_id_announcements_id_fk": {
+          "name": "notification_reads_announcement_id_announcements_id_fk",
+          "tableFrom": "notification_reads",
+          "tableTo": "announcements",
+          "columnsFrom": [
+            "announcement_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_reads_user_announcement_unq": {
+          "name": "notification_reads_user_announcement_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "announcement_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_automation_tokens": {
+      "name": "project_automation_tokens",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "project_automation_tokens_token_hash_unq": {
+          "name": "project_automation_tokens_token_hash_unq",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_automation_tokens_project_id_projects_id_fk": {
+          "name": "project_automation_tokens_project_id_projects_id_fk",
+          "tableFrom": "project_automation_tokens",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_requirement_analyses": {
+      "name": "ai_requirement_analyses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_input": {
+          "name": "source_input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ko'"
+        },
+        "attached_file_type": {
+          "name": "attached_file_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_file_char_count": {
+          "name": "attached_file_char_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ai_requirement_analyses_project_id_projects_id_fk": {
+          "name": "ai_requirement_analyses_project_id_projects_id_fk",
+          "tableFrom": "ai_requirement_analyses",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ai_requirement_analyses_attached_file_type_check": {
+          "name": "ai_requirement_analyses_attached_file_type_check",
+          "value": "\"ai_requirement_analyses\".\"attached_file_type\" in ('pdf', 'markdown')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.test_scenarios": {
+      "name": "test_scenarios",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requirement_analysis_id": {
+          "name": "requirement_analysis_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'positive'"
+        },
+        "related_requirement_ids": {
+          "name": "related_requirement_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'DRAFT'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle_status": {
+          "name": "lifecycle_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "test_scenarios_project_id_projects_id_fk": {
+          "name": "test_scenarios_project_id_projects_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk": {
+          "name": "test_scenarios_requirement_analysis_id_ai_requirement_analyses_id_fk",
+          "tableFrom": "test_scenarios",
+          "tableTo": "ai_requirement_analyses",
+          "columnsFrom": [
+            "requirement_analysis_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "test_scenarios_type_check": {
+          "name": "test_scenarios_type_check",
+          "value": "\"test_scenarios\".\"type\" in ('positive', 'negative', 'edge_case')"
+        },
+        "test_scenarios_status_check": {
+          "name": "test_scenarios_status_check",
+          "value": "\"test_scenarios\".\"status\" in ('DRAFT', 'REVIEW', 'CONFIRMED')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.target_sites": {
+      "name": "target_sites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_secret_encrypted": {
+          "name": "auth_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "target_sites_project_id_projects_id_fk": {
+          "name": "target_sites_project_id_projects_id_fk",
+          "tableFrom": "target_sites",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1781583348019,
       "tag": "0017_funny_enchantress",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1781966074579,
+      "tag": "0018_kind_gideon",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/test-scenarios.ts
+++ b/packages/db/src/schema/test-scenarios.ts
@@ -48,12 +48,14 @@ export const testScenarios = pgTable(
     /** 작성 상태: 초안 / 검토 / 확정. */
     status: varchar('status', { length: 20 }).$type<ScenarioStatus>().default('DRAFT').notNull(),
     sort_order: integer('sort_order').default(0).notNull(),
+    created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+    /** 휴지통 진입(소프트 삭제) 시각. 잔여일·30일 자동 정리 계산의 기준. ACTIVE 면 NULL. */
+    archived_at: timestamp('archived_at', { withTimezone: true }),
     lifecycle_status: varchar('lifecycle_status', { length: 20 })
       .$type<LifecycleStatus>()
       .default('ACTIVE')
       .notNull(),
-    created_at: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
-    updated_at: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
   },
   (t) => ({
     // dev 는 pgEnum 대신 varchar+CHECK 채택(#150). ai_requirement_analyses 와 동일 방식.


### PR DESCRIPTION
## 작업 유형

- [x] fix — 버그 수정 (관련 2건 묶음)

## 요약
AI/시나리오 영역에서 PR #165 리뷰로 분리된 버그 두 건을 함께 수정합니다.

1. (#167) AI 월 사용 한도의 검사·기록 경합(TOCTOU)으로 한도가 소폭 초과될 수 있던 문제
2. (#166) 삭제한 시나리오가 휴지통에서 관리되지 않던 문제 (복원·영구삭제·자동 정리 누락)

## #167 AI 월 사용 한도 원자화
- 사용량 검사와 기록을 한 트랜잭션으로 묶고 프로젝트 단위 잠금으로 직렬화해, 동시 요청에서도 한도를 넘기지 않도록 함
- 잔여 한도보다 많이 요청해도 남은 만큼만 채택해 집계하고, 채택된 건수만큼만 사용자에게 반환
- 동시 요청에 밀려 채택할 여유가 0건이면 한도 초과로 안내
- 세 AI 생성 경로(시나리오 생성·케이스 생성·요구사항 분석)를 동일한 원자적 집계 방식으로 통일
- 케이스 생성 경로는 그동안 남은 한도를 반영하지 않아 한 번에 한도를 넘길 수 있었는데 이번에 함께 차단됨

## #166 시나리오 휴지통 통합
- 삭제한 시나리오를 휴지통 대상에 포함: 목록 노출·복원·영구 삭제·30일 자동 정리에 모두 반영
- 시나리오 삭제 시각을 기록하도록 컬럼을 추가해, 잔여일과 자동 정리 기준으로 사용
- 복원은 시나리오만 되돌리며, 파생 스위트는 별도로 휴지통에서 관리되므로 상호작용·유니크 제약 충돌이 없음을 확인
- 휴지통 화면의 유형 필터와 항목 표시에 시나리오를 추가

## 영향 범위 / 주의사항

- [x] DB 변경 있음: 시나리오 테이블에 삭제 시각 컬럼 추가 (마이그레이션 0018). 기존 테이블 컬럼 추가라 RLS 영향 없음
- 마이그레이션은 아직 dev/prod 에 미적용. 적용 필요
- 사용자 앱 한정(web). 정상 단일 요청 흐름과 응답 형식은 그대로

## 테스트 방법
1. AI 생성 3종이 평소대로 동작하고 사용량이 한도 내로만 집계되는지 확인
2. 한도 근처에서 동시에 여러 생성 요청을 보내도 누적 사용량이 한도를 넘지 않는지 확인
3. 시나리오 삭제 후 휴지통에 노출되고 복원·영구삭제·30일 자동 정리가 동작하는지 확인