### PR TITLE
fix(security): 백오피스 루트 인증 가드 + 재정렬 IDOR 차단 (감사 C-1/H-A)

### DIFF
--- a/apps/back-office/app/page.tsx
+++ b/apps/back-office/app/page.tsx
@@ -2,11 +2,15 @@ import {
   type RealDashboardData,
   getDashboardData,
 } from '@/entities/admin-dashboard/api/get-dashboard-data';
+import { requireAdmin } from '@/features/auth-gate/lib/admin-gate';
 import { DashboardPage } from '@/pages/dashboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function Home() {
+  // 다른 페이지와 동일한 인증 가드. 누락 시 미인증으로 운영 지표가 노출됨(+ Hyperdrive DB 주입도 겸함).
+  await requireAdmin('/');
+
   let data: RealDashboardData | null = null;
   try {
     data = await getDashboardData();

--- a/apps/web/src/features/reorder/api/actions.ts
+++ b/apps/web/src/features/reorder/api/actions.ts
@@ -1,14 +1,26 @@
 'use server';
 
+import { requireProjectAccess } from '@/access/lib/require-access';
 import type { ActionResult } from '@/shared/types';
 import * as Sentry from '@sentry/nextjs';
 import { getDatabase, testCases, testSuites } from '@testea/db';
-import { and, asc, eq } from 'drizzle-orm';
+import { and, asc, eq, inArray } from 'drizzle-orm';
 
 import { SORT_ORDER_GAP } from '../model/sort-utils';
 
+const accessDenied = (): ActionResult<void> => ({
+  success: false,
+  errors: { _form: ['접근 권한이 없습니다.'] },
+});
+
+const targetNotFound = (): ActionResult<void> => ({
+  success: false,
+  errors: { _form: ['대상을 찾을 수 없습니다.'] },
+});
+
 /**
- * 테스트 케이스 sort_order 업데이트
+ * 테스트 케이스 sort_order 업데이트.
+ * id 로 소유 프로젝트를 확인하고 requireProjectAccess 로 가드한다(IDOR 방지).
  */
 export async function reorderTestCase(
   id: string,
@@ -16,10 +28,18 @@ export async function reorderTestCase(
 ): Promise<ActionResult<void>> {
   try {
     const db = getDatabase();
+
+    const [row] = await db
+      .select({ projectId: testCases.project_id })
+      .from(testCases)
+      .where(eq(testCases.id, id))
+      .limit(1);
+    if (!row?.projectId || !(await requireProjectAccess(row.projectId))) return accessDenied();
+
     await db
       .update(testCases)
       .set({ sort_order: newSortOrder, updated_at: new Date() })
-      .where(eq(testCases.id, id));
+      .where(and(eq(testCases.id, id), eq(testCases.project_id, row.projectId)));
 
     return { success: true, data: undefined };
   } catch (error) {
@@ -29,7 +49,7 @@ export async function reorderTestCase(
 }
 
 /**
- * 테스트 스위트 sort_order 업데이트
+ * 테스트 스위트 sort_order 업데이트. id 소유 프로젝트로 가드.
  */
 export async function reorderTestSuite(
   id: string,
@@ -37,10 +57,18 @@ export async function reorderTestSuite(
 ): Promise<ActionResult<void>> {
   try {
     const db = getDatabase();
+
+    const [row] = await db
+      .select({ projectId: testSuites.project_id })
+      .from(testSuites)
+      .where(eq(testSuites.id, id))
+      .limit(1);
+    if (!row?.projectId || !(await requireProjectAccess(row.projectId))) return accessDenied();
+
     await db
       .update(testSuites)
       .set({ sort_order: newSortOrder, updated_at: new Date() })
-      .where(eq(testSuites.id, id));
+      .where(and(eq(testSuites.id, id), eq(testSuites.project_id, row.projectId)));
 
     return { success: true, data: undefined };
   } catch (error) {
@@ -50,7 +78,8 @@ export async function reorderTestSuite(
 }
 
 /**
- * TC를 다른 스위트로 이동
+ * TC를 다른 스위트로 이동. caseId 소유 프로젝트로 가드하고,
+ * 대상 스위트(newSuiteId)도 같은 프로젝트 소속인지 검증(cross-project 이동 차단).
  */
 export async function moveTestCaseToSuite(
   caseId: string,
@@ -59,8 +88,30 @@ export async function moveTestCaseToSuite(
   try {
     const db = getDatabase();
 
-    // 새 스위트의 마지막 sort_order 조회
-    const conditions = [eq(testCases.lifecycle_status, 'ACTIVE')];
+    const [caseRow] = await db
+      .select({ projectId: testCases.project_id })
+      .from(testCases)
+      .where(eq(testCases.id, caseId))
+      .limit(1);
+    if (!caseRow?.projectId || !(await requireProjectAccess(caseRow.projectId)))
+      return accessDenied();
+    const projectId = caseRow.projectId;
+
+    // 대상 스위트가 같은 프로젝트 소속인지 확인 (다른 프로젝트 스위트로 끌어가지 못하게)
+    if (newSuiteId) {
+      const [suiteRow] = await db
+        .select({ id: testSuites.id })
+        .from(testSuites)
+        .where(and(eq(testSuites.id, newSuiteId), eq(testSuites.project_id, projectId)))
+        .limit(1);
+      if (!suiteRow) return targetNotFound();
+    }
+
+    // 새 스위트의 마지막 sort_order 조회 (같은 프로젝트 범위 내)
+    const conditions = [
+      eq(testCases.project_id, projectId),
+      eq(testCases.lifecycle_status, 'ACTIVE'),
+    ];
     if (newSuiteId) {
       conditions.push(eq(testCases.test_suite_id, newSuiteId));
     }
@@ -84,7 +135,7 @@ export async function moveTestCaseToSuite(
         sort_order: maxOrder,
         updated_at: new Date(),
       })
-      .where(eq(testCases.id, caseId));
+      .where(and(eq(testCases.id, caseId), eq(testCases.project_id, projectId)));
 
     return { success: true, data: undefined };
   } catch (error) {
@@ -96,7 +147,10 @@ export async function moveTestCaseToSuite(
 /**
  * sort_order 전체 재정렬 (rebalance)
  * @param entityType - 'testCase' | 'testSuite'
- * @param scopeId - projectId (스위트) 또는 suiteId (TC)
+ * @param scopeId - testCase 면 suiteId, testSuite 면 projectId
+ *
+ * scope 의 소유 프로젝트로 가드하고, orderedIds 가 모두 그 프로젝트 소속인지 확인한 뒤
+ * 프로젝트 범위로만 UPDATE 한다(임의 id 일괄 갱신 차단).
  */
 export async function rebalanceSortOrder(
   entityType: 'testCase' | 'testSuite',
@@ -105,20 +159,50 @@ export async function rebalanceSortOrder(
 ): Promise<ActionResult<void>> {
   try {
     const db = getDatabase();
+    const uniqueIds = [...new Set(orderedIds)];
 
     if (entityType === 'testCase') {
+      // scopeId = suiteId → 그 스위트의 프로젝트로 가드
+      const [suiteRow] = await db
+        .select({ projectId: testSuites.project_id })
+        .from(testSuites)
+        .where(eq(testSuites.id, scopeId))
+        .limit(1);
+      if (!suiteRow?.projectId || !(await requireProjectAccess(suiteRow.projectId)))
+        return accessDenied();
+      const projectId = suiteRow.projectId;
+
+      if (uniqueIds.length > 0) {
+        const owned = await db
+          .select({ id: testCases.id })
+          .from(testCases)
+          .where(and(inArray(testCases.id, uniqueIds), eq(testCases.project_id, projectId)));
+        if (owned.length !== uniqueIds.length) return targetNotFound();
+      }
+
       for (let i = 0; i < orderedIds.length; i++) {
         await db
           .update(testCases)
           .set({ sort_order: (i + 1) * SORT_ORDER_GAP })
-          .where(eq(testCases.id, orderedIds[i]));
+          .where(and(eq(testCases.id, orderedIds[i]), eq(testCases.project_id, projectId)));
       }
     } else {
+      // scopeId = projectId
+      if (!(await requireProjectAccess(scopeId))) return accessDenied();
+
+      if (uniqueIds.length > 0) {
+        const owned = await db
+          .select({ id: testSuites.id })
+          .from(testSuites)
+          .where(and(inArray(testSuites.id, uniqueIds), eq(testSuites.project_id, scopeId)));
+        if (owned.length !== uniqueIds.length) return targetNotFound();
+      }
+
       for (let i = 0; i < orderedIds.length; i++) {
         await db
           .update(testSuites)
           .set({ sort_order: (i + 1) * SORT_ORDER_GAP })
-          .where(eq(testSuites.id, orderedIds[i]));
+          .where(and(eq(testSuites.id, orderedIds[i]), eq(testSuites.project_id, scopeId)));
       }
     }
 
@@ -132,13 +216,15 @@ export async function rebalanceSortOrder(
 }
 
 /**
- * 스위트 내 TC의 sort_order 초기화 (null → 1000 간격)
+ * 스위트 내 TC의 sort_order 초기화 (null → 1000 간격). projectId 로 가드.
  */
 export async function initializeSortOrders(
   projectId: string,
   suiteId?: string
 ): Promise<ActionResult<void>> {
   try {
+    if (!(await requireProjectAccess(projectId))) return accessDenied();
+
     const db = getDatabase();
 
     const conditions = [
@@ -160,7 +246,7 @@ export async function initializeSortOrders(
       await db
         .update(testCases)
         .set({ sort_order: (i + 1) * SORT_ORDER_GAP })
-        .where(eq(testCases.id, rows[i].id));
+        .where(and(eq(testCases.id, rows[i].id), eq(testCases.project_id, projectId)));
     }
 
     return { success: true, data: undefined };


### PR DESCRIPTION
## 작업 유형

- [x] fix — 보안 수정 (2026-06-21 정적 보안 감사 발견)

## 요약
보안 감사에서 확인한 인증·권한 결함 두 건을 수정합니다. 백오피스 대시보드 첫 화면의 인증 가드 누락(CRITICAL)과, 케이스·스위트 순서 변경 서버 액션의 권한 검증 부재(HIGH)입니다.

## 변경 사항

백오피스 대시보드 루트 인증 가드 (CRITICAL)
- 백오피스의 다른 모든 페이지는 첫 줄에서 관리자 인증을 강제하는데, 첫 화면(루트)만 빠져 있어 인증 없이 운영 지표(프로젝트 수·AI 비용·매출 퍼널 등)가 노출될 수 있었음. 다른 페이지와 동일한 인증 가드를 추가(누락 시 게이트로 리다이렉트). 이 가드는 운영 DB 주입도 겸하므로 일관성도 회복됨

케이스·스위트 재정렬 권한 검증 (HIGH)
- 순서 변경·스위트 이동·재정렬·초기화 서버 액션들이 대상이 호출자 소유 프로젝트인지 확인하지 않아, 대상 식별자만 알면 임의 프로젝트의 케이스·스위트 순서를 바꾸거나 다른 프로젝트로 이동시킬 수 있었음(IDOR)
- 각 액션이 대상의 소유 프로젝트를 조회해 접근 권한을 확인하고, 갱신도 그 프로젝트 범위로만 수행하도록 제한. 스위트 이동은 대상 스위트가 같은 프로젝트 소속인지 추가 검증하고, 일괄 재정렬은 전달된 식별자가 모두 해당 프로젝트 소속일 때만 진행

## 영향 범위 / 주의사항

- [ ] DB / 환경 변수 변경 없음
- 백오피스(인증 가드) + 사용자 앱(web 재정렬). 정상 사용 흐름은 동일하며 권한 경계만 강화

## 테스트 방법
1. 백오피스 루트(`/`)에 미인증 접근 시 게이트로 리다이렉트되는지 확인
2. 케이스·스위트 순서 변경/이동/재정렬이 자기 프로젝트에서 정상 동작하는지 확인
3. 타 프로젝트 식별자로는 변경이 거부되는지 확인

## 비고
같은 감사의 MEDIUM/LOW 항목(읽기 액션 IDOR·CF Access fail-open·보안 헤더 등)은 별도 이슈로 추적합니다.