### PR TITLE
fix(#155): FDD-TR09 자동화 결과·토큰 리뷰 후속 보강 (8항목)

### DIFF
--- a/apps/web/app/api/projects/[projectName]/runs/[runId]/auto-results/route.ts
+++ b/apps/web/app/api/projects/[projectName]/runs/[runId]/auto-results/route.ts
@@ -2,15 +2,7 @@ import { NextResponse } from 'next/server';
 
 import { verifyAutomationTokenFromRequest } from '@/features/automation-token/lib/verify';
 import * as Sentry from '@sentry/nextjs';
-import {
-  type TestCaseRunResultSource,
-  type TestCaseRunStatus,
-  type TestRunStatus,
-  getDatabase,
-  testCaseRuns,
-  testCases,
-  testRuns,
-} from '@testea/db';
+import { type TestRunStatus, getDatabase, testCaseRuns, testCases, testRuns } from '@testea/db';
 import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 
@@ -48,7 +40,12 @@ const RequestSchema = z
   .object({
     results: z.array(ResultItemSchema).min(1).max(500),
   })
-  .strict();
+  .strict()
+  // 같은 caseKey 가 여러 번 오면 동일 row 를 반복 갱신하고 matched 카운트가 부풀려지므로 입력에서 거부.
+  .refine((data) => new Set(data.results.map((r) => r.caseKey)).size === data.results.length, {
+    message: 'duplicate caseKey in results',
+    path: ['results'],
+  });
 
 interface Params {
   params: Promise<{ projectName: string; runId: string }>;
@@ -134,37 +131,41 @@ export async function POST(request: Request, { params }: Params) {
     }
 
     // 6) 결과 보충 (보수 정책: 매칭 row 만 UPDATE, 새 case_run 자동 생성 안 함)
+    // 7) Run 상태 재계산까지 한 트랜잭션으로 묶어, 중간 실패 시 일부만 반영된 채 500 으로 새지 않게 한다.
     const matched: string[] = [];
     const unmapped: string[] = [];
     const now = new Date();
 
-    for (const result of parsed.data.results) {
-      const target = caseKeyMap.get(result.caseKey);
-      if (!target) {
-        unmapped.push(result.caseKey);
-        continue;
-      }
+    await db.transaction(async (tx) => {
+      for (const result of parsed.data.results) {
+        const target = caseKeyMap.get(result.caseKey);
+        if (!target) {
+          unmapped.push(result.caseKey);
+          continue;
+        }
 
-      const automationMeta = buildAutomationMeta(result);
-      const commentValue = result.comment ?? result.errorMessage ?? null;
+        const automationMeta = buildAutomationMeta(result);
 
-      await db
-        .update(testCaseRuns)
-        .set({
-          status: result.status satisfies TestCaseRunStatus,
-          comment: commentValue,
+        const setValues: Partial<typeof testCaseRuns.$inferInsert> = {
+          status: result.status,
           executed_at: result.status !== 'untested' ? now : null,
-          result_source: 'auto' satisfies TestCaseRunResultSource,
+          result_source: 'auto',
           automation_meta: Object.keys(automationMeta).length ? automationMeta : null,
           updated_at: now,
-        })
-        .where(eq(testCaseRuns.id, target.caseRunId));
+        };
+        // comment / errorMessage 둘 다 미전송이면 기존(사용자 수동) 코멘트를 덮어쓰지 않는다.
+        if (result.comment !== undefined || result.errorMessage !== undefined) {
+          setValues.comment = result.comment ?? result.errorMessage ?? null;
+        }
 
-      matched.push(result.caseKey);
-    }
+        await tx.update(testCaseRuns).set(setValues).where(eq(testCaseRuns.id, target.caseRunId));
 
-    // 7) Run 상태 재계산 (untested 개수 기반 NOT_STARTED / IN_PROGRESS / COMPLETED)
-    await recalcRunStatus(db, runId);
+        matched.push(result.caseKey);
+      }
+
+      // untested 개수 기반 NOT_STARTED / IN_PROGRESS / COMPLETED 재계산
+      await recalcRunStatus(tx, runId);
+    });
 
     return NextResponse.json(
       { runId, matched: matched.length, unmapped },
@@ -186,7 +187,11 @@ function buildAutomationMeta(result: z.infer<typeof ResultItemSchema>): Record<s
   return meta;
 }
 
-async function recalcRunStatus(db: ReturnType<typeof getDatabase>, testRunId: string) {
+type DbClient = ReturnType<typeof getDatabase>;
+/** 트랜잭션 콜백 인자(tx)와 일반 db 를 모두 받기 위한 타입. */
+type DbOrTx = DbClient | Parameters<Parameters<DbClient['transaction']>[0]>[0];
+
+async function recalcRunStatus(db: DbOrTx, testRunId: string) {
   const rows = await db
     .select({ status: testCaseRuns.status })
     .from(testCaseRuns)

--- a/apps/web/src/features/automation-token/lib/token.ts
+++ b/apps/web/src/features/automation-token/lib/token.ts
@@ -11,6 +11,12 @@ import { createHash, randomBytes } from 'node:crypto';
 const TOKEN_PREFIX = 'testea_pk_';
 const SECRET_BYTES = 32;
 const VISIBLE_PREFIX_LEN = TOKEN_PREFIX.length + 8;
+/** 32 bytes 를 base64url(패딩 없음)로 인코딩한 본체 길이. */
+const SECRET_BODY_LEN = 43;
+/** 평문 토큰 전체 길이: prefix(10) + 본체(43) = 53. */
+const TOKEN_TOTAL_LEN = TOKEN_PREFIX.length + SECRET_BODY_LEN;
+/** base64url 문자 집합으로 정확히 본체 길이만큼. */
+const TOKEN_BODY_PATTERN = new RegExp(`^[A-Za-z0-9_-]{${SECRET_BODY_LEN}}$`);
 
 export interface IssuedToken {
   /** UI 에 1회만 노출되는 평문. 저장 금지. */
@@ -38,7 +44,10 @@ export function extractTokenPrefix(plaintext: string): string {
 }
 
 export function isValidTokenFormat(value: string): boolean {
-  return value.startsWith(TOKEN_PREFIX) && value.length > VISIBLE_PREFIX_LEN;
+  // prefix + 최소 길이만 보면 임의의 긴 문자열도 통과한다. 정확 길이(53)와 base64url 본체(43자)까지 고정.
+  if (value.length !== TOKEN_TOTAL_LEN) return false;
+  if (!value.startsWith(TOKEN_PREFIX)) return false;
+  return TOKEN_BODY_PATTERN.test(value.slice(TOKEN_PREFIX.length));
 }
 
 export const AUTOMATION_TOKEN_PREFIX = TOKEN_PREFIX;

--- a/apps/web/src/features/runs/api/bulk-update-test-case-runs.ts
+++ b/apps/web/src/features/runs/api/bulk-update-test-case-runs.ts
@@ -62,6 +62,8 @@ export async function bulkUpdateTestCaseRunStatus(
         status: input.status,
         ...(input.comment !== undefined ? { comment: input.comment ?? null } : {}),
         executed_at: input.status !== 'untested' ? now : null,
+        // 사용자가 수동으로 수정하면 자동(auto) 출처를 manual 로 되돌려 출처가 stale 해지지 않게 한다.
+        result_source: 'manual',
         updated_at: now,
       })
       .where(

--- a/apps/web/src/features/runs/api/update-test-case-run.ts
+++ b/apps/web/src/features/runs/api/update-test-case-run.ts
@@ -4,7 +4,7 @@ import { requireProjectAccess } from '@/access/lib/require-access';
 import type { UpdateTestCaseRunInput, UpdateTestCaseRunResult } from '@/entities/test-run';
 import { ActionResult } from '@/shared/types';
 import * as Sentry from '@sentry/nextjs';
-import { TestCaseRunStatus, TestRunStatus, getDatabase, testCaseRuns, testRuns } from '@testea/db';
+import { TestRunStatus, getDatabase, testCaseRuns, testRuns } from '@testea/db';
 import { and, eq, isNull } from 'drizzle-orm';
 
 export async function updateTestCaseRunStatus(
@@ -38,6 +38,8 @@ export async function updateTestCaseRunStatus(
         status: input.status,
         comment: input.comment ?? null,
         executed_at: input.status !== 'untested' ? now : null,
+        // 사용자가 수동으로 수정하면 자동(auto) 출처를 manual 로 되돌려 출처가 stale 해지지 않게 한다.
+        result_source: 'manual',
         updated_at: now,
       })
       .where(eq(testCaseRuns.id, input.testCaseRunId))

--- a/apps/web/src/view/project/settings/_components/automation-token-section.tsx
+++ b/apps/web/src/view/project/settings/_components/automation-token-section.tsx
@@ -33,6 +33,10 @@ export const AutomationTokenSection = ({ projectId }: AutomationTokenSectionProp
 
   const status = statusQuery.data?.success ? statusQuery.data.data : null;
   const exists = !!status?.exists;
+  // 조회가 성공으로 확정되기 전(로딩·에러·실패)에는 발급을 막는다.
+  // 그 동안 status=null → exists=false 라 "토큰 없음"으로 보이는데, 이때 발급하면 upsert 가
+  // 기존 CI 토큰을 덮어써 현재 시크릿이 깨질 수 있다.
+  const statusSettled = statusQuery.isSuccess && !!statusQuery.data?.success;
 
   const handleIssue = () => {
     issueMutation.mutate(undefined, {
@@ -110,7 +114,7 @@ export const AutomationTokenSection = ({ projectId }: AutomationTokenSectionProp
               variant="solid"
               size="small"
               onClick={handleIssue}
-              disabled={issueMutation.isPending}
+              disabled={issueMutation.isPending || !statusSettled}
               className="shrink-0"
             >
               {issueMutation.isPending ? (
@@ -158,11 +162,17 @@ export const AutomationTokenSection = ({ projectId }: AutomationTokenSectionProp
       </SettingsCard.Root>
 
       {/* 발급 직후 평문 노출 모달 (1회만)
-          Dialog.Root 는 외부 onOpenChange 콜백을 지원하지 않으므로 외부 상태 정리는
-          명시 close 버튼에서 setIssuedPlaintext(null) 로 처리한다.
+          backdrop 클릭·Escape·명시 닫기 어느 경로로 닫혀도 onOpenChange 로 평문 상태를 정리해
+          메모리에 남거나 재오픈 시 이전 평문이 노출되지 않게 한다.
           `key={issuedPlaintext}` 로 재발급 시마다 강제 re-mount 해 defaultOpen 이 적용되도록 한다. */}
       {issuedPlaintext && (
-        <Dialog.Root key={issuedPlaintext} defaultOpen>
+        <Dialog.Root
+          key={issuedPlaintext}
+          defaultOpen
+          onOpenChange={(open) => {
+            if (!open) setIssuedPlaintext(null);
+          }}
+        >
           <Dialog.Portal>
             <Dialog.Overlay
               className="animate-in fade-in"
@@ -218,9 +228,15 @@ export const AutomationTokenSection = ({ projectId }: AutomationTokenSectionProp
         </Dialog.Root>
       )}
 
-      {/* 회수 확인 다이얼로그 */}
+      {/* 회수 확인 다이얼로그
+          backdrop·Escape 로 닫혀도 부모 confirmRevoke 를 false 로 되돌려, 이후 회수 버튼이 다시 열리도록 한다. */}
       {confirmRevoke && (
-        <Dialog.Root defaultOpen>
+        <Dialog.Root
+          defaultOpen
+          onOpenChange={(open) => {
+            if (!open) setConfirmRevoke(false);
+          }}
+        >
           <Dialog.Portal>
             <Dialog.Overlay
               className="animate-in fade-in"

--- a/apps/web/src/widgets/notification-center/announcement-detail-dialog.tsx
+++ b/apps/web/src/widgets/notification-center/announcement-detail-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import type { AnnouncementWithReadState } from '@testea/db';
 import { DSButton, Dialog } from '@testea/ui';
@@ -21,12 +21,18 @@ export function AnnouncementDetailDialog({ announcement, onClose }: Announcement
   const markRead = useMarkRead();
   const labels = useAnnouncementLabels();
 
+  // mutation 상태 변경 리렌더마다 markRead/announcement 가 새 참조가 되어 effect 가 재실행되고
+  // 같은 공지에 읽음 POST 가 반복되던 문제를, 이미 호출한 id 를 ref 로 가드해 막는다.
+  // (deps 는 정직하게 채우고 중복은 가드로 차단)
+  const markedIdRef = useRef<string | null>(null);
+
   useEffect(() => {
     if (!announcement) return;
     if (announcement.readAt) return;
+    if (markedIdRef.current === announcement.id) return;
+    markedIdRef.current = announcement.id;
     markRead.mutate(announcement.id);
-    // mutate 는 안정 참조라 dep 에 넣지 않아도 동일 효과지만 lint 회피용으로 포함
-  }, [announcement?.id, announcement?.readAt, markRead, announcement]);
+  }, [announcement, markRead]);
 
   if (!announcement) return null;
 

--- a/packages/ui/src/primitives/dialog/dialog.tsx
+++ b/packages/ui/src/primitives/dialog/dialog.tsx
@@ -32,10 +32,29 @@ const useDialogContext = () => {
 interface DialogRootProps {
   children: React.ReactNode;
   defaultOpen?: boolean;
+  /**
+   * 열림/닫힘 상태가 바뀔 때 통지한다. backdrop 클릭·Escape 로 닫힐 때도 호출되므로,
+   * 소비처가 외부 상태(예: 발급 평문)를 함께 정리하는 데 쓸 수 있다. optional 이라 기존 사용처는 무영향.
+   */
+  onOpenChange?: (open: boolean) => void;
 }
 
-const DialogRoot = ({ children, defaultOpen = false }: DialogRootProps) => {
+const DialogRoot = ({ children, defaultOpen = false, onOpenChange }: DialogRootProps) => {
   const disclosure = useDisclosure(defaultOpen);
+
+  // 인라인 콜백이 매 렌더 새 참조여도 onOpen/onClose 가 재생성되지 않도록 ref 로 잡는다.
+  const onOpenChangeRef = React.useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
+  const onOpen = React.useCallback(() => {
+    disclosure.onOpen();
+    onOpenChangeRef.current?.(true);
+  }, [disclosure.onOpen]);
+
+  const onClose = React.useCallback(() => {
+    disclosure.onClose();
+    onOpenChangeRef.current?.(false);
+  }, [disclosure.onClose]);
 
   // a11y
   const id = React.useId();
@@ -43,7 +62,9 @@ const DialogRoot = ({ children, defaultOpen = false }: DialogRootProps) => {
   const descriptionId = `description-${id}`;
 
   return (
-    <DialogContext.Provider value={{ ...disclosure, titleId, descriptionId }}>
+    <DialogContext.Provider
+      value={{ isOpen: disclosure.isOpen, onOpen, onClose, titleId, descriptionId }}
+    >
       {children}
     </DialogContext.Provider>
   );


### PR DESCRIPTION
## 작업 유형

- [x] fix — 버그 수정 (PR #139 리뷰에서 분리한 후속 보강 8항목)

## 요약
자동화 결과 수신 라우트와 자동화 토큰, 토큰 발급 UI, 공지 읽음 처리에서 PR #139 코드리뷰(CodeRabbit·Codex)가 지적한 정합성·보안·UX 결함을 보강합니다.

## 변경 사항

자동화 결과 수신
- 같은 케이스 키가 여러 번 들어오면 입력 단계에서 거부해, 동일 항목 반복 갱신과 매칭 수 부풀림을 막음
- 결과 반영과 실행 상태 재계산을 한 트랜잭션으로 묶어, 중간 실패 시 일부만 반영된 채 노출되지 않도록 원자성 보장
- 상태만 보내고 코멘트를 보내지 않은 경우 사용자가 남긴 수동 코멘트를 지우지 않고 보존

출처 정합성
- 자동으로 저장된 실행을 사용자가 수동으로 수정하면 출처를 수동으로 되돌려, 출처 표시가 어긋나지 않게 함 (단건·일괄 모두)

자동화 토큰
- 토큰 형식 검증을 정확한 길이와 본문 문자 집합까지 고정해, 접두사만 맞는 임의 문자열이 통과하지 않게 강화

토큰 발급 화면
- 발급 직후 평문을 보여주는 창이 배경 클릭이나 ESC 로 닫혀도 평문 상태를 정리해, 메모리에 남거나 다시 열 때 노출되지 않게 함
- 상태 조회가 끝나기 전에는 발급 버튼을 비활성화해, 조회 지연 중 발급이 기존 토큰을 덮어써 시크릿이 깨지는 일을 방지
- 회수 확인 창이 배경·ESC 로 닫혀도 내부 상태를 정리해, 이후 회수 버튼이 다시 정상 동작하게 함

공지
- 읽음 처리 동작이 리렌더마다 반복 호출되던 것을, 이미 처리한 항목을 기억해 한 번만 보내도록 가드

공통
- 디자인 시스템 다이얼로그에 열림/닫힘 통지 콜백(optional)을 추가해, 배경·ESC 로 닫을 때 소비처가 외부 상태를 함께 정리할 수 있게 함 (기존 사용처 무영향)

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- 사용자 앱(web) + 디자인 시스템(다이얼로그 콜백 추가, 하위 호환)

## 테스트 방법
1. 자동화 결과를 중복 키로 보내면 거부되는지, 정상 키는 트랜잭션으로 일괄 반영되는지 확인
2. 상태만 보낸 보고가 기존 수동 코멘트를 지우지 않는지 확인
3. 자동 저장된 실행을 수동 수정하면 출처가 수동으로 바뀌는지 확인
4. 발급 평문 창과 회수 창을 배경 클릭·ESC 로 닫은 뒤 상태가 깨끗이 정리되는지 확인
5. 토큰 상태 조회 중 발급 버튼이 비활성인지 확인
6. 미읽음 공지를 열어 둔 채 두어도 읽음 요청이 한 번만 가는지 확인