### PR TITLE
test(security): IDOR 가드 회귀 테스트 추가 (가드 자체 + reorder 거부 경로)

### DIFF
--- a/apps/web/src/access/lib/require-access.test.ts
+++ b/apps/web/src/access/lib/require-access.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProjectAccessTokenPayload } from '../policy/types';
+import { requireProjectAccess } from './require-access';
+
+// vi.hoisted 로 mock 함수를 끌어올려 factory 와 테스트가 같은 인스턴스를 공유하게 한다.
+const { mockCookies, mockVerify } = vi.hoisted(() => ({
+  mockCookies: vi.fn(),
+  mockVerify: vi.fn(),
+}));
+
+// setup-tests.ts 가 require-access 를 전역 mock(항상 true)으로 덮으므로, 이 파일에서는
+// 실제 구현을 검증하기 위해 unmock 한 뒤 그 의존(cookies·access-token)만 모킹한다.
+vi.unmock('@/access/lib/require-access');
+vi.mock('./cookies', () => ({ getAllAccessTokenCookies: mockCookies }));
+vi.mock('./access-token', () => ({ verifyProjectAccessToken: mockVerify }));
+
+const payloadFor = (projectId: string): ProjectAccessTokenPayload => ({
+  type: 'project_access',
+  projectId,
+  projectName: 'sample',
+  issuedAt: 0,
+  expiresAt: Number.MAX_SAFE_INTEGER,
+});
+
+describe('requireProjectAccess', () => {
+  beforeEach(() => {
+    mockCookies.mockReset();
+    mockVerify.mockReset();
+  });
+
+  it('유효 토큰이 대상 projectId 와 일치하면 true', async () => {
+    mockCookies.mockResolvedValue(new Map([['c', 'token']]));
+    mockVerify.mockResolvedValue({ valid: true, payload: payloadFor('proj-1') });
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(true);
+  });
+
+  it('유효 토큰이지만 다른 projectId 면 false (IDOR 차단)', async () => {
+    mockCookies.mockResolvedValue(new Map([['c', 'token']]));
+    mockVerify.mockResolvedValue({ valid: true, payload: payloadFor('proj-OTHER') });
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(false);
+  });
+
+  it('무효(서명/만료) 토큰이면 false', async () => {
+    mockCookies.mockResolvedValue(new Map([['c', 'bad']]));
+    mockVerify.mockResolvedValue({ valid: false, error: 'TOKEN_INVALID' });
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(false);
+  });
+
+  it('여러 쿠키 중 하나라도 대상과 일치하면 true', async () => {
+    mockCookies.mockResolvedValue(
+      new Map([
+        ['a', 'token-a'],
+        ['b', 'token-b'],
+      ])
+    );
+    mockVerify
+      .mockResolvedValueOnce({ valid: true, payload: payloadFor('other') })
+      .mockResolvedValueOnce({ valid: true, payload: payloadFor('proj-1') });
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(true);
+  });
+
+  it('쿠키가 하나도 없으면 false', async () => {
+    mockCookies.mockResolvedValue(new Map());
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(false);
+  });
+
+  it('쿠키 조회가 throw 하면 false (fail-closed)', async () => {
+    mockCookies.mockRejectedValue(new Error('cookie store unavailable'));
+
+    await expect(requireProjectAccess('proj-1')).resolves.toBe(false);
+  });
+});

--- a/apps/web/src/features/reorder/api/actions.test.ts
+++ b/apps/web/src/features/reorder/api/actions.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { reorderTestCase, reorderTestSuite } from './actions';
+
+// 전역 setup 은 requireProjectAccess 를 항상 true 로 mock 한다. IDOR 거부 경로를 검증하려면
+// 이 파일에서 동적 mock 으로 덮어 true/false 를 제어한다.
+const { mockAccess } = vi.hoisted(() => ({ mockAccess: vi.fn() }));
+vi.mock('@/access/lib/require-access', () => ({ requireProjectAccess: mockAccess }));
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+
+const mockLimit = vi.fn();
+const mockUpdateWhere = vi.fn(() => Promise.resolve());
+const mockUpdate = vi.fn(() => ({ set: vi.fn(() => ({ where: mockUpdateWhere })) }));
+const mockDb = {
+  select: vi.fn(() => ({
+    from: vi.fn(() => ({ where: vi.fn(() => ({ limit: mockLimit })) })),
+  })),
+  update: mockUpdate,
+};
+vi.mock('@testea/db', () => ({
+  getDatabase: () => mockDb,
+  testCases: { id: 'id', project_id: 'project_id' },
+  testSuites: { id: 'id', project_id: 'project_id' },
+}));
+
+describe('reorder 액션 — IDOR 가드 회귀', () => {
+  beforeEach(() => {
+    mockAccess.mockReset();
+    mockLimit.mockReset();
+    mockUpdate.mockClear();
+    mockUpdateWhere.mockClear();
+  });
+
+  it('reorderTestCase: 대상 소유 프로젝트 접근이 거부되면 실패하고 UPDATE 하지 않는다', async () => {
+    mockLimit.mockResolvedValue([{ projectId: 'proj-1' }]);
+    mockAccess.mockResolvedValue(false);
+
+    const result = await reorderTestCase('case-1', 1000);
+
+    expect(result.success).toBe(false);
+    expect(mockAccess).toHaveBeenCalledWith('proj-1');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reorderTestCase: 접근이 허용되면 UPDATE 를 수행한다', async () => {
+    mockLimit.mockResolvedValue([{ projectId: 'proj-1' }]);
+    mockAccess.mockResolvedValue(true);
+
+    const result = await reorderTestCase('case-1', 1000);
+
+    expect(result.success).toBe(true);
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('reorderTestCase: 대상 케이스가 없으면 권한검사 전에 실패한다', async () => {
+    mockLimit.mockResolvedValue([]);
+
+    const result = await reorderTestCase('missing', 1000);
+
+    expect(result.success).toBe(false);
+    expect(mockAccess).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reorderTestSuite: 접근이 거부되면 실패하고 UPDATE 하지 않는다', async () => {
+    mockLimit.mockResolvedValue([{ projectId: 'proj-1' }]);
+    mockAccess.mockResolvedValue(false);
+
+    const result = await reorderTestSuite('suite-1', 1000);
+
+    expect(result.success).toBe(false);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 작업 유형

- [x] test — 보안 회귀 테스트 추가

## 요약
프로젝트 접근 권한 가드와, 최근 IDOR 수정한 재정렬 액션의 권한 거부 경로에 대한 단위 테스트를 추가합니다. 기존에는 모든 액션 테스트가 접근 허용을 전제로 모킹해, 권한 거부(IDOR) 경로가 한 곳도 검증되지 않았습니다.

## 변경 사항
- 접근 권한 가드 자체에 대한 테스트: 유효 토큰이 다른 프로젝트를 가리키면 거부(IDOR 차단), 무효 토큰·빈 쿠키 거부, 내부 오류 시 거부(fail-closed)
- 재정렬 액션의 권한 거부 경로 테스트: 대상 소유 프로젝트 접근이 거부되면 변경을 수행하지 않음, 대상이 없으면 권한 검사 전에 실패

## 비고 (테스트 인프라 메모)
전역 테스트 셋업이 접근 가드를 항상 통과로 모킹하기 때문에, 가드 자체를 검증할 때는 해당 모듈만 unmock 하고, 액션의 거부 경로를 검증할 때는 파일 단위로 가드를 동적 모킹해 통과/거부를 제어했습니다. 나머지 권한 거부 경로(휴지통·자동화 결과 수신 등)도 같은 패턴으로 보강할 수 있습니다.

## 영향 범위
- [ ] 제품 코드·DB 변경 없음 (테스트 추가만)
- 참고: 현재 CI 는 vitest 를 게이트하지 않아 이 테스트는 자동 실행되지 않습니다. CI 게이트 추가는 별도 이슈로 추적합니다.