### PR TITLE
feat(#234): qaground 홈을 비공개 베타 스플래시로 전환

### DIFF
--- a/apps/qaground/app/page.tsx
+++ b/apps/qaground/app/page.tsx
@@ -1,5 +1,12 @@
-import { LandingView } from '@/view/landing';
+import type { Metadata } from 'next';
+
+import { BetaLandingView } from '@/view/landing-beta';
+
+export const metadata: Metadata = {
+  title: 'qaground — QA 자동화 연습 플레이그라운드 (비공개 베타)',
+  description: 'QA 자동화 연습 플레이그라운드 qaground. 비공개 베타 신청.',
+};
 
 export default function Home() {
-  return <LandingView />;
+  return <BetaLandingView />;
 }

--- a/apps/qaground/app/preview/page.tsx
+++ b/apps/qaground/app/preview/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+import { LandingView } from '@/view/landing';
+
+export const metadata: Metadata = {
+  title: 'qaground 미리보기 — QA 자동화 연습 플레이그라운드',
+  description:
+    'QA 엔지니어를 위한 자동화 테스트 연습 플레이그라운드와 채용 과제전형. 정식 랜딩 미리보기.',
+};
+
+export default function PreviewPage() {
+  return <LandingView />;
+}

--- a/apps/qaground/src/view/landing-beta/index.ts
+++ b/apps/qaground/src/view/landing-beta/index.ts
@@ -1,0 +1,1 @@
+export { BetaLandingView } from './landing-beta-view';

--- a/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
+++ b/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
@@ -1,0 +1,62 @@
+import { WaitlistForm } from './waitlist-form';
+
+export const BetaLandingView = () => {
+  return (
+    <div className="bg-bg-1 text-text-1 relative flex h-screen w-full flex-col overflow-hidden font-sans">
+      {/* 배경 그라데이션 */}
+      <div
+        aria-hidden
+        className="from-primary/10 pointer-events-none absolute inset-0 bg-gradient-to-b via-transparent to-transparent"
+      />
+
+      {/* 헤더 */}
+      <header className="relative z-10 flex h-16 shrink-0 items-center justify-between px-6">
+        <div className="flex items-baseline gap-2">
+          <span className="text-lg font-bold tracking-tight">
+            qa<span className="text-primary">ground</span>
+          </span>
+          <a
+            href="https://gettestea.com"
+            target="_blank"
+            rel="noreferrer"
+            className="text-text-3 hover:text-text-2 text-xs transition-colors"
+          >
+            by Testea
+          </a>
+        </div>
+        <span className="border-line-2 bg-bg-2 text-text-2 inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs">
+          <span className="bg-primary inline-block h-1.5 w-1.5 rounded-full" />
+          비공개 베타
+        </span>
+      </header>
+
+      {/* 본문 (중앙 정렬) */}
+      <main className="relative z-10 flex flex-1 flex-col items-center justify-center gap-7 px-6 text-center">
+        <h1 className="text-4xl leading-[130%] font-bold tracking-tight sm:text-5xl md:text-6xl">
+          작성한 테스트를
+          <br />
+          <span className="text-primary">실행하고 채점받는</span>
+          <br />
+          QA 연습 플레이그라운드
+        </h1>
+        <p className="text-text-2 max-w-xl text-base leading-[170%] sm:text-lg">
+          곧 공개됩니다. 가장 먼저 연습을 시작하고 싶다면 베타를 신청하세요.
+        </p>
+        <WaitlistForm />
+      </main>
+
+      {/* 푸터 */}
+      <footer className="relative z-10 flex shrink-0 flex-col items-center gap-2 px-6 py-5 text-center">
+        <a
+          href="https://gettestea.com"
+          target="_blank"
+          rel="noreferrer"
+          className="text-text-3 hover:text-text-1 text-xs transition-colors"
+        >
+          실제 프로젝트 QA는 Testea로 관리하세요 →
+        </a>
+        <span className="text-text-4 text-xs">© 2026 Testea</span>
+      </footer>
+    </div>
+  );
+};

--- a/apps/qaground/src/view/landing-beta/waitlist-form.tsx
+++ b/apps/qaground/src/view/landing-beta/waitlist-form.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+
+export const WaitlistForm = () => {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  // TODO: 백엔드 연동 (대기자 명단 저장). 현재는 제출 시 로컬 확인만 한다.
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!email.includes('@')) return;
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <p className="text-primary text-sm font-medium" role="status">
+        신청 완료. 공개되면 가장 먼저 알려드릴게요.
+      </p>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full max-w-md flex-col gap-3 sm:flex-row">
+      <input
+        type="email"
+        required
+        value={email}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+        placeholder="이메일 주소"
+        aria-label="베타 신청 이메일"
+        className="border-line-3 bg-bg-2 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary h-button-lg flex-1 border px-4 text-sm transition-colors outline-none"
+      />
+      <button
+        type="submit"
+        className="bg-primary rounded-button h-button-lg hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-6 text-sm font-medium whitespace-nowrap text-white transition-colors"
+      >
+        베타 신청
+      </button>
+    </form>
+  );
+};


### PR DESCRIPTION
## 개요

정식 공개 전까지 홈을 비공개 베타 스플래시로 띄운다. 한 화면에 들어가고 스크롤이 없는 단일 뷰포트 구성이다.

## 변경 사항

- 홈 화면을 베타 안내 스플래시로 교체했다. 로고와 비공개 베타 표시, 핵심 한 줄 메시지, 베타 신청 입력란이 한 화면에 담긴다.
- 베타 신청 입력은 현재 화면 내 확인만 하며 대기자 저장 연동은 이후 작업으로 남겨 두었다.
- 앞서 만든 정식 랜딩은 사라지지 않도록 미리보기 경로로 옮겨 두었다.
- 본 제품으로 이동하는 안내를 헤더와 하단에 유지했다.

## 검증

- 프로덕션 빌드, 포매팅 검사 통과. 홈과 미리보기 경로 렌더를 로컬에서 확인했다.
