### PR TITLE
feat(#234): qaground API 트랙 - 가짜 REST API + API 챌린지

### DIFF
--- a/apps/qaground/app/api/practice/auth/login/route.ts
+++ b/apps/qaground/app/api/practice/auth/login/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { DEMO_EMAIL, DEMO_PASSWORD, DEMO_TOKEN } from '@/shared/practice-api/auth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/practice/auth/login
+ * - 유효 자격증명: 200 { token }
+ * - 무효 자격증명: 401 { error }
+ * - 잘못된 본문: 400 { error }
+ */
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const { email, password } = (body ?? {}) as { email?: unknown; password?: unknown };
+  if (typeof email !== 'string' || typeof password !== 'string') {
+    return NextResponse.json({ error: 'email과 password가 필요합니다.' }, { status: 400 });
+  }
+
+  if (email === DEMO_EMAIL && password === DEMO_PASSWORD) {
+    return NextResponse.json({ token: DEMO_TOKEN });
+  }
+
+  return NextResponse.json({ error: '자격증명이 올바르지 않습니다.' }, { status: 401 });
+}

--- a/apps/qaground/app/api/practice/products/[id]/route.ts
+++ b/apps/qaground/app/api/practice/products/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+
+import { isAuthorized } from '@/shared/practice-api/auth';
+import { findProduct } from '@/shared/practice-api/data';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/practice/products/:id
+ * - 존재: 200 { ...product }
+ * - 없음: 404 { error }
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const product = findProduct(Number(id));
+  if (!product) {
+    return NextResponse.json({ error: '상품을 찾을 수 없습니다.' }, { status: 404 });
+  }
+  return NextResponse.json(product);
+}
+
+/**
+ * DELETE /api/practice/products/:id
+ * - 인증 필요: 토큰 없으면 401.
+ * - 존재: 204 (no content, 데모라 실제 삭제는 안 함).
+ * - 없음: 404 { error }.
+ */
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+  }
+  const { id } = await params;
+  if (!findProduct(Number(id))) {
+    return NextResponse.json({ error: '상품을 찾을 수 없습니다.' }, { status: 404 });
+  }
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/qaground/app/api/practice/products/route.ts
+++ b/apps/qaground/app/api/practice/products/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server';
+
+import { isAuthorized } from '@/shared/practice-api/auth';
+import { PRODUCTS } from '@/shared/practice-api/data';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/practice/products?page=1&limit=5&category=주변기기
+ * - 페이지네이션 + 선택적 카테고리 필터. 메타데이터(total·totalPages) 포함.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, Number(searchParams.get('page') ?? '1') || 1);
+  const limit = Math.min(50, Math.max(1, Number(searchParams.get('limit') ?? '5') || 5));
+  const category = searchParams.get('category');
+
+  const filtered = category ? PRODUCTS.filter((p) => p.category === category) : PRODUCTS;
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const data = filtered.slice((page - 1) * limit, page * limit);
+
+  return NextResponse.json({ page, limit, total, totalPages, data });
+}
+
+const CreateSchema = z
+  .object({
+    name: z.string().trim().min(1).max(100),
+    price: z.number().int().positive(),
+    category: z.string().trim().min(1).max(50).optional(),
+  })
+  .strict();
+
+/**
+ * POST /api/practice/products
+ * - 인증 필요: 토큰 없으면 401.
+ * - 본문 검증 실패: 400 { error, issues }.
+ * - 성공: 201 { id, ... } (실제로 영속하지 않는 데모 응답).
+ */
+export async function POST(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  const created = {
+    id: PRODUCTS.length + 1,
+    name: parsed.data.name,
+    category: parsed.data.category ?? '기타',
+    price: parsed.data.price,
+    inStock: true,
+  };
+  return NextResponse.json(created, { status: 201 });
+}

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -15,6 +15,16 @@ export interface ChallengeSelector {
   desc: string;
 }
 
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export interface ApiEndpoint {
+  method: HttpMethod;
+  path: string;
+  /** 인증(토큰) 필요 여부. */
+  auth?: boolean;
+  desc: string;
+}
+
 export interface Challenge {
   slug: string;
   title: string;
@@ -24,10 +34,16 @@ export interface Challenge {
   summary: string;
   /** 요구사항: 이 항목들을 검증하는 테스트를 작성한다. */
   requirement: string[];
-  /** 테스트 대상 샌드박스 경로 슬러그 (`/sandbox/[sandboxSlug]`). */
-  sandboxSlug: string;
-  /** 학습자가 참고할 안정적 셀렉터. */
-  selectors: ChallengeSelector[];
+  /** UI 트랙: 테스트 대상 샌드박스 경로 슬러그 (`/sandbox/[sandboxSlug]`). */
+  sandboxSlug?: string;
+  /** UI 트랙: 학습자가 참고할 안정적 셀렉터. */
+  selectors?: ChallengeSelector[];
+  /** API 트랙: 엔드포인트 베이스 경로 (예: `/api/practice`). */
+  apiBase?: string;
+  /** API 트랙: 연습 대상 엔드포인트 목록. */
+  endpoints?: ApiEndpoint[];
+  /** API 트랙: 데모 계정·토큰 등 안내. */
+  apiNote?: string;
 }
 
 export const TRACK_LABEL: Record<ChallengeTrack, string> = {
@@ -48,7 +64,7 @@ export const CHALLENGES: Challenge[] = [
     title: '로그인 폼 자동화',
     track: 'automation',
     difficulty: 'easy',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '유효·무효 자격증명에 따른 로그인 동작을 검증하는 자동화 테스트를 작성하세요.',
     requirement: [
       '유효한 자격증명(tester / qaground123)으로 로그인하면 환영 메시지가 보인다.',
@@ -69,7 +85,7 @@ export const CHALLENGES: Challenge[] = [
     title: '회원가입 폼 검증',
     track: 'automation',
     difficulty: 'easy',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '이메일 형식, 비밀번호 규칙, 비밀번호 확인 일치를 검증하는 테스트를 작성하세요.',
     requirement: [
       '이메일 형식이 올바르지 않으면 이메일 에러가 보인다.',
@@ -94,7 +110,7 @@ export const CHALLENGES: Challenge[] = [
     title: '데이터 테이블 검색·정렬·페이지네이션',
     track: 'automation',
     difficulty: 'medium',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '검색 필터, 컬럼 정렬, 페이지 이동이 있는 테이블을 검증하는 테스트를 작성하세요.',
     requirement: [
       '이름 검색어를 입력하면 일치하는 행만 보인다.',
@@ -116,7 +132,7 @@ export const CHALLENGES: Challenge[] = [
     title: '비동기 로딩과 대기',
     track: 'automation',
     difficulty: 'easy',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '지연 로딩되는 콘텐츠를 적절히 대기해 검증하는 테스트를 작성하세요.',
     requirement: [
       '불러오기 버튼을 누르면 로딩 스피너가 보인다.',
@@ -134,7 +150,7 @@ export const CHALLENGES: Challenge[] = [
     title: '모달 다이얼로그 확인',
     track: 'automation',
     difficulty: 'easy',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '열기·확인·취소가 있는 모달의 흐름을 검증하는 테스트를 작성하세요.',
     requirement: [
       '열기 버튼을 누르면 모달이 나타난다.',
@@ -155,7 +171,7 @@ export const CHALLENGES: Challenge[] = [
     title: '드래그앤드롭 배치',
     track: 'automation',
     difficulty: 'medium',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: 'HTML5 드래그앤드롭으로 위젯을 드롭존에 배치하는 동작을 검증하는 테스트를 작성하세요.',
     requirement: [
       '위젯을 드롭존으로 끌어다 놓으면 배치 완료 메시지가 보인다.',
@@ -173,7 +189,7 @@ export const CHALLENGES: Challenge[] = [
     title: '파일 업로드',
     track: 'automation',
     difficulty: 'easy',
-    tools: ['Playwright', 'Cypress', 'Selenium'],
+    tools: ['Playwright'],
     summary: '파일을 선택하고 업로드해 완료 상태를 검증하는 테스트를 작성하세요.',
     requirement: [
       '파일을 선택하면 선택한 파일 이름이 보인다.',
@@ -186,6 +202,36 @@ export const CHALLENGES: Challenge[] = [
       { name: '업로드 버튼', testid: 'upload-submit', desc: '업로드 제출 버튼' },
       { name: '업로드 결과', testid: 'upload-result', desc: '업로드 완료 시 노출' },
     ],
+  },
+  {
+    slug: 'rest-api-products',
+    title: '상품 REST API 자동화',
+    track: 'api',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '상품 REST API의 목록·조회·생성·삭제와 인증을 검증하는 API 테스트를 작성하세요. 브라우저가 아니라 HTTP 요청으로 검증합니다.',
+    requirement: [
+      '상품 목록은 page·limit 쿼리로 페이지네이션되고 total·totalPages 메타데이터를 포함한다.',
+      '존재하지 않는 상품 ID 조회는 404를 반환한다.',
+      '로그인은 유효 자격증명에 토큰을, 무효 자격증명에 401을 반환한다.',
+      '상품 생성은 토큰이 없으면 401, 필수 필드 누락이면 400, 정상이면 201을 반환한다.',
+      '상품 삭제는 토큰이 필요하며 정상 시 204를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      {
+        method: 'GET',
+        path: '/products?page=1&limit=5',
+        desc: '상품 목록 (페이지네이션·category 필터)',
+      },
+      { method: 'GET', path: '/products/:id', desc: '상품 단건 (없으면 404)' },
+      { method: 'POST', path: '/auth/login', desc: '로그인 → 토큰 (무효 시 401)' },
+      { method: 'POST', path: '/products', auth: true, desc: '상품 생성 (검증 400 / 성공 201)' },
+      { method: 'DELETE', path: '/products/:id', auth: true, desc: '상품 삭제 (204 / 404)' },
+    ],
+    apiNote:
+      '데모 계정 tester@qaground.dev / qaground123 로 로그인해 토큰을 받고, 보호된 요청에 Authorization: Bearer <token> 헤더를 붙이세요.',
   },
 ];
 

--- a/apps/qaground/src/shared/practice-api/auth.ts
+++ b/apps/qaground/src/shared/practice-api/auth.ts
@@ -1,0 +1,14 @@
+/**
+ * 연습용 가짜 API 인증 (API 트랙).
+ *
+ * - 데모 자격증명으로 로그인하면 고정 토큰을 돌려준다.
+ * - 보호된 엔드포인트는 `Authorization: Bearer <token>` 를 요구한다.
+ */
+
+export const DEMO_EMAIL = 'tester@qaground.dev';
+export const DEMO_PASSWORD = 'qaground123';
+export const DEMO_TOKEN = 'qaground-demo-token';
+
+export function isAuthorized(request: Request): boolean {
+  return request.headers.get('authorization') === `Bearer ${DEMO_TOKEN}`;
+}

--- a/apps/qaground/src/shared/practice-api/data.ts
+++ b/apps/qaground/src/shared/practice-api/data.ts
@@ -1,0 +1,34 @@
+/**
+ * 연습용 가짜 REST API 데이터 (API 트랙).
+ *
+ * - 예측 가능하고 상태가 없는(stateless) 응답을 준다(reqres.in 스타일).
+ *   쓰기(POST/DELETE)는 성공 응답을 돌려주되 실제로 영속하지 않는다.
+ *   여러 학습자가 동시에 써도 데이터가 흔들리지 않아 테스트가 안정적이다.
+ */
+
+export interface Product {
+  id: number;
+  name: string;
+  category: string;
+  price: number;
+  inStock: boolean;
+}
+
+export const PRODUCTS: Product[] = [
+  { id: 1, name: '무선 키보드', category: '주변기기', price: 39000, inStock: true },
+  { id: 2, name: '기계식 키보드', category: '주변기기', price: 89000, inStock: true },
+  { id: 3, name: '무선 마우스', category: '주변기기', price: 29000, inStock: true },
+  { id: 4, name: '27인치 모니터', category: '모니터', price: 259000, inStock: false },
+  { id: 5, name: '34인치 울트라와이드', category: '모니터', price: 590000, inStock: true },
+  { id: 6, name: '노트북 거치대', category: '액세서리', price: 35000, inStock: true },
+  { id: 7, name: 'USB-C 허브', category: '액세서리', price: 49000, inStock: true },
+  { id: 8, name: '웹캠 1080p', category: '주변기기', price: 69000, inStock: false },
+  { id: 9, name: '게이밍 노트북', category: '노트북', price: 1890000, inStock: true },
+  { id: 10, name: '경량 노트북', category: '노트북', price: 1290000, inStock: true },
+  { id: 11, name: '노이즈캔슬링 헤드셋', category: '주변기기', price: 159000, inStock: true },
+  { id: 12, name: '모니터 암', category: '액세서리', price: 79000, inStock: false },
+];
+
+export function findProduct(id: number): Product | undefined {
+  return PRODUCTS.find((p) => p.id === id);
+}

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -1,8 +1,21 @@
 import Link from 'next/link';
 
-import { type Challenge, DIFFICULTY_LABEL, TRACK_LABEL } from '@/shared/challenges/registry';
+import {
+  type Challenge,
+  DIFFICULTY_LABEL,
+  type HttpMethod,
+  TRACK_LABEL,
+} from '@/shared/challenges/registry';
 
 import { PlaygroundHeader } from './playground-header';
+
+const METHOD_COLOR: Record<HttpMethod, string> = {
+  GET: 'text-primary',
+  POST: 'text-amber-500',
+  PUT: 'text-blue-600',
+  PATCH: 'text-blue-600',
+  DELETE: 'text-system-red',
+};
 
 export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => {
   return (
@@ -42,37 +55,82 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           </ol>
         </section>
 
-        <section className="mt-8">
-          <h2 className="text-lg font-semibold">연습 대상</h2>
-          <p className="text-text-2 mt-2 text-sm leading-relaxed">
-            아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.
-          </p>
-          <Link
-            href={`/sandbox/${challenge.sandboxSlug}`}
-            target="_blank"
-            className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
-          >
-            연습 대상 열기
-          </Link>
+        {challenge.endpoints ? (
+          <section className="mt-8">
+            <h2 className="text-lg font-semibold">연습 대상 API</h2>
+            <p className="text-text-2 mt-2 text-sm leading-relaxed">
+              아래 엔드포인트에 HTTP 요청을 보내 응답 본문과 상태 코드를 검증하세요.
+            </p>
+            <p className="text-text-2 mt-3 text-sm">
+              베이스 경로{' '}
+              <code className="text-primary font-mono text-xs">{challenge.apiBase}</code>
+            </p>
 
-          <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
-            <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
-              <span>셀렉터</span>
-              <span>설명</span>
-            </div>
-            {challenge.selectors.map((s) => (
-              <div
-                key={s.testid}
-                className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
-              >
-                <code className="text-primary font-mono text-xs">
-                  [data-testid=&quot;{s.testid}&quot;]
-                </code>
-                <span className="text-text-2 text-sm">{s.desc}</span>
+            <div className="border-line-2 bg-bg-2 mt-4 overflow-hidden rounded-xl border">
+              <div className="border-line-2 text-text-3 grid grid-cols-[3.5rem_1fr_2.5rem] gap-3 border-b px-5 py-3 text-xs">
+                <span>메서드</span>
+                <span>경로</span>
+                <span>인증</span>
               </div>
-            ))}
-          </div>
-        </section>
+              {challenge.endpoints.map((ep) => (
+                <div
+                  key={`${ep.method} ${ep.path}`}
+                  className="border-line-2 grid grid-cols-[3.5rem_1fr_2.5rem] items-start gap-3 border-b px-5 py-3 text-sm last:border-b-0"
+                >
+                  <span className={`font-mono text-xs font-semibold ${METHOD_COLOR[ep.method]}`}>
+                    {ep.method}
+                  </span>
+                  <span className="flex flex-col gap-1">
+                    <code className="text-text-1 font-mono text-xs break-all">{ep.path}</code>
+                    <span className="text-text-3 text-xs">{ep.desc}</span>
+                  </span>
+                  <span className="text-text-3 text-xs">{ep.auth ? '필요' : '-'}</span>
+                </div>
+              ))}
+            </div>
+
+            {challenge.apiNote && (
+              <p className="border-line-2 bg-bg-2 text-text-2 mt-4 rounded-xl border px-4 py-3 text-xs leading-relaxed">
+                {challenge.apiNote}
+              </p>
+            )}
+          </section>
+        ) : (
+          challenge.sandboxSlug && (
+            <section className="mt-8">
+              <h2 className="text-lg font-semibold">연습 대상</h2>
+              <p className="text-text-2 mt-2 text-sm leading-relaxed">
+                아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져
+                있습니다.
+              </p>
+              <Link
+                href={`/sandbox/${challenge.sandboxSlug}`}
+                target="_blank"
+                className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
+              >
+                연습 대상 열기
+              </Link>
+
+              <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
+                <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
+                  <span>셀렉터</span>
+                  <span>설명</span>
+                </div>
+                {(challenge.selectors ?? []).map((s) => (
+                  <div
+                    key={s.testid}
+                    className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
+                  >
+                    <code className="text-primary font-mono text-xs">
+                      [data-testid=&quot;{s.testid}&quot;]
+                    </code>
+                    <span className="text-text-2 text-sm">{s.desc}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )
+        )}
 
         <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
           <h2 className="text-base font-semibold">자동 채점 제출</h2>


### PR DESCRIPTION
﻿## 개요

FDD 의 API 연습 트랙을 시작한다. 학습자가 브라우저가 아니라 HTTP 요청으로 검증하는 가짜 REST API와, 그 API를 대상으로 하는 챌린지를 추가한다. API 테스트는 라우트 핸들러로 실제 엔드포인트를 제공한다(서버 액션이 아니라 REST 이어야 Postman 등으로 호출 가능).

도구 표준은 트랙별로 정리했다. 자동화 트랙은 Playwright, API 트랙은 Postman 으로 통일했다.

## 변경 사항

- 연습용 상품 REST API를 추가했다. 목록은 페이지·개수 쿼리로 페이지네이션되고 카테고리 필터와 메타데이터를 제공한다. 단건 조회는 없는 경우 404를 준다.
- 로그인 엔드포인트를 추가했다. 유효 자격증명에는 토큰을, 무효에는 401을 준다.
- 상품 생성·삭제는 토큰을 요구한다. 토큰이 없으면 401, 본문 검증 실패는 400, 정상 생성은 201, 정상 삭제는 204를 준다.
- 응답은 예측 가능하도록 상태를 영속하지 않는다. 여러 학습자가 동시에 호출해도 데이터가 흔들리지 않는다.
- API 챌린지를 추가했다. 챌린지 상세가 트랙에 따라 셀렉터 표 또는 엔드포인트 표를 보여주도록 했고, 메서드별 색상과 인증 필요 여부를 함께 노출한다.
- 기존 자동화 챌린지의 도구 표기를 Playwright 로 통일했다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 다섯 엔드포인트를 실제 HTTP 호출로 확인했다. 목록 페이지네이션과 카테고리 필터, 단건과 404, 로그인 성공과 401, 생성의 401·400·201, 삭제의 401·204·404가 모두 의도대로 동작한다.
