### PR TITLE
fix(test): dev 검증 부채 테스트 2건 정리 (#219·#220)

### DIFF
--- a/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.test.tsx
+++ b/apps/back-office/src/widgets/dashboard/ui/additional-analysis-section.test.tsx
@@ -1,24 +1,40 @@
-import type { FunnelStep, StorageProject } from '@/entities/admin-dashboard';
+import type { FunnelStep, StorageProject, StorageSummary } from '@/entities/admin-dashboard';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { AdditionalAnalysisSection } from './additional-analysis-section';
 
-describe('AdditionalAnalysisSection 진행률 보정', () => {
-  it('퍼널 전환율(문자열 %)이 100을 넘으면 100으로 보정한다', () => {
-    const funnel: FunnelStep[] = [['가입', '100', '150%', '']];
+const emptySummary: StorageSummary = { totalSize: '0 B', totalRows: '0' };
 
-    render(<AdditionalAnalysisSection funnel={funnel} storageProjects={[]} />);
+describe('AdditionalAnalysisSection 진행률 보정', () => {
+  it('퍼널 전환율(percent)이 100을 넘으면 100으로 보정한다', () => {
+    const funnel: FunnelStep[] = [
+      { label: '가입', count: '100', rate: '150%', percent: 150, churn: '' },
+    ];
+
+    render(
+      <AdditionalAnalysisSection
+        funnel={funnel}
+        storageProjects={[]}
+        storageSummary={emptySummary}
+      />
+    );
 
     const bar = screen.getByRole('progressbar', { name: '가입 전환율' });
     expect(bar).toHaveAttribute('aria-valuenow', '100');
     expect(bar.querySelector('div')).toHaveStyle({ width: '100%' });
   });
 
-  it('스토리지 사용률이 100을 넘으면 100으로 보정한다', () => {
-    const storageProjects: StorageProject[] = [['p1', '10GB', 150]];
+  it('스토리지 사용률(percent)이 100을 넘으면 100으로 보정한다', () => {
+    const storageProjects: StorageProject[] = [{ name: 'p1', usage: '10GB', percent: 150 }];
 
-    render(<AdditionalAnalysisSection funnel={[]} storageProjects={storageProjects} />);
+    render(
+      <AdditionalAnalysisSection
+        funnel={[]}
+        storageProjects={storageProjects}
+        storageSummary={emptySummary}
+      />
+    );
 
     const bar = screen.getByRole('progressbar', { name: 'p1 스토리지 사용률' });
     expect(bar).toHaveAttribute('aria-valuenow', '100');

--- a/packages/db/src/client/drizzle.test.ts
+++ b/packages/db/src/client/drizzle.test.ts
@@ -13,10 +13,12 @@ vi.mock('postgres', () => {
   };
 });
 
+// drizzle 인스턴스 생성 시 전달된 옵션(logger 등)을 캡처해 검증한다.
 vi.mock('drizzle-orm/postgres-js', () => ({
-  drizzle: vi.fn((client) => ({
+  drizzle: vi.fn((client, options) => ({
     execute: vi.fn().mockResolvedValue([{ health: 1 }]),
     _: { client },
+    __options: options,
   })),
 }));
 
@@ -44,7 +46,7 @@ describe('데이터베이스 연결 관리 (Database Connection)', () => {
     expect(db1).toBe(db2);
   });
 
-  it('개발 환경에서 올바른 설정값(Connection Pool 등)으로 클라이언트가 초기화되어야 한다', async () => {
+  it('서버리스 단일 커넥션 풀 설정(max/idle/ssl/prepare)으로 클라이언트가 초기화되어야 한다', async () => {
     const postgres = (await import('postgres')).default;
     getDatabase();
     expect(postgres).toHaveBeenCalledWith(
@@ -52,20 +54,29 @@ describe('데이터베이스 연결 관리 (Database Connection)', () => {
       expect.objectContaining({
         max: 1,
         idle_timeout: 20,
+        connect_timeout: 30,
+        ssl: 'require',
+        prepare: false,
       })
     );
   });
 
-  it('운영(Production) 환경 설정을 올바르게 반영해야 한다', async () => {
-    process.env.NODE_ENV = 'production';
-    const postgres = (await import('postgres')).default;
+  it('개발 환경에서는 쿼리 로거를 활성화한다', async () => {
+    const { drizzle } = await import('drizzle-orm/postgres-js');
     getDatabase();
-    expect(postgres).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        max: 5,
-        idle_timeout: 60,
-      })
+    expect(drizzle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ logger: true })
+    );
+  });
+
+  it('운영(Production) 환경에서는 쿼리 로거를 비활성화한다', async () => {
+    process.env.NODE_ENV = 'production';
+    const { drizzle } = await import('drizzle-orm/postgres-js');
+    getDatabase();
+    expect(drizzle).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ logger: false })
     );
   });
 


### PR DESCRIPTION
## 개요

dev 전체 test 실행 시 실패하던 stale 테스트 2건을 정정합니다. 룰·구현이 바뀌었는데 테스트가 옛 기대를 유지하던 부채입니다.

## 변경 사항

- drizzle 클라이언트 테스트: 운영 환경 기대값이 옛 설계(커넥션 풀 max 5)에 맞춰져 실패하던 것을, 현재 구현인 서버리스 단일 커넥션 풀 설정(max·idle·ssl·prepare) 검증으로 정정. 환경 차이는 쿼리 로거 활성/비활성으로 명확히 검증.
- 백오피스 대시보드 추가 분석 테스트: 컴포넌트가 튜플에서 객체 props 로 바뀌고 스토리지 요약 prop 이 추가됐는데 테스트가 옛 구조를 써서 실패하던 것을, 현재 props 구조로 갱신.

## 검증

- 두 테스트 모두 통과
- 변경 파일 포맷 검사 통과

Closes #219
Closes #220