### PR TITLE
chore(#156): e2e CI 공급망·자격증명 하드닝 (액션 SHA pin + persist-credentials)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,17 @@ jobs:
     # push 이벤트엔 base PR 개념이 없어 PR 에서만 수행 (게이팅 지점)
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # base 대비 변경 파일 diff 를 위해 전체 히스토리 필요
           fetch-depth: 0
+          # 워크플로 토큰을 git config 에 남기지 않는다(후속 스텝의 토큰 재사용·노출 방지)
+          persist-credentials: false
 
       # packageManager 필드(pnpm@10.23.0)를 그대로 인식
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -69,11 +71,14 @@ jobs:
       # AI config 진입 spec 이 있어 필요 (없으면 일부 spec 만 영향)
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # e2e 잡은 push 가 필요 없으므로 자격증명 비지속화
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -83,7 +88,7 @@ jobs:
 
       # Playwright 브라우저 바이너리는 무겁다. 의존성 hash 기반으로 캐시.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
@@ -98,7 +103,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-smoke
           path: apps/web/playwright-report
@@ -106,7 +111,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-smoke
           path: apps/web/test-results
@@ -127,11 +132,14 @@ jobs:
       CLOUDFLARE_TURNSTILE_SECRET_KEY: 1x0000000000000000000000000000000AA
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # e2e 잡은 push 가 필요 없으므로 자격증명 비지속화
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -140,7 +148,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
@@ -154,7 +162,7 @@ jobs:
 
       - name: Upload Playwright report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: playwright-report-full
           path: apps/web/playwright-report
@@ -162,7 +170,7 @@ jobs:
 
       - name: Upload test results
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-full
           path: apps/web/test-results


### PR DESCRIPTION
## 작업 유형

- [x] chore — CI 보안 하드닝

## 요약
e2e / format CI 잡의 공급망·자격증명 보안을 강화합니다. 외부 액션을 변경 불가능한 커밋 해시로 고정하고, 체크아웃이 워크플로 토큰을 작업공간에 남기지 않도록 합니다. (PR #139 리뷰에서 분리된 후속 작업)

## 배경 / 동기
기존에는 외부 액션을 이동 가능한 메이저 태그로 참조해, 태그가 다른 커밋으로 재지정되면 의도치 않은 코드가 CI 에서 실행될 수 있었습니다. 또한 체크아웃 기본 동작이 워크플로 토큰을 작업공간 git 설정에 남겨, 이후 스텝이 토큰을 재사용하거나 노출할 여지가 있었습니다.

## 변경 사항
- CI 워크플로의 모든 외부 액션 참조(체크아웃·pnpm 셋업·노드 셋업·캐시·아티팩트 업로드)를 메이저 태그에서 고정 커밋 해시로 전환하고, 가독성을 위해 버전 주석을 함께 남김
- 세 개 체크아웃 스텝 모두에 자격증명 비지속화를 적용해, 워크플로 토큰이 작업공간에 남지 않도록 함 (e2e 잡은 푸시가 필요 없음)

## 영향 범위 / 주의사항

- [ ] 애플리케이션 코드·DB 변경 없음 (CI 워크플로 한정)
- 동작 자체는 동일하며 보안 속성만 강화. SHA 는 각 액션의 v4 태그가 현재 가리키는 커밋으로 고정

## 테스트 방법
1. PR 에서 format·e2e smoke 잡이 정상 부트·실행되는지 확인
2. 고정한 커밋 해시가 각 액션 저장소에 실제 존재하는 유효 커밋인지 확인