### PR TITLE
feat(#234): qaground 챌린지 카테고리 아사이드 + 쿼리스트링 필터

### DIFF
--- a/apps/qaground/app/challenges/page.tsx
+++ b/apps/qaground/app/challenges/page.tsx
@@ -7,6 +7,11 @@ export const metadata: Metadata = {
   description: 'QA 자동화 연습 챌린지. 로그인 없이 연습 대상에 직접 테스트를 작성해 보세요.',
 };
 
-export default function ChallengesPage() {
-  return <ChallengesView />;
+export default async function ChallengesPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ category?: string }>;
+}) {
+  const { category } = await searchParams;
+  return <ChallengesView selectedCategory={category} />;
 }

--- a/apps/qaground/src/view/challenges/challenges-view.tsx
+++ b/apps/qaground/src/view/challenges/challenges-view.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import {
   CATEGORY_LABEL,
   type Challenge,
+  type ChallengeCategory,
   DIFFICULTY_LABEL,
   TRACK_LABEL,
   challengesByCategory,
@@ -30,36 +31,75 @@ function ChallengeCard({ challenge }: { challenge: Challenge }) {
   );
 }
 
-export const ChallengesView = () => {
+type Selected = ChallengeCategory | 'all';
+
+/**
+ * 선택 카테고리는 쿼리스트링(`?category=`)으로 받는다. 필터된 화면을 그대로
+ * 링크로 공유·북마크할 수 있고, 아사이드 항목은 실제 링크라 새 탭·복사가 된다.
+ */
+export const ChallengesView = ({ selectedCategory }: { selectedCategory?: string }) => {
   const groups = challengesByCategory();
+  const total = groups.reduce((n, g) => n + g.items.length, 0);
+
+  const isValid = groups.some((g) => g.category === selectedCategory);
+  const selected: Selected = isValid ? (selectedCategory as ChallengeCategory) : 'all';
+  const visible = selected === 'all' ? groups : groups.filter((g) => g.category === selected);
+
+  const navItem = (key: Selected, label: string, count: number) => {
+    const active = selected === key;
+    return (
+      <Link
+        key={key}
+        href={key === 'all' ? '/challenges' : `/challenges?category=${key}`}
+        scroll={false}
+        aria-current={active ? 'true' : undefined}
+        className={[
+          'flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm whitespace-nowrap transition-colors',
+          active ? 'bg-bg-3 text-text-1 font-medium' : 'text-text-2 hover:bg-bg-2',
+        ].join(' ')}
+      >
+        <span>{label}</span>
+        <span className="text-text-3 text-xs">{count}</span>
+      </Link>
+    );
+  };
 
   return (
     <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
       <PlaygroundHeader />
       <main className="mx-auto w-full max-w-5xl flex-1 px-4 py-12 sm:px-6">
-        <header className="mb-12 flex flex-col gap-3">
+        <header className="mb-10 flex flex-col gap-3">
           <h1 className="text-3xl font-bold">연습 챌린지</h1>
           <p className="text-text-2 text-sm">
             연습 대상에 직접 자동화 테스트를 작성해 보세요. 로그인 없이 누구나 이용할 수 있습니다.
           </p>
         </header>
 
-        <div className="flex flex-col gap-12">
-          {groups.map((group) => (
-            <section key={group.category}>
-              <h2 className="mb-4 flex items-baseline gap-2 text-lg font-semibold">
-                {CATEGORY_LABEL[group.category]}
-                <span className="text-text-3 text-sm font-normal">{group.items.length}</span>
-              </h2>
-              <ul className="grid gap-4 sm:grid-cols-2">
-                {group.items.map((c) => (
-                  <li key={c.slug}>
-                    <ChallengeCard challenge={c} />
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+        <div className="flex flex-col gap-8 sm:flex-row sm:gap-10">
+          <aside className="sm:w-44 sm:shrink-0">
+            <nav className="flex gap-1 overflow-x-auto sm:sticky sm:top-24 sm:flex-col sm:overflow-visible">
+              {navItem('all', '전체', total)}
+              {groups.map((g) => navItem(g.category, CATEGORY_LABEL[g.category], g.items.length))}
+            </nav>
+          </aside>
+
+          <div className="flex flex-1 flex-col gap-12">
+            {visible.map((group) => (
+              <section key={group.category}>
+                <h2 className="mb-4 flex items-baseline gap-2 text-lg font-semibold">
+                  {CATEGORY_LABEL[group.category]}
+                  <span className="text-text-3 text-sm font-normal">{group.items.length}</span>
+                </h2>
+                <ul className="grid gap-4 sm:grid-cols-2">
+                  {group.items.map((c) => (
+                    <li key={c.slug}>
+                      <ChallengeCard challenge={c} />
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ))}
+          </div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
﻿## 개요

챌린지 목록 왼쪽에 카테고리 아사이드를 두어 카테고리를 선택할 수 있게 한다. 선택 상태는 주소의 쿼리스트링으로 표현해, 필터된 화면을 그대로 링크로 공유하거나 북마크할 수 있다.

## 변경 사항

- 챌린지 목록 왼쪽에 카테고리 목록 아사이드를 추가했다. 전체와 각 카테고리를 개수와 함께 보여주고, 현재 선택을 강조한다.
- 카테고리 선택을 주소의 쿼리 값으로 다룬다. 특정 카테고리를 고른 화면의 주소를 그대로 공유하면 같은 필터로 열린다.
- 아사이드 항목을 실제 링크로 만들어 새 탭 열기와 주소 복사가 가능하게 했다. 선택 시 화면이 위로 튀지 않도록 했다.
- 선택이 없으면 전체를 카테고리별 구획으로, 선택이 있으면 해당 카테고리만 보여준다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 전체 화면과 카테고리를 지정한 주소를 로컬에서 확인했다. 아사이드 강조와 본문 필터가 주소와 일치한다.
