### PR TITLE
feat(#234): qaground 챌린지 카테고리 + 목록 그룹화

### DIFF
--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -8,6 +8,8 @@
 
 export type ChallengeTrack = 'automation' | 'manual' | 'api';
 export type ChallengeDifficulty = 'easy' | 'medium' | 'hard';
+/** 주제 카테고리. 트랙(테스트 방식)과 별개인 도메인 축. */
+export type ChallengeCategory = 'auth' | 'forms' | 'data' | 'interaction' | 'async';
 
 export interface ChallengeSelector {
   name: string;
@@ -29,6 +31,7 @@ export interface Challenge {
   slug: string;
   title: string;
   track: ChallengeTrack;
+  category: ChallengeCategory;
   difficulty: ChallengeDifficulty;
   tools: string[];
   summary: string;
@@ -58,11 +61,29 @@ export const DIFFICULTY_LABEL: Record<ChallengeDifficulty, string> = {
   hard: '고급',
 };
 
+export const CATEGORY_LABEL: Record<ChallengeCategory, string> = {
+  auth: '인증',
+  forms: '폼',
+  data: '데이터',
+  interaction: '상호작용',
+  async: '비동기',
+};
+
+/** 목록에 카테고리를 노출할 순서. */
+export const CATEGORY_ORDER: ChallengeCategory[] = [
+  'auth',
+  'forms',
+  'data',
+  'interaction',
+  'async',
+];
+
 export const CHALLENGES: Challenge[] = [
   {
     slug: 'login-basic',
     title: '로그인 폼 자동화',
     track: 'automation',
+    category: 'auth',
     difficulty: 'easy',
     tools: ['Playwright'],
     summary: '유효·무효 자격증명에 따른 로그인 동작을 검증하는 자동화 테스트를 작성하세요.',
@@ -84,6 +105,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'signup-validation',
     title: '회원가입 폼 검증',
     track: 'automation',
+    category: 'forms',
     difficulty: 'easy',
     tools: ['Playwright'],
     summary: '이메일 형식, 비밀번호 규칙, 비밀번호 확인 일치를 검증하는 테스트를 작성하세요.',
@@ -109,6 +131,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'data-table',
     title: '데이터 테이블 검색·정렬·페이지네이션',
     track: 'automation',
+    category: 'data',
     difficulty: 'medium',
     tools: ['Playwright'],
     summary: '검색 필터, 컬럼 정렬, 페이지 이동이 있는 테이블을 검증하는 테스트를 작성하세요.',
@@ -131,6 +154,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'async-load',
     title: '비동기 로딩과 대기',
     track: 'automation',
+    category: 'async',
     difficulty: 'easy',
     tools: ['Playwright'],
     summary: '지연 로딩되는 콘텐츠를 적절히 대기해 검증하는 테스트를 작성하세요.',
@@ -149,6 +173,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'modal',
     title: '모달 다이얼로그 확인',
     track: 'automation',
+    category: 'interaction',
     difficulty: 'easy',
     tools: ['Playwright'],
     summary: '열기·확인·취소가 있는 모달의 흐름을 검증하는 테스트를 작성하세요.',
@@ -170,6 +195,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'drag-and-drop',
     title: '드래그앤드롭 배치',
     track: 'automation',
+    category: 'interaction',
     difficulty: 'medium',
     tools: ['Playwright'],
     summary: 'HTML5 드래그앤드롭으로 위젯을 드롭존에 배치하는 동작을 검증하는 테스트를 작성하세요.',
@@ -188,6 +214,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'file-upload',
     title: '파일 업로드',
     track: 'automation',
+    category: 'interaction',
     difficulty: 'easy',
     tools: ['Playwright'],
     summary: '파일을 선택하고 업로드해 완료 상태를 검증하는 테스트를 작성하세요.',
@@ -207,6 +234,7 @@ export const CHALLENGES: Challenge[] = [
     slug: 'rest-api-products',
     title: '상품 REST API 자동화',
     track: 'api',
+    category: 'data',
     difficulty: 'medium',
     tools: ['Postman'],
     summary:
@@ -237,4 +265,12 @@ export const CHALLENGES: Challenge[] = [
 
 export function getChallenge(slug: string): Challenge | undefined {
   return CHALLENGES.find((c) => c.slug === slug);
+}
+
+/** 카테고리 순서대로 묶은 챌린지 그룹 (빈 카테고리는 제외). */
+export function challengesByCategory(): { category: ChallengeCategory; items: Challenge[] }[] {
+  return CATEGORY_ORDER.map((category) => ({
+    category,
+    items: CHALLENGES.filter((c) => c.category === category),
+  })).filter((group) => group.items.length > 0);
 }

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 
 import {
+  CATEGORY_LABEL,
   type Challenge,
   DIFFICULTY_LABEL,
   type HttpMethod,
@@ -32,6 +33,9 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
         <div className="mb-3 flex items-center gap-2">
           <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
             {TRACK_LABEL[challenge.track]}
+          </span>
+          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+            {CATEGORY_LABEL[challenge.category]}
           </span>
           <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
             {DIFFICULTY_LABEL[challenge.difficulty]}

--- a/apps/qaground/src/view/challenges/challenges-view.tsx
+++ b/apps/qaground/src/view/challenges/challenges-view.tsx
@@ -1,42 +1,66 @@
 import Link from 'next/link';
 
-import { CHALLENGES, DIFFICULTY_LABEL, TRACK_LABEL } from '@/shared/challenges/registry';
+import {
+  CATEGORY_LABEL,
+  type Challenge,
+  DIFFICULTY_LABEL,
+  TRACK_LABEL,
+  challengesByCategory,
+} from '@/shared/challenges/registry';
 
 import { PlaygroundHeader } from './playground-header';
 
+function ChallengeCard({ challenge }: { challenge: Challenge }) {
+  return (
+    <Link
+      href={`/challenges/${challenge.slug}`}
+      className="border-line-2 bg-bg-2 hover:border-line-3 flex h-full flex-col gap-3 rounded-2xl border p-6 transition-colors"
+    >
+      <div className="flex items-center gap-2">
+        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+          {TRACK_LABEL[challenge.track]}
+        </span>
+        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+          {DIFFICULTY_LABEL[challenge.difficulty]}
+        </span>
+      </div>
+      <span className="text-lg font-semibold">{challenge.title}</span>
+      <span className="text-text-2 text-sm leading-relaxed">{challenge.summary}</span>
+    </Link>
+  );
+}
+
 export const ChallengesView = () => {
+  const groups = challengesByCategory();
+
   return (
     <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
       <PlaygroundHeader />
       <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-12 sm:px-6">
-        <header className="mb-10 flex flex-col gap-3">
+        <header className="mb-12 flex flex-col gap-3">
           <h1 className="text-3xl font-bold">연습 챌린지</h1>
           <p className="text-text-2 text-sm">
             연습 대상에 직접 자동화 테스트를 작성해 보세요. 로그인 없이 누구나 이용할 수 있습니다.
           </p>
         </header>
 
-        <ul className="grid gap-4 sm:grid-cols-2">
-          {CHALLENGES.map((c) => (
-            <li key={c.slug}>
-              <Link
-                href={`/challenges/${c.slug}`}
-                className="border-line-2 bg-bg-2 hover:border-line-3 flex h-full flex-col gap-3 rounded-2xl border p-6 transition-colors"
-              >
-                <div className="flex items-center gap-2">
-                  <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
-                    {TRACK_LABEL[c.track]}
-                  </span>
-                  <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
-                    {DIFFICULTY_LABEL[c.difficulty]}
-                  </span>
-                </div>
-                <span className="text-lg font-semibold">{c.title}</span>
-                <span className="text-text-2 text-sm leading-relaxed">{c.summary}</span>
-              </Link>
-            </li>
+        <div className="flex flex-col gap-12">
+          {groups.map((group) => (
+            <section key={group.category}>
+              <h2 className="mb-4 flex items-baseline gap-2 text-lg font-semibold">
+                {CATEGORY_LABEL[group.category]}
+                <span className="text-text-3 text-sm font-normal">{group.items.length}</span>
+              </h2>
+              <ul className="grid gap-4 sm:grid-cols-2">
+                {group.items.map((c) => (
+                  <li key={c.slug}>
+                    <ChallengeCard challenge={c} />
+                  </li>
+                ))}
+              </ul>
+            </section>
           ))}
-        </ul>
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
﻿## 개요

챌린지에 주제 카테고리 축을 추가한다. 트랙(테스트 방식)과 별개로, 어떤 도메인을 연습하는지를 인증·폼·데이터·상호작용·비동기로 분류한다. 목록 화면은 카테고리별 섹션으로 묶어 보여준다.

## 변경 사항

- 챌린지마다 주제 카테고리를 부여했다. 인증, 폼, 데이터, 상호작용, 비동기 다섯 가지다.
- 챌린지 목록을 카테고리별 섹션으로 그룹화하고, 각 섹션 제목 옆에 개수를 표시한다.
- 챌린지 상세 상단에 카테고리 배지를 추가해 트랙·난도와 함께 보여준다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 목록 화면에서 다섯 카테고리가 순서대로 묶여 노출되고 개수가 맞는 것을 로컬에서 확인했다.
