### PR TITLE
feat(#234): qaground 플레이그라운드 기반 (챌린지·샌드박스, 공개)

### DIFF
--- a/apps/qaground/app/challenges/[slug]/page.tsx
+++ b/apps/qaground/app/challenges/[slug]/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+
+import { CHALLENGES, getChallenge } from '@/shared/challenges/registry';
+import { ChallengeDetailView } from '@/view/challenges';
+
+export function generateStaticParams() {
+  return CHALLENGES.map((c) => ({ slug: c.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const challenge = getChallenge(slug);
+  if (!challenge) return { title: '챌린지를 찾을 수 없음 — qaground' };
+  return {
+    title: `${challenge.title} — qaground`,
+    description: challenge.summary,
+  };
+}
+
+export default async function ChallengeDetailPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const challenge = getChallenge(slug);
+  if (!challenge) notFound();
+  return <ChallengeDetailView challenge={challenge} />;
+}

--- a/apps/qaground/app/challenges/page.tsx
+++ b/apps/qaground/app/challenges/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+import { ChallengesView } from '@/view/challenges';
+
+export const metadata: Metadata = {
+  title: '연습 챌린지 — qaground',
+  description: 'QA 자동화 연습 챌린지. 로그인 없이 연습 대상에 직접 테스트를 작성해 보세요.',
+};
+
+export default function ChallengesPage() {
+  return <ChallengesView />;
+}

--- a/apps/qaground/app/sandbox/[slug]/page.tsx
+++ b/apps/qaground/app/sandbox/[slug]/page.tsx
@@ -1,0 +1,14 @@
+import { notFound } from 'next/navigation';
+
+import { SANDBOXES } from '@/view/sandbox';
+
+export function generateStaticParams() {
+  return Object.keys(SANDBOXES).map((slug) => ({ slug }));
+}
+
+export default async function SandboxPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const Sandbox = SANDBOXES[slug];
+  if (!Sandbox) notFound();
+  return <Sandbox />;
+}

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -1,0 +1,71 @@
+/**
+ * 챌린지 레지스트리 (MVP).
+ *
+ * - 아직 DB 없이 정적 정의로 시작한다. 폐루프(제출→러너→채점)가 증명되면
+ *   exercises 스키마로 옮긴다(FDD-QG05/QG09).
+ * - sandboxSlug 가 가리키는 `/sandbox/[slug]` 가 실제 테스트 대상 페이지다.
+ */
+
+export type ChallengeTrack = 'automation' | 'manual' | 'api';
+export type ChallengeDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface ChallengeSelector {
+  name: string;
+  testid: string;
+  desc: string;
+}
+
+export interface Challenge {
+  slug: string;
+  title: string;
+  track: ChallengeTrack;
+  difficulty: ChallengeDifficulty;
+  tools: string[];
+  summary: string;
+  /** 요구사항: 이 항목들을 검증하는 테스트를 작성한다. */
+  requirement: string[];
+  /** 테스트 대상 샌드박스 경로 슬러그 (`/sandbox/[sandboxSlug]`). */
+  sandboxSlug: string;
+  /** 학습자가 참고할 안정적 셀렉터. */
+  selectors: ChallengeSelector[];
+}
+
+export const TRACK_LABEL: Record<ChallengeTrack, string> = {
+  automation: 'Automation',
+  manual: 'Manual',
+  api: 'API',
+};
+
+export const DIFFICULTY_LABEL: Record<ChallengeDifficulty, string> = {
+  easy: '입문',
+  medium: '중급',
+  hard: '고급',
+};
+
+export const CHALLENGES: Challenge[] = [
+  {
+    slug: 'login-basic',
+    title: '로그인 폼 자동화',
+    track: 'automation',
+    difficulty: 'easy',
+    tools: ['Playwright', 'Cypress', 'Selenium'],
+    summary: '유효·무효 자격증명에 따른 로그인 동작을 검증하는 자동화 테스트를 작성하세요.',
+    requirement: [
+      '유효한 자격증명(tester / qaground123)으로 로그인하면 환영 메시지가 보인다.',
+      '잘못된 자격증명으로 로그인하면 에러 메시지가 보인다.',
+      '아이디나 비밀번호를 비우고 제출하면 필수 입력 에러가 보인다.',
+    ],
+    sandboxSlug: 'login-basic',
+    selectors: [
+      { name: '아이디 입력', testid: 'username', desc: '아이디 입력 필드' },
+      { name: '비밀번호 입력', testid: 'password', desc: '비밀번호 입력 필드' },
+      { name: '로그인 버튼', testid: 'login-submit', desc: '제출 버튼' },
+      { name: '성공 메시지', testid: 'login-success', desc: '로그인 성공 시 노출' },
+      { name: '에러 메시지', testid: 'login-error', desc: '실패·검증 에러 시 노출' },
+    ],
+  },
+];
+
+export function getChallenge(slug: string): Challenge | undefined {
+  return CHALLENGES.find((c) => c.slug === slug);
+}

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -1,0 +1,86 @@
+import Link from 'next/link';
+
+import { type Challenge, DIFFICULTY_LABEL, TRACK_LABEL } from '@/shared/challenges/registry';
+
+import { PlaygroundHeader } from './playground-header';
+
+export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => {
+  return (
+    <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
+      <PlaygroundHeader />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-12 sm:px-6">
+        <Link
+          href="/challenges"
+          className="text-text-3 hover:text-text-1 mb-6 inline-block text-sm transition-colors"
+        >
+          ← 챌린지 목록
+        </Link>
+
+        <div className="mb-3 flex items-center gap-2">
+          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+            {TRACK_LABEL[challenge.track]}
+          </span>
+          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+            {DIFFICULTY_LABEL[challenge.difficulty]}
+          </span>
+          {challenge.tools.map((tool) => (
+            <span key={tool} className="text-text-3 text-xs">
+              {tool}
+            </span>
+          ))}
+        </div>
+
+        <h1 className="text-2xl font-bold sm:text-3xl">{challenge.title}</h1>
+        <p className="text-text-2 mt-3 text-sm leading-relaxed">{challenge.summary}</p>
+
+        <section className="mt-10">
+          <h2 className="text-lg font-semibold">요구사항</h2>
+          <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
+            {challenge.requirement.map((r) => (
+              <li key={r}>{r}</li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="mt-8">
+          <h2 className="text-lg font-semibold">연습 대상</h2>
+          <p className="text-text-2 mt-2 text-sm leading-relaxed">
+            아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.
+          </p>
+          <Link
+            href={`/sandbox/${challenge.sandboxSlug}`}
+            target="_blank"
+            className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
+          >
+            연습 대상 열기
+          </Link>
+
+          <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
+            <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
+              <span>셀렉터</span>
+              <span>설명</span>
+            </div>
+            {challenge.selectors.map((s) => (
+              <div
+                key={s.testid}
+                className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
+              >
+                <code className="text-primary font-mono text-xs">
+                  [data-testid=&quot;{s.testid}&quot;]
+                </code>
+                <span className="text-text-2 text-sm">{s.desc}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
+          <h2 className="text-base font-semibold">자동 채점 제출</h2>
+          <p className="text-text-3 mt-2 text-sm leading-relaxed">
+            작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.
+          </p>
+        </section>
+      </main>
+    </div>
+  );
+};

--- a/apps/qaground/src/view/challenges/challenges-view.tsx
+++ b/apps/qaground/src/view/challenges/challenges-view.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+
+import { CHALLENGES, DIFFICULTY_LABEL, TRACK_LABEL } from '@/shared/challenges/registry';
+
+import { PlaygroundHeader } from './playground-header';
+
+export const ChallengesView = () => {
+  return (
+    <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
+      <PlaygroundHeader />
+      <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-12 sm:px-6">
+        <header className="mb-10 flex flex-col gap-3">
+          <h1 className="text-3xl font-bold">연습 챌린지</h1>
+          <p className="text-text-2 text-sm">
+            연습 대상에 직접 자동화 테스트를 작성해 보세요. 로그인 없이 누구나 이용할 수 있습니다.
+          </p>
+        </header>
+
+        <ul className="grid gap-4 sm:grid-cols-2">
+          {CHALLENGES.map((c) => (
+            <li key={c.slug}>
+              <Link
+                href={`/challenges/${c.slug}`}
+                className="border-line-2 bg-bg-2 hover:border-line-3 flex h-full flex-col gap-3 rounded-2xl border p-6 transition-colors"
+              >
+                <div className="flex items-center gap-2">
+                  <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+                    {TRACK_LABEL[c.track]}
+                  </span>
+                  <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+                    {DIFFICULTY_LABEL[c.difficulty]}
+                  </span>
+                </div>
+                <span className="text-lg font-semibold">{c.title}</span>
+                <span className="text-text-2 text-sm leading-relaxed">{c.summary}</span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+};

--- a/apps/qaground/src/view/challenges/index.ts
+++ b/apps/qaground/src/view/challenges/index.ts
@@ -1,0 +1,2 @@
+export { ChallengesView } from './challenges-view';
+export { ChallengeDetailView } from './challenge-detail-view';

--- a/apps/qaground/src/view/challenges/playground-header.tsx
+++ b/apps/qaground/src/view/challenges/playground-header.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link';
+
+export const PlaygroundHeader = () => {
+  return (
+    <header className="border-line-2 bg-bg-1/80 sticky top-0 z-50 border-b backdrop-blur">
+      <div className="mx-auto flex h-16 w-full max-w-5xl items-center justify-between px-4 sm:px-6">
+        <Link href="/" className="text-lg font-bold tracking-tight">
+          qa<span className="text-primary">ground</span>
+        </Link>
+        <Link
+          href="/challenges"
+          className="text-text-2 hover:text-text-1 text-sm transition-colors"
+        >
+          챌린지
+        </Link>
+      </div>
+    </header>
+  );
+};

--- a/apps/qaground/src/view/sandbox/index.ts
+++ b/apps/qaground/src/view/sandbox/index.ts
@@ -1,0 +1,8 @@
+import type { ComponentType } from 'react';
+
+import { LoginSandbox } from './login-sandbox';
+
+/** 샌드박스 슬러그 → 테스트 대상 컴포넌트. 챌린지 레지스트리의 sandboxSlug 와 매칭. */
+export const SANDBOXES: Record<string, ComponentType> = {
+  'login-basic': LoginSandbox,
+};

--- a/apps/qaground/src/view/sandbox/login-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/login-sandbox.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+
+const VALID_USERNAME = 'tester';
+const VALID_PASSWORD = 'qaground123';
+
+type Result = { type: 'success' } | { type: 'error'; message: string } | null;
+
+/**
+ * 로그인 폼 샌드박스 (테스트 대상).
+ *
+ * 자동화 연습용 의도적 타깃. 안정적 셀렉터(data-testid)를 심어 두었다.
+ * - 유효 자격증명(tester / qaground123): 성공 메시지
+ * - 무효 자격증명: 에러 메시지
+ * - 빈 입력: 필수 입력 에러
+ */
+export const LoginSandbox = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [result, setResult] = useState<Result>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!username.trim() || !password.trim()) {
+      setResult({ type: 'error', message: '아이디와 비밀번호를 모두 입력하세요.' });
+      return;
+    }
+    if (username === VALID_USERNAME && password === VALID_PASSWORD) {
+      setResult({ type: 'success' });
+      return;
+    }
+    setResult({ type: 'error', message: '아이디 또는 비밀번호가 올바르지 않습니다.' });
+  };
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-sm rounded-2xl border p-8">
+        <h1 className="mb-6 text-xl font-bold" data-testid="login-heading">
+          로그인
+        </h1>
+
+        {result?.type === 'success' ? (
+          <p
+            data-testid="login-success"
+            role="status"
+            className="border-primary/30 bg-primary/10 text-primary rounded-xl border px-4 py-3 text-sm font-medium"
+          >
+            환영합니다, {VALID_USERNAME}님. 로그인에 성공했습니다.
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">아이디</span>
+              <input
+                data-testid="username"
+                name="username"
+                type="text"
+                value={username}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setUsername(e.target.value)}
+                className="border-line-3 bg-bg-3 rounded-button text-text-1 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">비밀번호</span>
+              <input
+                data-testid="password"
+                name="password"
+                type="password"
+                value={password}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value)}
+                className="border-line-3 bg-bg-3 rounded-button text-text-1 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none"
+              />
+            </label>
+
+            {result?.type === 'error' && (
+              <p data-testid="login-error" role="alert" className="text-system-red text-sm">
+                {result.message}
+              </p>
+            )}
+
+            <button
+              data-testid="login-submit"
+              type="submit"
+              className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-1 inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-colors"
+            >
+              로그인
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+};


### PR DESCRIPTION
﻿## 개요

FDD-QG01(챌린지/플레이그라운드)의 첫 슬라이스를 구현한다. 자동화 연습 대상이 되는 샌드박스와 챌린지 목록·상세를 공개(로그인 없이 누구나) 라우트로 제공한다.

이번 단계는 연습 대상과 챌린지 구조까지다. 제출을 격리 러너로 채점하는 폐루프는 신뢰할 수 없는 코드 실행 보안 검토가 선결이라 다음 단계로 분리했다. 상세 화면에는 자동 채점이 곧 제공된다는 안내만 둔다.

## 변경 사항

- 연습 챌린지 목록 화면을 추가했다. 트랙과 난도를 배지로 보여준다.
- 챌린지 상세 화면을 추가했다. 요구사항, 참고 셀렉터 표, 연습 대상 열기, 자동 채점 예고를 담는다.
- 실제 테스트 대상이 되는 로그인 폼 샌드박스를 추가했다. 안정적인 셀렉터를 의도적으로 심어 두었고, 유효·무효·빈 입력에 따라 동작이 갈린다.
- 챌린지는 아직 데이터베이스 없이 정적 목록으로 시작한다. 폐루프가 증명되면 도메인 스키마로 옮긴다.
- 세 화면 모두 검색 노출을 위해 정적으로 미리 생성된다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 세 화면 렌더와 샌드박스의 유효·무효·빈 입력 동작, 안내된 셀렉터 일치를 로컬에서 확인했다.
