### PR TITLE
feat(#234): qaground 챌린지 추가 (모달·DnD·파일 업로드)

### DIFF
--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -129,6 +129,64 @@ export const CHALLENGES: Challenge[] = [
       { name: '콘텐츠 목록', testid: 'loaded-content', desc: '로딩 완료 후 노출' },
     ],
   },
+  {
+    slug: 'modal',
+    title: '모달 다이얼로그 확인',
+    track: 'automation',
+    difficulty: 'easy',
+    tools: ['Playwright', 'Cypress', 'Selenium'],
+    summary: '열기·확인·취소가 있는 모달의 흐름을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '열기 버튼을 누르면 모달이 나타난다.',
+      '모달에서 취소를 누르면 모달이 닫히고 결과는 없다.',
+      '모달에서 삭제(확인)를 누르면 모달이 닫히고 완료 메시지가 보인다.',
+    ],
+    sandboxSlug: 'modal',
+    selectors: [
+      { name: '모달 열기', testid: 'modal-open', desc: '모달 여는 버튼' },
+      { name: '모달', testid: 'modal', desc: '모달 컨테이너' },
+      { name: '확인 버튼', testid: 'modal-confirm', desc: '모달 확인(삭제) 버튼' },
+      { name: '취소 버튼', testid: 'modal-cancel', desc: '모달 취소 버튼' },
+      { name: '결과 메시지', testid: 'modal-result', desc: '확인 후 노출' },
+    ],
+  },
+  {
+    slug: 'drag-and-drop',
+    title: '드래그앤드롭 배치',
+    track: 'automation',
+    difficulty: 'medium',
+    tools: ['Playwright', 'Cypress', 'Selenium'],
+    summary: 'HTML5 드래그앤드롭으로 위젯을 드롭존에 배치하는 동작을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '위젯을 드롭존으로 끌어다 놓으면 배치 완료 메시지가 보인다.',
+      '배치 후에는 드래그 가능한 위젯이 사라진다.',
+    ],
+    sandboxSlug: 'drag-and-drop',
+    selectors: [
+      { name: '드래그 항목', testid: 'drag-item', desc: '끌 수 있는 위젯' },
+      { name: '드롭존', testid: 'drop-zone', desc: '놓는 영역' },
+      { name: '배치 결과', testid: 'drop-result', desc: '배치 완료 시 노출' },
+    ],
+  },
+  {
+    slug: 'file-upload',
+    title: '파일 업로드',
+    track: 'automation',
+    difficulty: 'easy',
+    tools: ['Playwright', 'Cypress', 'Selenium'],
+    summary: '파일을 선택하고 업로드해 완료 상태를 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '파일을 선택하면 선택한 파일 이름이 보인다.',
+      '업로드 버튼을 누르면 업로드 완료 메시지가 보인다.',
+    ],
+    sandboxSlug: 'file-upload',
+    selectors: [
+      { name: '파일 입력', testid: 'file-input', desc: '파일 선택 input' },
+      { name: '파일 이름', testid: 'file-name', desc: '선택한 파일 이름' },
+      { name: '업로드 버튼', testid: 'upload-submit', desc: '업로드 제출 버튼' },
+      { name: '업로드 결과', testid: 'upload-result', desc: '업로드 완료 시 노출' },
+    ],
+  },
 ];
 
 export function getChallenge(slug: string): Challenge | undefined {

--- a/apps/qaground/src/view/sandbox/dnd-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/dnd-sandbox.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * 드래그앤드롭 샌드박스 (테스트 대상).
+ * - HTML5 네이티브 DnD. 위젯을 드롭존으로 끌어다 놓으면 배치된다.
+ */
+export const DndSandbox = () => {
+  const [dropped, setDropped] = useState(false);
+  const [over, setOver] = useState(false);
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-md rounded-2xl border p-8">
+        <h1 className="mb-6 text-xl font-bold">위젯 배치</h1>
+
+        {!dropped && (
+          <div
+            data-testid="drag-item"
+            draggable
+            onDragStart={(e: React.DragEvent<HTMLDivElement>) => {
+              e.dataTransfer.setData('text/plain', 'payment-widget');
+              e.dataTransfer.effectAllowed = 'move';
+            }}
+            className="border-line-3 bg-bg-3 mb-6 inline-flex cursor-grab items-center rounded-xl border px-4 py-3 text-sm active:cursor-grabbing"
+          >
+            결제 위젯
+          </div>
+        )}
+
+        <div
+          data-testid="drop-zone"
+          onDragOver={(e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            setOver(true);
+          }}
+          onDragLeave={() => setOver(false)}
+          onDrop={(e: React.DragEvent<HTMLDivElement>) => {
+            e.preventDefault();
+            setOver(false);
+            setDropped(true);
+          }}
+          className={[
+            'flex min-h-28 items-center justify-center rounded-xl border-2 border-dashed px-4 text-sm transition-colors',
+            over ? 'border-primary bg-primary/10' : 'border-line-3 text-text-3',
+          ].join(' ')}
+        >
+          {dropped ? (
+            <span data-testid="drop-result" className="text-primary font-medium">
+              결제 위젯이 배치되었습니다.
+            </span>
+          ) : (
+            '여기에 위젯을 끌어다 놓으세요'
+          )}
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/apps/qaground/src/view/sandbox/file-upload-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/file-upload-sandbox.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * 파일 업로드 샌드박스 (테스트 대상).
+ * - 파일 선택 → 파일명 표시 → 업로드 버튼 → 완료 메시지.
+ */
+export const FileUploadSandbox = () => {
+  const [fileName, setFileName] = useState('');
+  const [uploaded, setUploaded] = useState(false);
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-md rounded-2xl border p-8">
+        <h1 className="mb-5 text-xl font-bold">증빙 파일 업로드</h1>
+
+        <input
+          data-testid="file-input"
+          type="file"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setUploaded(false);
+            setFileName(e.target.files?.[0]?.name ?? '');
+          }}
+          className="text-text-2 file:border-line-3 file:bg-bg-3 file:text-text-1 block w-full text-sm file:mr-3 file:rounded-md file:border file:px-3 file:py-2 file:text-sm"
+        />
+
+        {fileName && (
+          <p data-testid="file-name" className="text-text-2 mt-4 text-sm">
+            선택한 파일: <span className="text-text-1">{fileName}</span>
+          </p>
+        )}
+
+        <button
+          data-testid="upload-submit"
+          type="button"
+          disabled={!fileName}
+          onClick={() => setUploaded(true)}
+          className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          업로드
+        </button>
+
+        {uploaded && (
+          <p
+            data-testid="upload-result"
+            role="status"
+            className="text-primary mt-4 text-sm font-medium"
+          >
+            업로드 완료: {fileName}
+          </p>
+        )}
+      </div>
+    </main>
+  );
+};

--- a/apps/qaground/src/view/sandbox/index.ts
+++ b/apps/qaground/src/view/sandbox/index.ts
@@ -2,7 +2,10 @@ import type { ComponentType } from 'react';
 
 import { AsyncLoadSandbox } from './async-load-sandbox';
 import { DataTableSandbox } from './data-table-sandbox';
+import { DndSandbox } from './dnd-sandbox';
+import { FileUploadSandbox } from './file-upload-sandbox';
 import { LoginSandbox } from './login-sandbox';
+import { ModalSandbox } from './modal-sandbox';
 import { SignupSandbox } from './signup-sandbox';
 
 /** 샌드박스 슬러그 → 테스트 대상 컴포넌트. 챌린지 레지스트리의 sandboxSlug 와 매칭. */
@@ -11,4 +14,7 @@ export const SANDBOXES: Record<string, ComponentType> = {
   'signup-validation': SignupSandbox,
   'data-table': DataTableSandbox,
   'async-load': AsyncLoadSandbox,
+  modal: ModalSandbox,
+  'drag-and-drop': DndSandbox,
+  'file-upload': FileUploadSandbox,
 };

--- a/apps/qaground/src/view/sandbox/modal-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/modal-sandbox.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * 모달/다이얼로그 샌드박스 (테스트 대상).
+ * - 열기 → 모달 → 확인(결과 표시) 또는 취소(닫기).
+ */
+export const ModalSandbox = () => {
+  const [open, setOpen] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-md rounded-2xl border p-8">
+        <h1 className="mb-5 text-xl font-bold">계정 삭제</h1>
+
+        <button
+          data-testid="modal-open"
+          type="button"
+          onClick={() => {
+            setConfirmed(false);
+            setOpen(true);
+          }}
+          className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
+        >
+          계정 삭제 열기
+        </button>
+
+        {confirmed && (
+          <p
+            data-testid="modal-result"
+            role="status"
+            className="text-primary mt-5 text-sm font-medium"
+          >
+            계정이 삭제되었습니다.
+          </p>
+        )}
+      </div>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4">
+          <div
+            data-testid="modal"
+            role="dialog"
+            aria-modal="true"
+            className="border-line-2 bg-bg-2 w-full max-w-sm rounded-2xl border p-6"
+          >
+            <h2 className="text-base font-semibold">정말 삭제할까요?</h2>
+            <p className="text-text-2 mt-2 text-sm">이 작업은 되돌릴 수 없습니다.</p>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                data-testid="modal-cancel"
+                type="button"
+                onClick={() => setOpen(false)}
+                className="border-line-3 rounded-button text-text-1 hover:bg-bg-3 h-button-md border px-4 text-sm transition-colors"
+              >
+                취소
+              </button>
+              <button
+                data-testid="modal-confirm"
+                type="button"
+                onClick={() => {
+                  setConfirmed(true);
+                  setOpen(false);
+                }}
+                className="bg-system-red rounded-button h-button-md inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-opacity hover:opacity-90"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+};


### PR DESCRIPTION
﻿## 개요

플레이그라운드 연습 챌린지를 더 추가한다. 모달 다이얼로그, 드래그앤드롭, 파일 업로드 세 가지로, 모두 로그인 없이 누구나 접근하는 공개 라우트다. 이로써 연습 챌린지는 일곱 가지가 된다.

## 변경 사항

- 모달 다이얼로그 챌린지를 추가했다. 열기, 취소, 확인 흐름과 확인 후 결과 노출을 검증하는 연습 대상이다.
- 드래그앤드롭 챌린지를 추가했다. HTML5 네이티브 드래그앤드롭으로 위젯을 드롭존에 배치하는 동작을 검증한다.
- 파일 업로드 챌린지를 추가했다. 파일 선택과 업로드 완료 상태를 검증한다.
- 세 대상 모두 안정적인 셀렉터를 의도적으로 심었고, 상세 화면에 요구사항과 셀렉터 표가 자동으로 노출된다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과. 새 대상이 모두 정적으로 미리 생성된다.
- 각 동작을 로컬 브라우저에서 확인했다. 모달의 취소와 확인 분기, 드래그앤드롭의 배치 결과, 파일 선택과 업로드 완료가 의도대로 동작한다.
