### PR TITLE
feat(#234): qaground 랜딩페이지 구성

### DIFF
--- a/apps/qaground/app/page.tsx
+++ b/apps/qaground/app/page.tsx
@@ -1,53 +1,5 @@
-const PILLARS = [
-  {
-    label: '플레이그라운드',
-    desc: '로그인, 폼, 테이블, 드래그앤드롭, 가짜 API 등 자동화 연습용 페이지',
-  },
-  {
-    label: '자동 실행·채점',
-    desc: '제출한 Playwright/Cypress 스펙을 격리 러너에서 실행하고 통과/실패 채점',
-  },
-  {
-    label: '학습 경로·인증',
-    desc: '난도별 과제, 진행률 추적, 수료 배지',
-  },
-  {
-    label: '과제전형',
-    desc: '기업이 QA 채용 과제를 출제하고 자동 채점 리포트를 받는 B2B 평가',
-  },
-];
+import { LandingView } from '@/view/landing';
 
 export default function Home() {
-  return (
-    <main className="mx-auto flex w-full max-w-3xl flex-1 flex-col justify-center gap-12 px-6 py-20">
-      <header className="flex flex-col gap-4">
-        <span className="text-primary text-sm font-semibold tracking-tight">
-          qaground.gettestea.com
-        </span>
-        <h1 className="text-3xl font-bold">
-          QA 자동화를 <span className="text-primary">직접 돌려보며</span> 연습하는 곳
-        </h1>
-        <p className="text-text-2 text-base">
-          연습 페이지만 주는 곳이 아닙니다. 작성한 테스트를 실행하고, 채점하고, 어디서 틀렸는지
-          알려줍니다. 기업은 같은 엔진으로 채용 과제전형을 돌립니다.
-        </p>
-      </header>
-
-      <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {PILLARS.map((p) => (
-          <li
-            key={p.label}
-            className="border-line-2 bg-bg-2 flex flex-col gap-2 rounded-xl border border-solid p-5"
-          >
-            <span className="font-semibold">{p.label}</span>
-            <span className="text-text-2 text-sm">{p.desc}</span>
-          </li>
-        ))}
-      </ul>
-
-      <footer className="text-text-3 text-xs">
-        스캐폴딩 단계. 기능 정리: docs/issues/qaground
-      </footer>
-    </main>
-  );
+  return <LandingView />;
 }

--- a/apps/qaground/src/app-shell/globals.css
+++ b/apps/qaground/src/app-shell/globals.css
@@ -167,3 +167,27 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* Fade-in 애니메이션 (CSS-only, JS 의존 없음) */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@utility animate-fade-in-up {
+  animation: fade-in-up 0.6s ease-out both;
+}
+
+@utility animate-fade-in-up-delay {
+  animation: fade-in-up 0.6s ease-out 0.15s both;
+}
+
+@utility animate-fade-in-up-delay-2 {
+  animation: fade-in-up 0.6s ease-out 0.3s both;
+}

--- a/apps/qaground/src/view/landing/index.ts
+++ b/apps/qaground/src/view/landing/index.ts
@@ -1,0 +1,1 @@
+export { LandingView } from './landing-view';

--- a/apps/qaground/src/view/landing/landing-assessment.tsx
+++ b/apps/qaground/src/view/landing/landing-assessment.tsx
@@ -1,0 +1,42 @@
+const POINTS = [
+  '실제 시나리오 기반 과제 출제',
+  '제출 코드 자동 실행·채점',
+  '응시자 객관 비교 리포트',
+];
+
+export const LandingAssessment = () => {
+  return (
+    <section id="assessment" className="w-full py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <div className="border-primary/30 from-primary/10 relative overflow-hidden rounded-3xl border bg-gradient-to-br to-transparent p-8 sm:p-12">
+          <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex max-w-xl flex-col gap-4">
+              <span className="text-primary text-sm font-semibold">기업용 · 과제전형</span>
+              <h2 className="text-2xl font-bold sm:text-3xl">
+                QA 채용, 말 대신 <span className="text-primary">실행 결과</span>로 검증하세요
+              </h2>
+              <p className="text-text-2 text-sm leading-relaxed sm:text-base">
+                후보에게 실제 시나리오를 주고, 제출한 자동화 코드를 자동으로 실행·채점합니다. 면접
+                감에 의존하지 않고 같은 기준으로 비교한 리포트를 받아 보세요.
+              </p>
+              <ul className="mt-1 flex flex-col gap-2">
+                {POINTS.map((p) => (
+                  <li key={p} className="text-text-1 flex items-center gap-2 text-sm">
+                    <span className="text-primary">●</span>
+                    {p}
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <a
+              href="mailto:hello@gettestea.com?subject=qaground 과제전형 도입 문의"
+              className="border-line-3 rounded-button h-button-lg text-text-1 hover:bg-bg-3 inline-flex shrink-0 items-center justify-center border px-8 font-medium transition-colors"
+            >
+              도입 문의
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-comparison.tsx
+++ b/apps/qaground/src/view/landing/landing-comparison.tsx
@@ -1,0 +1,54 @@
+const ROWS = [
+  { label: '연습 대상 페이지', legacy: true, qaground: true },
+  { label: '내 테스트 코드 실행', legacy: false, qaground: true },
+  { label: '통과/실패 자동 채점', legacy: false, qaground: true },
+  { label: '어디서 틀렸는지 피드백', legacy: false, qaground: true },
+  { label: '학습 진척·수료 인증', legacy: false, qaground: true },
+  { label: '기업 채용 과제전형', legacy: false, qaground: true },
+];
+
+function Mark({ on }: { on: boolean }) {
+  return on ? (
+    <span className="text-primary font-semibold">있음</span>
+  ) : (
+    <span className="text-text-4">없음</span>
+  );
+}
+
+export const LandingComparison = () => {
+  return (
+    <section className="w-full py-20">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6">
+        <h2 className="text-center text-2xl font-bold sm:text-3xl">
+          연습 페이지만 주는 곳과는 <span className="text-primary">다릅니다</span>
+        </h2>
+        <p className="text-text-2 mt-3 text-center text-sm leading-relaxed">
+          대부분의 QA 연습 사이트는 페이지만 제공합니다. qaground는 실행하고, 채점하고, 길을
+          알려줍니다.
+        </p>
+
+        <div className="border-line-2 bg-bg-2 mt-10 overflow-hidden rounded-2xl border">
+          <div className="border-line-2 text-text-3 grid grid-cols-[1fr_auto_auto] gap-4 border-b px-5 py-3 text-xs sm:px-6">
+            <span></span>
+            <span className="w-20 text-center">기존 사이트</span>
+            <span className="w-20 text-center">qaground</span>
+          </div>
+          {ROWS.map((row) => (
+            <div
+              key={row.label}
+              className="border-line-2 grid grid-cols-[1fr_auto_auto] items-center gap-4 border-b px-5 py-4 text-sm last:border-b-0 sm:px-6"
+            >
+              <span className="text-text-1">{row.label}</span>
+              <span className="w-20 text-center text-sm">
+                <Mark on={row.legacy} />
+              </span>
+              <span className="w-20 text-center text-sm">
+                <Mark on={row.qaground} />
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-footer.tsx
+++ b/apps/qaground/src/view/landing/landing-footer.tsx
@@ -1,0 +1,37 @@
+export const LandingFooter = () => {
+  return (
+    <footer className="border-line-2 w-full border-t">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-12 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="flex flex-col gap-2">
+          <span className="text-base font-bold tracking-tight">
+            qa<span className="text-primary">ground</span>
+          </span>
+          <span className="text-text-3 text-xs">
+            QA 자동화 연습과 채용 과제전형. Testea 제품군.
+          </span>
+        </div>
+        <nav className="flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+          <a
+            href="https://gettestea.com"
+            className="text-text-2 hover:text-text-1 transition-colors"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Testea 알아보기
+          </a>
+          <a href="#how" className="text-text-2 hover:text-text-1 transition-colors">
+            작동 방식
+          </a>
+          <a href="#assessment" className="text-text-2 hover:text-text-1 transition-colors">
+            과제전형
+          </a>
+        </nav>
+      </div>
+      <div className="border-line-2 border-t">
+        <div className="text-text-4 mx-auto w-full max-w-6xl px-4 py-5 text-xs sm:px-6">
+          © 2026 Testea. All rights reserved.
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-header.tsx
+++ b/apps/qaground/src/view/landing/landing-header.tsx
@@ -1,0 +1,45 @@
+const NAV = [
+  { label: '연습', href: '#playground' },
+  { label: '작동 방식', href: '#how' },
+  { label: '과제전형', href: '#assessment' },
+];
+
+export const LandingHeader = () => {
+  return (
+    <header className="border-line-2 bg-bg-1/80 sticky top-0 z-50 border-b backdrop-blur">
+      <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4 sm:px-6">
+        <div className="flex items-baseline gap-2">
+          <a href="#top" className="text-lg font-bold tracking-tight">
+            qa<span className="text-primary">ground</span>
+          </a>
+          <a
+            href="https://gettestea.com"
+            target="_blank"
+            rel="noreferrer"
+            className="text-text-3 hover:text-text-2 hidden text-xs transition-colors sm:inline"
+          >
+            by Testea
+          </a>
+        </div>
+
+        <nav className="flex items-center gap-1 sm:gap-2">
+          {NAV.map((item) => (
+            <a
+              key={item.href}
+              href={item.href}
+              className="text-text-2 hover:text-text-1 hidden rounded-md px-3 py-2 text-sm transition-colors sm:inline-block"
+            >
+              {item.label}
+            </a>
+          ))}
+          <a
+            href="#playground"
+            className="bg-primary rounded-button hover:bg-primary/90 active:bg-primary/80 ml-1 inline-flex h-9 items-center justify-center px-4 text-sm font-medium text-white transition-colors"
+          >
+            연습 시작하기
+          </a>
+        </nav>
+      </div>
+    </header>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-hero.tsx
+++ b/apps/qaground/src/view/landing/landing-hero.tsx
@@ -1,0 +1,63 @@
+const DIFFERENTIATORS = [
+  '연습 페이지 제공',
+  '내 코드 실행',
+  '자동 채점',
+  '개선 피드백',
+  '진척 추적',
+];
+
+export const LandingHero = () => {
+  return (
+    <section id="top" className="relative w-full overflow-hidden">
+      {/* 배경 그라데이션 */}
+      <div
+        aria-hidden
+        className="from-primary/10 pointer-events-none absolute inset-0 bg-gradient-to-b via-transparent to-transparent"
+      />
+
+      <div className="relative mx-auto flex w-full max-w-4xl flex-col items-center gap-6 px-4 py-24 text-center sm:px-6 sm:py-32">
+        <span className="border-line-2 bg-bg-2 text-text-2 animate-fade-in-up inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs">
+          <span className="bg-primary inline-block h-1.5 w-1.5 rounded-full" />
+          QA 자동화 연습 플랫폼 · 비공개 베타 준비 중
+        </span>
+
+        <h1 className="animate-fade-in-up text-4xl leading-[130%] font-bold tracking-tight sm:text-5xl md:text-6xl">
+          작성한 테스트를
+          <br />
+          <span className="text-primary">진짜로 실행하고 채점받는</span>
+          <br />
+          QA 연습 플레이그라운드
+        </h1>
+
+        <p className="animate-fade-in-up-delay text-text-2 max-w-2xl text-base leading-[170%] sm:text-lg">
+          로그인 폼부터 동적 테이블, 가짜 API까지. 연습용 페이지에 직접 Playwright·Cypress 테스트를
+          작성해 제출하면, 격리된 러너가 실행하고 어디서 틀렸는지 알려줍니다.
+        </p>
+
+        <div className="animate-fade-in-up-delay-2 flex flex-col items-center gap-3 sm:flex-row">
+          <a
+            href="#playground"
+            className="bg-primary rounded-button h-button-lg hover:bg-primary/90 active:bg-primary/80 inline-flex w-full items-center justify-center px-8 font-medium text-white transition-colors sm:w-auto"
+          >
+            연습 시작하기
+          </a>
+          <a
+            href="#how"
+            className="border-line-3 rounded-button h-button-lg text-text-1 hover:bg-bg-3 inline-flex w-full items-center justify-center border px-8 font-medium transition-colors sm:w-auto"
+          >
+            작동 방식 보기
+          </a>
+        </div>
+
+        <ul className="animate-fade-in-up-delay-2 text-text-3 mt-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-xs">
+          {DIFFERENTIATORS.map((d) => (
+            <li key={d} className="flex items-center gap-1.5">
+              <span className="text-primary">●</span>
+              {d}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-how-it-works.tsx
+++ b/apps/qaground/src/view/landing/landing-how-it-works.tsx
@@ -1,0 +1,40 @@
+const STEPS = [
+  {
+    no: '1',
+    title: '연습 페이지 선택',
+    desc: '난도와 도구(Playwright·Cypress·Selenium)에 맞는 연습 대상 페이지를 고릅니다.',
+  },
+  {
+    no: '2',
+    title: '테스트 작성·제출',
+    desc: '해당 페이지를 검증하는 자동화 테스트를 직접 작성해 제출합니다.',
+  },
+  {
+    no: '3',
+    title: '실행·채점·피드백',
+    desc: '격리된 러너가 코드를 실행하고, 통과/실패와 함께 개선할 점을 알려줍니다.',
+  },
+];
+
+export const LandingHowItWorks = () => {
+  return (
+    <section id="how" className="w-full py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <h2 className="text-center text-2xl font-bold sm:text-3xl">
+          어떻게 <span className="text-primary">작동하나요</span>
+        </h2>
+        <div className="mt-12 grid gap-6 sm:grid-cols-3">
+          {STEPS.map((s) => (
+            <div key={s.no} className="flex flex-col gap-4">
+              <span className="bg-bg-3 text-primary flex h-10 w-10 items-center justify-center rounded-full text-base font-bold">
+                {s.no}
+              </span>
+              <h3 className="text-lg font-semibold">{s.title}</h3>
+              <p className="text-text-2 text-sm leading-relaxed">{s.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-pillars.tsx
+++ b/apps/qaground/src/view/landing/landing-pillars.tsx
@@ -1,0 +1,46 @@
+const PILLARS = [
+  {
+    no: '01',
+    title: '연습 플레이그라운드',
+    desc: '로그인, 폼 검증, 동적 테이블, 드래그앤드롭, 파일 업로드, 가짜 REST API까지. 자동화 연습에 필요한 페이지를 난도별로 제공합니다.',
+  },
+  {
+    no: '02',
+    title: '자동 실행·채점',
+    desc: '제출한 Playwright·Cypress 스펙을 격리된 러너에서 실행하고, 숨겨진 검증 기준으로 통과/실패를 채점합니다.',
+  },
+  {
+    no: '03',
+    title: '학습 경로·인증',
+    desc: '난도별 과제와 추천 학습 경로, 진행률 추적, 수료 배지로 실력이 쌓이는 과정을 눈에 보이게 만듭니다.',
+  },
+  {
+    no: '04',
+    title: '채용 과제전형',
+    desc: '기업은 실제 시나리오로 과제를 출제하고, 후보가 제출한 자동화 코드를 자동 채점해 객관적 리포트로 비교합니다.',
+  },
+];
+
+export const LandingPillars = () => {
+  return (
+    <section id="playground" className="w-full py-20">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <h2 className="text-center text-2xl font-bold sm:text-3xl">
+          연습부터 채용 평가까지, <span className="text-primary">한 곳에서</span>
+        </h2>
+        <div className="mt-12 grid gap-5 sm:grid-cols-2">
+          {PILLARS.map((p) => (
+            <article
+              key={p.no}
+              className="border-line-2 bg-bg-2 hover:border-line-3 flex flex-col gap-3 rounded-2xl border p-6 transition-colors sm:p-8"
+            >
+              <span className="text-primary text-sm font-semibold">{p.no}</span>
+              <h3 className="text-lg font-semibold">{p.title}</h3>
+              <p className="text-text-2 text-sm leading-relaxed">{p.desc}</p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-testea-promo.tsx
+++ b/apps/qaground/src/view/landing/landing-testea-promo.tsx
@@ -1,0 +1,21 @@
+export const LandingTesteaPromo = () => {
+  return (
+    <aside className="bg-bg-2 w-full">
+      <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-4 py-6 text-center sm:flex-row sm:px-6 sm:text-left">
+        <p className="text-text-2 text-sm">
+          <span className="text-text-3">깨알 정보.</span> 연습을 끝냈다면, 실제 프로젝트 QA는{' '}
+          <span className="text-primary font-semibold">Testea</span>로 관리하세요.
+        </p>
+        <a
+          href="https://gettestea.com"
+          target="_blank"
+          rel="noreferrer"
+          className="border-line-3 text-text-1 hover:bg-bg-3 inline-flex items-center gap-1.5 rounded-full border px-4 py-2 text-sm font-medium whitespace-nowrap transition-colors"
+        >
+          Testea 둘러보기
+          <span aria-hidden>→</span>
+        </a>
+      </div>
+    </aside>
+  );
+};

--- a/apps/qaground/src/view/landing/landing-view.tsx
+++ b/apps/qaground/src/view/landing/landing-view.tsx
@@ -1,0 +1,44 @@
+import { LandingAssessment } from './landing-assessment';
+import { LandingComparison } from './landing-comparison';
+import { LandingFooter } from './landing-footer';
+import { LandingHeader } from './landing-header';
+import { LandingHero } from './landing-hero';
+import { LandingHowItWorks } from './landing-how-it-works';
+import { LandingPillars } from './landing-pillars';
+import { LandingTesteaPromo } from './landing-testea-promo';
+
+export const LandingView = () => {
+  return (
+    <div className="bg-bg-1 text-text-1 flex min-h-screen w-full flex-col font-sans">
+      <LandingHeader />
+      <main className="flex w-full flex-col">
+        <LandingHero />
+        <LandingComparison />
+        <LandingPillars />
+        <LandingHowItWorks />
+        <LandingAssessment />
+
+        {/* 마무리 CTA */}
+        <section className="w-full py-24">
+          <div className="mx-auto flex max-w-2xl flex-col items-center gap-6 px-4 text-center sm:px-6">
+            <h2 className="text-2xl font-bold sm:text-3xl">
+              지금 <span className="text-primary">첫 연습</span>을 시작하세요
+            </h2>
+            <p className="text-text-2 text-sm leading-relaxed sm:text-base">
+              연습 페이지를 고르고, 테스트를 작성해 제출하면 바로 채점 결과를 받습니다.
+            </p>
+            <a
+              href="#playground"
+              className="bg-primary rounded-button h-button-lg hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-8 font-medium text-white transition-colors"
+            >
+              연습 시작하기
+            </a>
+          </div>
+        </section>
+
+        <LandingTesteaPromo />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+};


### PR DESCRIPTION
## 개요

qaground 랜딩페이지를 구성했다. 이전 스캐폴딩의 플레이스홀더를 실제 마케팅 랜딩으로 교체한다. 기존 디자인 시스템 토큰과 톤을 그대로 따른다.

## 변경 사항

- 상단 헤더와 히어로 영역을 추가했다. 핵심 메시지는 작성한 테스트를 실제로 실행하고 채점받는다는 점이다.
- 기존 연습 사이트와의 차이를 한눈에 보여주는 비교 표를 넣었다.
- 제품의 네 기둥(연습 플레이그라운드, 자동 실행과 채점, 학습 경로와 인증, 채용 과제전형)을 카드로 정리했다.
- 작동 방식을 세 단계로 설명하는 영역과, 기업 채용 과제전형을 강조하는 영역을 추가했다.
- 마무리 행동 유도 영역과 푸터를 넣었다.
- 본 제품으로 자연스럽게 넘어가도록 헤더와 푸터, 그리고 푸터 위 작은 띠에 본 제품으로 이동하는 안내를 더했다.
- 헤더와 푸터 경계선만 남기고 섹션 사이 구분선은 정리해 더 깔끔하게 다듬었다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 로컬에서 실제 렌더링을 확인했다.
