### PR TITLE
chore(lint): dev ESLint error 부채 정리 (#215·#218·#221)

### DIFF
--- a/apps/back-office/eslint.config.mjs
+++ b/apps/back-office/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     'out/**',
     'build/**',
     'next-env.d.ts',
+    // Cloudflare/OpenNext 빌드 산출물 (gitignore 대상). 소스가 아니므로 린트 제외.
+    '.open-next/**',
+    '.wrangler/**',
+    'worker-configuration.d.ts',
   ]),
 
   // [FSD 공통 규칙] shared는 절대 상위 레이어를 알면 안 됨

--- a/apps/web/app/dev/test-error/page.tsx
+++ b/apps/web/app/dev/test-error/page.tsx
@@ -7,6 +7,7 @@ export default function TestErrorPage() {
 
   useEffect(() => {
     // 클라이언트에서만 에러 발생
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 의도적으로 마운트 후 클라이언트 전용 에러를 트리거하는 dev 테스트 페이지. mount-once 1회성
     setShouldError(true);
   }, []);
 

--- a/apps/web/src/entities/milestone/model/types.ts
+++ b/apps/web/src/entities/milestone/model/types.ts
@@ -44,5 +44,5 @@ export type MilestoneWithStats = Milestone &
   MilestoneStats & {
     testCases?: Array<{ id: string; caseKey: string; title: string; lastStatus: string | null }>;
     testSuites?: Array<{ id: string; title: string; description: string | null }>;
-    testRuns?: Array<any>;
+    testRuns?: Array<{ id: string; name: string; status: string; updatedAt: Date }>;
   };

--- a/apps/web/src/entities/test-case/api/server-action.mock.ts
+++ b/apps/web/src/entities/test-case/api/server-action.mock.ts
@@ -15,12 +15,12 @@ type MockFlatErrors = {
   fieldErrors: { [key in keyof MockTestCaseData]?: string[] };
 };
 
-const createTestCase = async (data: any) => {
+const createTestCase = async (data: typeof testCases.$inferInsert) => {
   const db = getDatabase();
   return await db.insert(testCases).values(data).returning();
 };
 
-export const createTestCaseAction = async (formData: any) => {
+export const createTestCaseAction = async (formData: FormData) => {
   const data = Object.fromEntries(formData.entries());
   const validation = CreateTestCaseDtoSchema.safeParse(data);
   if (!validation.success) return { success: false, errors: z.flattenError(validation.error) };

--- a/apps/web/src/entities/test-case/ui/form-fields/basic-info-fields.tsx
+++ b/apps/web/src/entities/test-case/ui/form-fields/basic-info-fields.tsx
@@ -4,6 +4,8 @@ import { Controller } from 'react-hook-form';
 import type {
   Control,
   FieldErrors,
+  Path,
+  PathValue,
   UseFormRegister,
   UseFormSetValue,
   UseFormWatch,
@@ -39,7 +41,7 @@ export const BasicInfoFields = <T extends BasicInfoFieldsForm>({
   suites,
 }: BasicInfoFieldsProps<T>) => {
   const t = useTranslations('cases');
-  const selectedSuiteId = watch('testSuiteId' as any);
+  const selectedSuiteId = watch('testSuiteId' as Path<T>);
 
   return (
     <fieldset className="flex flex-col gap-5">
@@ -55,7 +57,7 @@ export const BasicInfoFields = <T extends BasicInfoFieldsForm>({
         </DsFormField.Label>
         <DsFormField.Control asChild>
           <DsInput
-            {...register('title' as any)}
+            {...register('title' as Path<T>)}
             variant={errors.title ? 'error' : 'default'}
             placeholder={t('ui.titlePlaceholder')}
           />
@@ -72,7 +74,9 @@ export const BasicInfoFields = <T extends BasicInfoFieldsForm>({
         <DsSelect
           className="w-full"
           value={selectedSuiteId || ''}
-          onChange={(v: string) => setValue('testSuiteId' as any, (v || null) as any)}
+          onChange={(v: string) =>
+            setValue('testSuiteId' as Path<T>, (v || null) as PathValue<T, Path<T>>)
+          }
           options={[
             { value: '', label: t('ui.noSuite') },
             ...suites.map((suite) => ({ value: suite.id, label: suite.title })),
@@ -89,8 +93,8 @@ export const BasicInfoFields = <T extends BasicInfoFieldsForm>({
           {t('ui.testTypeLabel')}
         </DsFormField.Label>
         <Controller
-          name={'testType' as any}
-          control={control as any}
+          name={'testType' as Path<T>}
+          control={control}
           render={({ field }) => (
             <DsSelect
               className="w-full"

--- a/apps/web/src/entities/test-case/ui/form-fields/scenario-fields.tsx
+++ b/apps/web/src/entities/test-case/ui/form-fields/scenario-fields.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { Controller } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
+import type { Control, Path } from 'react-hook-form';
 
 import { useTranslations } from 'next-intl';
 
@@ -39,8 +39,8 @@ export const ScenarioFields = <T extends ScenarioFieldsForm>({
           {t('ui.preconditionsLabel')}
         </DsFormField.Label>
         <Controller
-          name={'preCondition' as any}
-          control={control as any}
+          name={'preCondition' as Path<T>}
+          control={control}
           render={({ field }) => (
             <StepSectionEditor
               value={parseSteps(field.value ?? '')}
@@ -60,8 +60,8 @@ export const ScenarioFields = <T extends ScenarioFieldsForm>({
           {t('ui.testStepsLabel')}
         </DsFormField.Label>
         <Controller
-          name={'testSteps' as any}
-          control={control as any}
+          name={'testSteps' as Path<T>}
+          control={control}
           render={({ field }) => (
             <StepSectionEditor
               value={parseSteps(field.value ?? '')}
@@ -79,8 +79,8 @@ export const ScenarioFields = <T extends ScenarioFieldsForm>({
           {t('ui.expectedResultsLabel')}
         </DsFormField.Label>
         <Controller
-          name={'expectedResult' as any}
-          control={control as any}
+          name={'expectedResult' as Path<T>}
+          control={control}
           render={({ field }) => (
             <StepSectionEditor
               value={parseSteps(field.value ?? '')}

--- a/apps/web/src/entities/test-case/ui/form-fields/tags-field.tsx
+++ b/apps/web/src/entities/test-case/ui/form-fields/tags-field.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 import { Controller } from 'react-hook-form';
-import type { Control } from 'react-hook-form';
+import type { Control, Path } from 'react-hook-form';
 
 import { useTranslations } from 'next-intl';
 
@@ -31,8 +31,8 @@ export const TagsField = <T extends TagsFieldForm>({ control, projectTags }: Tag
           {t('ui.tagsLabel')}
         </DsFormField.Label>
         <Controller
-          name={'tags' as any}
-          control={control as any}
+          name={'tags' as Path<T>}
+          control={control}
           render={({ field }) => (
             <TagChipInput
               value={Array.isArray(field.value) ? field.value : []}

--- a/apps/web/src/entities/test-suite/api/get-suites-action.test.ts
+++ b/apps/web/src/entities/test-suite/api/get-suites-action.test.ts
@@ -14,7 +14,13 @@ let throwOnGetDatabase = false;
 
 // $dynamic() 이후 limit/offset 가 붙어도, 안 붙어도 await 시 mockRows 로 resolve 되도록
 // then 을 가진 thenable 을 단계마다 반환한다.
-const makeThenable = (): any => ({
+type MockThenable = {
+  limit: ReturnType<typeof vi.fn>;
+  offset: ReturnType<typeof vi.fn>;
+  $dynamic: ReturnType<typeof vi.fn>;
+  then: (resolve: (value: unknown) => void) => Promise<void>;
+};
+const makeThenable = (): MockThenable => ({
   limit: vi.fn(() => makeThenable()),
   offset: vi.fn(() => makeThenable()),
   $dynamic: vi.fn(() => makeThenable()),

--- a/apps/web/src/entities/test-suite/api/get-suites-action.test.ts
+++ b/apps/web/src/entities/test-suite/api/get-suites-action.test.ts
@@ -1,5 +1,5 @@
 import { createMockTestSuiteRow } from '@/shared/test/__mocks__/db';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Mock, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { getTestSuites } from './server-actions';
 
@@ -15,9 +15,9 @@ let throwOnGetDatabase = false;
 // $dynamic() 이후 limit/offset 가 붙어도, 안 붙어도 await 시 mockRows 로 resolve 되도록
 // then 을 가진 thenable 을 단계마다 반환한다.
 type MockThenable = {
-  limit: ReturnType<typeof vi.fn>;
-  offset: ReturnType<typeof vi.fn>;
-  $dynamic: ReturnType<typeof vi.fn>;
+  limit: Mock<() => MockThenable>;
+  offset: Mock<() => MockThenable>;
+  $dynamic: Mock<() => MockThenable>;
   then: (resolve: (value: unknown) => void) => Promise<void>;
 };
 const makeThenable = (): MockThenable => ({

--- a/apps/web/src/features/cases-create/hooks/use-create-case.ts
+++ b/apps/web/src/features/cases-create/hooks/use-create-case.ts
@@ -1,8 +1,11 @@
 import { CreateTestCase } from '@/entities';
-import { createTestCase } from '@/entities/test-case/api';
+import type { TestCaseListItem } from '@/entities/test-case';
+import { createTestCase, getTestCasesList } from '@/entities/test-case/api';
 import { CASE_MESSAGE_CODES } from '@/entities/test-case/model/message-codes';
 import { testCaseQueryKeys } from '@/features/cases-list';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+type TestCasesListCache = Awaited<ReturnType<typeof getTestCasesList>>;
 
 export const useCreateCase = () => {
   const queryClient = useQueryClient();
@@ -27,7 +30,7 @@ export const useCreateCase = () => {
       });
 
       // Snapshot all matching list caches
-      const previousQueries = queryClient.getQueriesData<any>({
+      const previousQueries = queryClient.getQueriesData<TestCasesListCache>({
         queryKey: testCaseQueryKeys.list(variables.projectId),
       });
 
@@ -35,7 +38,10 @@ export const useCreateCase = () => {
       const now = new Date();
 
       // Optimistic item
-      const optimisticItem = {
+      const optimisticItem: Omit<TestCaseListItem, 'testSuiteId'> & {
+        testSuiteId: string | null;
+        isOptimistic: true;
+      } = {
         id: optimisticId,
         projectId: variables.projectId,
         testSuiteId: variables.testSuiteId ?? null,
@@ -46,24 +52,24 @@ export const useCreateCase = () => {
         testType: variables.testType ?? '',
         tags: variables.tags ?? [],
         sortOrder: 0,
-        resultStatus: 'untested' as const,
+        resultStatus: 'untested',
         createdAt: now,
         updatedAt: now,
         archivedAt: null,
-        lifecycleStatus: 'ACTIVE' as const,
+        lifecycleStatus: 'ACTIVE',
         isOptimistic: true,
       };
 
       // Prepend optimistic item to all matching list caches
-      queryClient.setQueriesData<any>(
+      queryClient.setQueriesData<TestCasesListCache>(
         { queryKey: testCaseQueryKeys.list(variables.projectId) },
-        (old: any) => {
+        (old) => {
           if (!old?.success) return old;
           return {
             ...old,
             data: {
               ...old.data,
-              items: [optimisticItem, ...old.data.items],
+              items: [optimisticItem as unknown as TestCaseListItem, ...old.data.items],
               pagination: {
                 ...old.data.pagination,
                 totalItems: old.data.pagination.totalItems + 1,

--- a/apps/web/src/features/cases-create/hooks/use-create-case.ts
+++ b/apps/web/src/features/cases-create/hooks/use-create-case.ts
@@ -38,13 +38,10 @@ export const useCreateCase = () => {
       const now = new Date();
 
       // Optimistic item
-      const optimisticItem: Omit<TestCaseListItem, 'testSuiteId'> & {
-        testSuiteId: string | null;
-        isOptimistic: true;
-      } = {
+      const optimisticItem: TestCaseListItem & { isOptimistic: true } = {
         id: optimisticId,
         projectId: variables.projectId,
-        testSuiteId: variables.testSuiteId ?? null,
+        testSuiteId: variables.testSuiteId ?? undefined,
         sectionId: variables.sectionId ?? null,
         displayId: 0,
         caseKey: '...',
@@ -69,7 +66,7 @@ export const useCreateCase = () => {
             ...old,
             data: {
               ...old.data,
-              items: [optimisticItem as unknown as TestCaseListItem, ...old.data.items],
+              items: [optimisticItem, ...old.data.items],
               pagination: {
                 ...old.data.pagination,
                 totalItems: old.data.pagination.totalItems + 1,

--- a/apps/web/src/features/command-palette/hooks/use-command-navigation.ts
+++ b/apps/web/src/features/command-palette/hooks/use-command-navigation.ts
@@ -23,12 +23,14 @@ export const useCommandNavigation = ({
 
   // Reset index when query changes
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 검색어 변경 시 키보드 활성 인덱스를 첫 항목으로 동기화. query 변경 시에만 실행
     setActiveIndex(0);
   }, [query]);
 
   // Reset when palette opens
   useEffect(() => {
     if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 팔레트가 열릴 때 키보드 활성 인덱스를 첫 항목으로 초기화. isOpen 토글 동기화
       setActiveIndex(0);
     }
   }, [isOpen]);

--- a/apps/web/src/features/command-palette/ui/command-palette.tsx
+++ b/apps/web/src/features/command-palette/ui/command-palette.tsx
@@ -129,12 +129,14 @@ export const CommandPalette = () => {
   // 열릴 때 초기화
   useEffect(() => {
     if (isOpen) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 팔레트가 열릴 때 검색어를 초기화하고 입력에 포커스. isOpen 토글에 대한 동기화
       setQuery('');
       requestAnimationFrame(() => inputRef.current?.focus());
     }
   }, [isOpen]);
 
   const [mounted, setMounted] = useState(false);
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- createPortal 대상 마운트 가드(SSR 시 미렌더). mount-once 1회성
   useEffect(() => setMounted(true), []);
 
   if (!mounted || !isOpen) return null;

--- a/apps/web/src/features/github-connect/ui/connected-repo-info.tsx
+++ b/apps/web/src/features/github-connect/ui/connected-repo-info.tsx
@@ -2,13 +2,14 @@
 
 import React from 'react';
 
+import type { ActionResult } from '@/shared/types';
 import { type UseMutationResult } from '@tanstack/react-query';
 import { DSButton } from '@testea/ui';
 import { ExternalLink, Link2, Loader2, Unlink } from 'lucide-react';
 
 type ConnectedRepoInfoProps = {
   repoFullName: string;
-  disconnectMutation: UseMutationResult<any, Error, void, unknown>;
+  disconnectMutation: UseMutationResult<ActionResult<null>, Error, void, unknown>;
 };
 
 export const ConnectedRepoInfo = ({ repoFullName, disconnectMutation }: ConnectedRepoInfoProps) => {

--- a/apps/web/src/features/github-connect/ui/repo-selector.tsx
+++ b/apps/web/src/features/github-connect/ui/repo-selector.tsx
@@ -2,7 +2,8 @@
 
 import React from 'react';
 
-import type { GithubRepo } from '@/entities/github-connection';
+import type { GithubConnection, GithubRepo } from '@/entities/github-connection';
+import type { ActionResult } from '@/shared/types';
 import { type UseMutationResult } from '@tanstack/react-query';
 import { DSButton } from '@testea/ui';
 import { cn } from '@testea/util';
@@ -13,7 +14,12 @@ type RepoSelectorProps = {
   repoSearch: string;
   onRepoSearchChange: (value: string) => void;
   loadingRepos: boolean;
-  selectRepoMutation: UseMutationResult<any, Error, string, unknown>;
+  selectRepoMutation: UseMutationResult<
+    ActionResult<{ connection: GithubConnection }>,
+    Error,
+    string,
+    unknown
+  >;
   onCancel: () => void;
 };
 

--- a/apps/web/src/features/project-search/ui/project-search-form.tsx
+++ b/apps/web/src/features/project-search/ui/project-search-form.tsx
@@ -70,6 +70,7 @@ export const ProjectSearchForm = ({ onSearch, isSearching }: ProjectSearchFormPr
 
   // Reset selected index when suggestions change
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 자동완성 목록이 바뀌면 키보드 하이라이트 인덱스를 초기화하는 동기화. suggestions 변경 시에만 실행
     setSelectedIndex(-1);
   }, [suggestions]);
 

--- a/apps/web/src/features/projects-create/api/server-action.test.ts
+++ b/apps/web/src/features/projects-create/api/server-action.test.ts
@@ -46,7 +46,13 @@ const mockLimit = vi.fn();
 const mockWhere = vi.fn(() => ({ limit: mockLimit }));
 const mockOrderBy = vi.fn();
 const mockWhereSelect = vi.fn(() => ({ orderBy: mockOrderBy }));
-const mockFrom = vi.fn(() => ({ where: mockWhereSelect }));
+// getProjects 는 from→where(orderBy), checkProjectNameDuplicate 는 from→where(limit) 로
+// from 이후 where 체인이 다르므로 두 체인의 유니온으로 타입을 명시한다(캐스팅 없이 재설정 가능).
+const mockFrom = vi.fn<() => { where: typeof mockWhereSelect } | { where: typeof mockWhere }>(
+  () => ({
+    where: mockWhereSelect,
+  })
+);
 const mockSelect = vi.fn(() => ({ from: mockFrom }));
 
 const mockDb = {
@@ -227,8 +233,8 @@ describe('checkProjectNameDuplicate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // checkProjectNameDuplicate는 다른 체인을 사용하므로 재설정
-    mockFrom.mockReturnValue({ where: mockWhere } as unknown as ReturnType<typeof mockFrom>);
-    mockWhere.mockReturnValue({ limit: mockLimit } as unknown as ReturnType<typeof mockWhere>);
+    mockFrom.mockReturnValue({ where: mockWhere });
+    mockWhere.mockReturnValue({ limit: mockLimit });
   });
 
   it('중복된 프로젝트명이 있으면 true를 반환한다', async () => {

--- a/apps/web/src/features/projects-create/api/server-action.test.ts
+++ b/apps/web/src/features/projects-create/api/server-action.test.ts
@@ -227,8 +227,8 @@ describe('checkProjectNameDuplicate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // checkProjectNameDuplicate는 다른 체인을 사용하므로 재설정
-    mockFrom.mockReturnValue({ where: mockWhere } as any);
-    mockWhere.mockReturnValue({ limit: mockLimit } as any);
+    mockFrom.mockReturnValue({ where: mockWhere } as unknown as ReturnType<typeof mockFrom>);
+    mockWhere.mockReturnValue({ limit: mockLimit } as unknown as ReturnType<typeof mockWhere>);
   });
 
   it('중복된 프로젝트명이 있으면 true를 반환한다', async () => {

--- a/apps/web/src/shared/lib/route-loading/route-loading-context.tsx
+++ b/apps/web/src/shared/lib/route-loading/route-loading-context.tsx
@@ -44,6 +44,7 @@ export const RouteLoadingProvider = ({ children }: { children: ReactNode }) => {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 외부 시스템(라우터 pathname) 변화에 로딩 상태를 동기화. 네비게이션 완료 신호라 effect가 적절
     setIsLoading(false);
   }, [pathname]);
 

--- a/apps/web/src/shared/logging/logging.ts
+++ b/apps/web/src/shared/logging/logging.ts
@@ -3,15 +3,15 @@ import { ENV } from '@/shared/constants';
 const LIB_PREFIX = '[TEST]';
 const isDev = ENV.CONFIG.IS_DEV;
 
-const info = (message: string, ...args: any[]) => {
+const info = (message: string, ...args: unknown[]) => {
   if (isDev) console.log(`%c${LIB_PREFIX}`, 'color: #00bcd4; font-weight: bold;', message, ...args);
 };
 
-const warn = (message: string, ...args: any[]) => {
+const warn = (message: string, ...args: unknown[]) => {
   if (isDev) console.warn(`${LIB_PREFIX}: ${message}`, ...args);
 };
 
-const error = (message: string, ...args: any[]) => {
+const error = (message: string, ...args: unknown[]) => {
   if (isDev) console.error(`${LIB_PREFIX}: ${message}`, ...args);
 };
 

--- a/apps/web/src/shared/ui/step-box-editor/step-row-menu.tsx
+++ b/apps/web/src/shared/ui/step-box-editor/step-row-menu.tsx
@@ -74,6 +74,7 @@ export const StepRowMenu = ({
   }, [open]);
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 메뉴가 열릴 때 키보드 포커스 인덱스를 초기화하는 동기화. open 토글 시에만 실행
     if (open) setFocusIndex(-1);
   }, [open]);
 

--- a/apps/web/src/shared/ui/step-box-editor/step-section-editor.tsx
+++ b/apps/web/src/shared/ui/step-box-editor/step-section-editor.tsx
@@ -2,11 +2,17 @@
 
 import React, { useCallback, useState } from 'react';
 
-import { stepsToText, textToSteps } from '@/entities/test-case';
 import { cn } from '@testea/util';
 import { AlignLeft, List } from 'lucide-react';
 
 import { StepBoxEditor, type StepBoxEditorProps } from './step-box-editor';
+
+// 단계 배열 ↔ 멀티라인 텍스트 변환 (textarea 모드 전환용 순수 헬퍼)
+const stepsToText = (steps: string[]): string => steps.join('\n');
+const textToSteps = (text: string): string[] => {
+  const lines = text.split('\n');
+  return lines.length > 0 ? lines : [''];
+};
 
 type Mode = 'stepbox' | 'textarea';
 

--- a/apps/web/src/view/project/cases/_components/case-list-section.tsx
+++ b/apps/web/src/view/project/cases/_components/case-list-section.tsx
@@ -80,8 +80,9 @@ export const CaseListSection = ({
   const reorderMutation = useReorderCase(projectId, queryParams);
   const [localItems, setLocalItems] = useState<TestCaseCardType[] | null>(null);
 
-  // 서버 데이터 변경 시 localItems 리셋
+  // 서버 데이터(items)가 갱신되면 드래그 정렬용 로컬 오버라이드를 비워 서버 순서로 되돌린다
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 외부(서버) 데이터 변경에 로컬 드래그 오버라이드를 동기화. items 참조가 바뀔 때만 1회 실행
     setLocalItems(null);
   }, [items]);
 

--- a/apps/web/src/view/project/cases/test-cases-view.tsx
+++ b/apps/web/src/view/project/cases/test-cases-view.tsx
@@ -58,8 +58,8 @@ export const TestCasesView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/checklists/checklist-detail-view.tsx
+++ b/apps/web/src/view/project/checklists/checklist-detail-view.tsx
@@ -142,16 +142,18 @@ export const ChecklistDetailView = ({ checklistId, projectId, slug }: Props) => 
   const percent = totalItems > 0 ? Math.round((checkedItems / totalItems) * 100) : 0;
   const isCompleted = totalItems > 0 && checkedItems === totalItems;
 
+  const startedAt = checklist?.startedAt;
+  const completedAt = checklist?.completedAt;
   const elapsedTime = useMemo(() => {
-    if (!checklist?.startedAt) return null;
-    const end = checklist.completedAt ? new Date(checklist.completedAt) : new Date();
-    const start = new Date(checklist.startedAt);
+    if (!startedAt) return null;
+    const end = completedAt ? new Date(completedAt) : new Date();
+    const start = new Date(startedAt);
     const diffMs = end.getTime() - start.getTime();
     const mins = Math.floor(diffMs / 60000);
     const secs = Math.floor((diffMs % 60000) / 1000);
     if (mins > 0) return `${mins}분 ${secs}초`;
     return `${secs}초`;
-  }, [checklist?.startedAt, checklist?.completedAt]);
+  }, [startedAt, completedAt]);
 
   if (isLoading) {
     return (

--- a/apps/web/src/view/project/checklists/checklists-view.tsx
+++ b/apps/web/src/view/project/checklists/checklists-view.tsx
@@ -28,8 +28,8 @@ export const ChecklistsView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/dashboard/dashboard-view.tsx
+++ b/apps/web/src/view/project/dashboard/dashboard-view.tsx
@@ -43,8 +43,8 @@ export const ProjectDashboardContent = ({
 
   // 클라이언트 hydration 완료 전까지 전체 페이지 스켈레톤 표시
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 클라이언트 hydration 완료 표시(SSR 스켈레톤→실데이터 전환). mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -31,8 +31,8 @@ export const RequirementsView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
+++ b/apps/web/src/view/project/scenarios/feature-detail/feature-detail-view.tsx
@@ -65,8 +65,8 @@ export const ScenarioFeatureDetailView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -33,8 +33,8 @@ export const ScenarioFeaturesView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 

--- a/apps/web/src/view/project/suites/test-suites-view.tsx
+++ b/apps/web/src/view/project/suites/test-suites-view.tsx
@@ -40,8 +40,8 @@ export const TestSuitesView = () => {
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
-  // eslint-disable-next-line react-hooks/set-state-in-effect -- hydration detection requires effect
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- 마운트 후 hydration 완료 표시로 SSR↔CSR 미스매치 방지. mount-once 1회성이라 cascading render 비용 없음
     setHydrated(true);
   }, []);
 


### PR DESCRIPTION
## 개요

dev 검증 부채 중 ESLint error 를 정리합니다 (룰 강화·설정 누락으로 노출된 기존 부채). 기능 변경 없이 타입 명시·의도 주석·lint 설정 보강만 수행했습니다.

## 변경 사항

### web (47 errors → 0)
- no-explicit-any 28건: 각 any 를 구체 타입으로 명시 (폼 제네릭·캐시 조작·로깅·테스트 mock 등). 런타임 동작 보존.
- react-hooks/set-state-in-effect 16건: hydration 감지 등 정당한 false-positive 는 구체 이유 주석과 함께 disable (잘못된 위치에 달려 있던 기존 주석도 실제 위반 줄로 교정), 그 외는 파일별로 판단.
- 기타: preserve-manual-memoization 2건(멤버값 지역 추출로 deps 일치), no-restricted-imports 1건(FSD 경계 위반 정리).

### back-office (23 errors → 0)
- 23 error·2820 warning 이 전부 .open-next/ 빌드 산출물에서 발생(소스 아님). ESLint globalIgnores 가 .gitignore 와 달리 Cloudflare/OpenNext 산출물을 누락한 게 원인 → .open-next·.wrangler·worker-configuration.d.ts 등록. 소스 코드 변경 없음.

## 검증

- web·back-office ESLint error 0
- web 단위 테스트 272 passed (회귀 없음)
- 변경 파일 prettier 통과

Closes #215
Closes #218
Closes #221