### PR TITLE
feat(#234): qaground 모노레포 신규 앱 스캐폴딩

### DIFF
--- a/apps/qaground/.gitignore
+++ b/apps/qaground/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts

--- a/apps/qaground/AGENTS.md
+++ b/apps/qaground/AGENTS.md
@@ -1,0 +1,8 @@
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
+
+# qaground
+
+QA 자동화 연습 플레이그라운드 + 과제전형(채용 평가) 서브 제품. `qaground.gettestea.com` 별도 배포 예정.
+구상·기능 정리는 `docs/issues/qaground/qaground-기능정리.md` 참조. 실행 인프라는 `apps/runner`(격리 Playwright 러너) 재사용.

--- a/apps/qaground/CLAUDE.md
+++ b/apps/qaground/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/qaground/README.md
+++ b/apps/qaground/README.md
@@ -1,0 +1,54 @@
+# qaground
+
+QA 엔지니어를 위한 **자동화 테스트 연습 플레이그라운드**이자, 기업이 **QA 채용 과제전형(평가)**을 돌리는 서브 제품. 배포 대상은 `qaground.gettestea.com` (web·back-office와 분리 배포).
+
+## 왜 만드나
+
+기존 QA 연습 사이트(qalearningweb.com, demoqa, the-internet 등)는 연습용 페이지만 제공한다. 작성한 테스트를 실행해 주지도, 채점하지도, 피드백을 주지도 않는다. qaground는 Testea가 이미 가진 격리 실행 러너(`apps/runner`)와 LLM 코드 생성 자산을 재사용해 **"제출 → 실행 → 자동 채점 → 피드백"** 폐루프를 제공한다. 무료 연습으로 유입을 만들고, 본 제품(Testea 테스트 관리)과 기업 과제전형으로 전환·수익화한다.
+
+## 기능 4기둥
+
+1. **플레이그라운드**: 로그인, 폼 검증, 동적 테이블, 드래그앤드롭, 파일 업로드, 가짜 REST API 등 자동화 연습 대상 페이지. 공개(인증 없음) = SEO 입구.
+2. **자동 실행·채점**: 제출한 Playwright/Cypress 스펙을 격리 러너에서 실행하고 숨김 검증 스펙으로 통과/실패 채점.
+3. **학습 경로·인증**: 난도별 과제 카탈로그, 진행률 추적, 수료 배지.
+4. **과제전형(B2B)**: 기업이 과제를 출제하고 후보 제출을 자동 채점한 리포트를 받는 채용 평가.
+
+전체 구상과 단계 로드맵, 열린 결정사항은 `docs/issues/qaground/qaground-기능정리.md` 참조.
+
+## 상태
+
+스캐폴딩 단계. 현재는 디자인 시스템이 연결된 플레이스홀더 랜딩만 있다. 다음 마일스톤은 MVP 1개 시나리오(스펙 제출 → 러너 실행 → 결과 표시) end-to-end.
+
+## 구조
+
+FSD(Feature-Sliced Design). 다른 앱(`apps/web`, `apps/back-office`)과 동일한 컨벤션을 따른다.
+
+```
+apps/qaground
+├── app/                 # Next.js App Router 진입점 (layout, page)
+├── src/
+│   ├── app-shell/       # globals.css 등 앱 셸
+│   └── shared/          # 공용 유틸·테스트 셋업 (상위 레이어 참조 금지)
+├── next.config.ts       # 모노레포 루트 고정 + @testea/* transpile
+└── vitest.config.ts
+```
+
+- 디자인 시스템은 `@testea/ui`를 쓴다. Tailwind v4 content scan에서 누락되지 않도록 `src/app-shell/globals.css`에 `@source`로 `packages/ui/src`를 등록해 둔다(신규 클래스 미적용 함정 방지).
+- 클라이언트 훅(`useState`·`useEffect` 등) 사용 파일은 최상단 `'use client'` 선언 필수.
+
+## 개발
+
+```bash
+pnpm --filter qaground dev     # http://localhost:3200
+pnpm --filter qaground build
+pnpm --filter qaground lint
+pnpm --filter qaground test
+```
+
+포트는 web(3000), back-office(3100)와 겹치지 않게 **3200**을 쓴다.
+
+## 관련
+
+- 실행 인프라: `apps/runner` (Fly.io 격리 Playwright 러너) 재사용
+- 결과 적재·인증 패턴: FDD-TR09 auto-results API, `project_automation_tokens`
+- 본 제품: Testea (테스트 관리, `apps/web`)

--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+
+import '@/app-shell/globals.css';
+
+export const metadata: Metadata = {
+  title: 'qaground — QA 자동화 연습 플레이그라운드',
+  description:
+    'QA 엔지니어를 위한 자동화 테스트 연습 그라운드. 직접 작성한 테스트를 실행하고 채점받으세요.',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="ko" className="h-full antialiased">
+      <body className="bg-bg-1 text-text-1 flex min-h-full flex-col">{children}</body>
+    </html>
+  );
+}

--- a/apps/qaground/app/page.tsx
+++ b/apps/qaground/app/page.tsx
@@ -1,0 +1,53 @@
+const PILLARS = [
+  {
+    label: '플레이그라운드',
+    desc: '로그인, 폼, 테이블, 드래그앤드롭, 가짜 API 등 자동화 연습용 페이지',
+  },
+  {
+    label: '자동 실행·채점',
+    desc: '제출한 Playwright/Cypress 스펙을 격리 러너에서 실행하고 통과/실패 채점',
+  },
+  {
+    label: '학습 경로·인증',
+    desc: '난도별 과제, 진행률 추적, 수료 배지',
+  },
+  {
+    label: '과제전형',
+    desc: '기업이 QA 채용 과제를 출제하고 자동 채점 리포트를 받는 B2B 평가',
+  },
+];
+
+export default function Home() {
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-center gap-12 px-6 py-20">
+      <header className="flex flex-col gap-4">
+        <span className="text-primary text-sm font-semibold tracking-tight">
+          qaground.gettestea.com
+        </span>
+        <h1 className="text-3xl font-bold">
+          QA 자동화를 <span className="text-primary">직접 돌려보며</span> 연습하는 곳
+        </h1>
+        <p className="text-text-2 text-base">
+          연습 페이지만 주는 곳이 아닙니다. 작성한 테스트를 실행하고, 채점하고, 어디서 틀렸는지
+          알려줍니다. 기업은 같은 엔진으로 채용 과제전형을 돌립니다.
+        </p>
+      </header>
+
+      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {PILLARS.map((p) => (
+          <li
+            key={p.label}
+            className="border-line-2 bg-bg-2 flex flex-col gap-2 rounded-xl border border-solid p-5"
+          >
+            <span className="font-semibold">{p.label}</span>
+            <span className="text-text-2 text-sm">{p.desc}</span>
+          </li>
+        ))}
+      </ul>
+
+      <footer className="text-text-3 text-xs">
+        스캐폴딩 단계. 기능 정리: docs/issues/qaground
+      </footer>
+    </main>
+  );
+}

--- a/apps/qaground/eslint.config.mjs
+++ b/apps/qaground/eslint.config.mjs
@@ -1,0 +1,43 @@
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+import prettier from 'eslint-config-prettier';
+import { defineConfig, globalIgnores } from 'eslint/config';
+
+const eslintConfig = defineConfig([
+  ...nextVitals,
+  ...nextTs,
+
+  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+
+  // [FSD 공통 규칙] shared는 절대 상위 레이어를 알면 안 됨
+  {
+    files: ['src/shared/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: [
+                '@/app/**/*',
+                '@/widgets/**/*',
+                '@/features/**/*',
+                '@/entities/**/*',
+                '../app/**/*',
+                '../widgets/**/*',
+                '../features/**/*',
+                '../entities/**/*',
+              ],
+              message:
+                'FSD 위반: shared 레이어는 상위 레이어(app, widgets, features, entities)를 참조할 수 없습니다.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  prettier,
+]);
+
+export default eslintConfig;

--- a/apps/qaground/next.config.ts
+++ b/apps/qaground/next.config.ts
@@ -1,0 +1,19 @@
+import type { NextConfig } from 'next';
+
+import path from 'node:path';
+
+// pnpm 모노레포 루트 고정.
+// - Turbopack 이 워크스페이스 루트를 잘못 추론해 next 패키지·@testea/* 워크스페이스
+//   패키지를 못 잡는 빌드 에러(inferred workspace root)를 막는다.
+// apps/qaground 기준 두 단계 위가 저장소 최상위.
+const repoRoot = path.join(__dirname, '..', '..');
+
+const nextConfig: NextConfig = {
+  turbopack: {
+    root: repoRoot,
+  },
+  outputFileTracingRoot: repoRoot,
+  transpilePackages: ['@testea/lib', '@testea/ui', '@testea/util'],
+};
+
+export default nextConfig;

--- a/apps/qaground/package.json
+++ b/apps/qaground/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "qaground",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --port 3200",
+    "build": "next build",
+    "start": "next start --port 3200",
+    "lint": "eslint",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "@testea/lib": "workspace:*",
+    "@testea/ui": "workspace:*",
+    "@testea/util": "workspace:*",
+    "lucide-react": "^0.561.0",
+    "next": "16.2.9",
+    "react": "19.2.3",
+    "react-dom": "19.2.3"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^25.0.2",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19",
+    "eslint": "^9.39.2",
+    "eslint-config-next": "16.0.10",
+    "eslint-config-prettier": "^10.1.8",
+    "jsdom": "^27.4.0",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5",
+    "vitest": "^4.1.5"
+  }
+}

--- a/apps/qaground/postcss.config.mjs
+++ b/apps/qaground/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+
+export default config;

--- a/apps/qaground/src/app-shell/globals.css
+++ b/apps/qaground/src/app-shell/globals.css
@@ -1,0 +1,169 @@
+/* Tailwind CSS */
+/* https://tailwindcss.com/ */
+@import 'tailwindcss';
+
+/* Tailwind v4 content scan: 워크스페이스 디자인 시스템(@testea/ui) 소스를 스캔 대상에
+   포함해야 해당 패키지에서 쓰는 클래스가 빌드에 누락되지 않는다. (node_modules 는 기본 제외) */
+@source '../../../../packages/ui/src/**/*.{ts,tsx}';
+
+/* DesignSystem theme tokens (Testea 공통) */
+@theme {
+  /* Font Family */
+  --font-sans:
+    'Pretendard Variable', 'Pretendard', -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic',
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', sans-serif;
+
+  /* Colors — Gray */
+  --color-gray-50: #f9fafb;
+  --color-gray-100: #f3f4f6;
+  --color-gray-200: #e5e7eb;
+  --color-gray-300: #d1d5db;
+  --color-gray-400: #9ca3af;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-900: #111827;
+
+  /* Colors — Blue */
+  --color-blue-50: #eff6ff;
+  --color-blue-100: #dbeafe;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+
+  /* Colors — Green */
+  --color-green-50: #f0fdf4;
+  --color-green-100: #dcfce7;
+  --color-green-600: #16a34a;
+  --color-green-700: #15803d;
+
+  /* Colors — Amber */
+  --color-amber-50: #fffbeb;
+  --color-amber-500: #f59e0b;
+  --color-amber-600: #d97706;
+
+  /* Colors — Red */
+  --color-red-50: #fef2f2;
+  --color-red-600: #dc2626;
+  --color-red-700: #b91c1c;
+
+  /* Shared UI package tokens (@testea/ui 가 의존) */
+  --color-text-1: #ffffff;
+  --color-text-2: rgb(255 255 255 / 0.7);
+  --color-text-3: rgb(255 255 255 / 0.4);
+  --color-text-4: rgb(255 255 255 / 0.2);
+  --color-primary: #0bb57f;
+  --color-secondary: #007351;
+  --color-inactive: rgb(255 255 255 / 0.4);
+  --color-line-1: #8f96a3;
+  --color-line-2: #2b2d31;
+  --color-line-3: #5c6370;
+  --color-icon-1: #4e4e4e;
+  --color-system-red: #fc4141;
+  --color-system-blue: #eaf9ff;
+  --color-system-green: #ecfbf6;
+  --color-bg-1: #0c0d0e;
+  --color-bg-2: #18191b;
+  --color-bg-3: #1e2024;
+  --color-bg-4: #2b2d31;
+  --color-bg-inactive: #1e2024;
+
+  /* Typography — Font Size */
+  --text-xs: 12px;
+  --text-sm: 14px;
+  --text-base: 16px;
+  --text-lg: 18px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 30px;
+
+  /* Typography — Font Weight */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Spacing */
+  --spacing: 4px;
+
+  /* Border Radius */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-2xl: 16px;
+  --radius-full: 9999px;
+  --radius-button: 6px;
+
+  /* Component Size */
+  --spacing-button-sm: 32px;
+  --spacing-button-md: 40px;
+  --spacing-button-lg: 48px;
+}
+
+/* HTML Elements */
+@layer base {
+  html,
+  body {
+    width: 100%;
+  }
+
+  html {
+    scroll-behavior: smooth;
+    min-height: 100vh;
+  }
+
+  body {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    min-height: 100vh;
+    @apply bg-bg-1 text-text-1 antialiased;
+  }
+
+  button,
+  [role='button'],
+  a,
+  summary,
+  select,
+  [type='checkbox'],
+  [type='radio'] {
+    cursor: pointer;
+  }
+
+  * {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    text-wrap: balance;
+  }
+
+  p {
+    text-wrap: pretty;
+  }
+
+  /* 폼 요소 입력 시 줌인 방지 (아이폰 대응) */
+  input,
+  textarea,
+  select {
+    font-size: 16px;
+  }
+}
+
+/* Simple utilities */
+@utility sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/apps/qaground/src/shared/test/setup-tests.ts
+++ b/apps/qaground/src/shared/test/setup-tests.ts
@@ -1,0 +1,31 @@
+import '@testing-library/jest-dom/vitest';
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  configurable: true,
+  value: ResizeObserverMock,
+});
+
+Object.defineProperty(window, 'PointerEvent', {
+  writable: true,
+  configurable: true,
+  value: MouseEvent,
+});
+
+Element.prototype.scrollIntoView = function scrollIntoView() {};
+
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = function hasPointerCapture() {
+    return false;
+  };
+}
+
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = function releasePointerCapture() {};
+}

--- a/apps/qaground/tsconfig.json
+++ b/apps/qaground/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "src/**/*",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/apps/qaground/vitest.config.ts
+++ b/apps/qaground/vitest.config.ts
@@ -1,0 +1,19 @@
+import * as path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/shared/test/setup-tests.ts'],
+    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    // jsdom 환경 콜드 스타트(첫 파일 import/transform)가 기본 5초를 넘겨 첫 테스트가
+    // 간헐 타임아웃되는 것을 방지한다.
+    testTimeout: 15000,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,73 @@ importers:
         specifier: ^4.100.0
         version: 4.100.0
 
+  apps/qaground:
+    dependencies:
+      '@testea/lib':
+        specifier: workspace:*
+        version: link:../../packages/lib
+      '@testea/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      '@testea/util':
+        specifier: workspace:*
+        version: link:../../packages/util
+      lucide-react:
+        specifier: ^0.561.0
+        version: 0.561.0(react@19.2.3)
+      next:
+        specifier: 16.2.9
+        version: 16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+    devDependencies:
+      '@tailwindcss/postcss':
+        specifier: ^4.1.18
+        version: 4.2.4
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^25.0.2
+        version: 25.6.0
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19
+        version: 19.2.3(@types/react@19.2.14)
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.4(jiti@2.6.1)
+      eslint-config-next:
+        specifier: 16.0.10
+        version: 16.0.10(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0(@noble/hashes@1.8.0)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.2.4
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.7)(jsdom@27.4.0(@noble/hashes@1.8.0))(msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+
   apps/runner:
     dependencies:
       '@hono/node-server':


### PR DESCRIPTION
## 개요

QA 자동화 연습 플레이그라운드와 과제전형(채용 평가)을 제공할 새 서브 제품 qaground를 모노레포 신규 앱으로 추가한다. 별도 서브도메인 배포를 전제로 한다. 이번 PR은 앱 골격(스캐폴딩)까지이며, 화면은 디자인 시스템이 연결된 플레이스홀더 랜딩만 포함한다.

기존 QA 연습 사이트들이 연습 페이지만 제공하는 것과 달리, qaground는 이미 갖춰진 격리 실행 러너와 코드 생성 자산을 재사용해 제출한 테스트를 실행하고 채점·피드백까지 잇는 것을 목표로 한다. 자세한 기능 구상과 단계 로드맵은 이슈 #234에 정리해 두었다.

## 변경 사항

- 사용자 웹앱, 백오피스와 분리된 새 앱을 추가하고 개발 포트를 별도로 분리했다.
- 다른 앱과 동일한 폴더 구조와 린트 규칙을 따르도록 구성했다.
- 공용 디자인 시스템을 끌어다 쓰도록 연결하고, 스타일 스캔에서 디자인 시스템 소스가 누락되지 않게 등록했다.
- 제품 소개 네 기둥(연습 플레이그라운드, 자동 실행·채점, 학습 경로·인증, 과제전형)을 보여주는 랜딩과 앱 안내 문서를 추가했다.

## 검증

- 프로덕션 빌드 통과, 타입체크 통과, 린트 무경고, 포매팅 검사 통과를 로컬에서 확인했다.
- 기존 앱과 패키지는 건드리지 않는 순수 추가이며, 잠금 파일에는 신규 앱 항목만 더해졌다.

## 후속

- 다음 마일스톤은 한 개 시나리오를 끝에서 끝까지 연결하는 것이다. 연습 페이지에서 작성한 테스트를 제출하면 러너가 실행해 결과를 돌려주는 흐름이다.
