### PR TITLE
feat(#242): qaground 베타 매직링크 토큰·검증·/beta (메일 발송 제외)

### DIFF
--- a/apps/qaground/app/api/magic/verify/route.ts
+++ b/apps/qaground/app/api/magic/verify/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { setBetaAccessCookie } from '@/shared/magic-link/cookie';
+import { verifyMagicToken } from '@/shared/magic-link/token';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+/**
+ * 매직링크 검증 진입점. 이메일로 받은 일회용 링크 클릭 시 호출된다.
+ *
+ * 토큰 검증 → 베타 접근 쿠키 주입 → /beta 리다이렉트.
+ * 검증 실패(없음/무효/만료)는 /beta?error=... 로 리다이렉트해 안내한다.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get('token');
+  const origin = url.origin;
+
+  if (!token) {
+    return NextResponse.redirect(`${origin}/beta?error=missing`);
+  }
+
+  const result = await verifyMagicToken(token);
+  if (!result.valid) {
+    return NextResponse.redirect(`${origin}/beta?error=${result.error.toLowerCase()}`);
+  }
+
+  await setBetaAccessCookie(token);
+  return NextResponse.redirect(`${origin}/beta`);
+}

--- a/apps/qaground/app/api/waitlist/route.ts
+++ b/apps/qaground/app/api/waitlist/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { createMagicToken } from '@/shared/magic-link/token';
 import { getDatabase, qagroundWaitlist } from '@testea/db';
 import { z } from 'zod';
 
@@ -41,7 +42,18 @@ export async function POST(request: Request) {
       .onConflictDoNothing({ target: qagroundWaitlist.email })
       .returning({ id: qagroundWaitlist.id });
 
-    return NextResponse.json({ ok: true, alreadyJoined: inserted.length === 0 });
+    // 매직링크 토큰 발급. 메일 발송 인프라는 후속(#242) — 현재는 stub:
+    // 서버 로그에 링크를 남기고, 비프로덕션에서만 응답에 노출해 폐루프를 확인한다.
+    const token = await createMagicToken(parsed.data.email);
+    const origin = new URL(request.url).origin;
+    const magicLink = `${origin}/api/magic/verify?token=${token}`;
+    console.info('[waitlist] 매직링크(stub, 메일 발송 전):', magicLink);
+
+    return NextResponse.json({
+      ok: true,
+      alreadyJoined: inserted.length === 0,
+      ...(process.env.NODE_ENV !== 'production' ? { devMagicLink: magicLink } : {}),
+    });
   } catch (error) {
     console.error('[waitlist] 대기자 저장 실패', error);
     return NextResponse.json({ ok: false, error: 'server_error' }, { status: 500 });

--- a/apps/qaground/app/beta/page.tsx
+++ b/apps/qaground/app/beta/page.tsx
@@ -1,0 +1,22 @@
+import { getBetaAccessCookie } from '@/shared/magic-link/cookie';
+import { verifyMagicToken } from '@/shared/magic-link/token';
+import { BetaView } from '@/view/beta';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * 베타 페이지. 쿠키의 매직링크 토큰을 검증해 접근을 가른다.
+ * 유효하면 베타 대시보드(대기 현황·소식), 아니면 안내.
+ */
+export default async function BetaPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error } = await searchParams;
+  const token = await getBetaAccessCookie();
+  const result = token ? await verifyMagicToken(token) : null;
+  const email = result?.valid ? result.email : null;
+
+  return <BetaView email={email} error={error ?? null} />;
+}

--- a/apps/qaground/src/shared/magic-link/cookie.ts
+++ b/apps/qaground/src/shared/magic-link/cookie.ts
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers';
+
+/**
+ * 베타 접근 쿠키. 매직링크 검증 후 토큰을 httpOnly 쿠키로 주입하고,
+ * /beta 에서 이 쿠키의 토큰을 다시 검증해 접근을 가른다.
+ */
+const COOKIE_NAME = 'qaground_beta_access';
+/** 토큰 만료(30분)와 동일하게. */
+const MAX_AGE = 30 * 60;
+
+export async function setBetaAccessCookie(token: string): Promise<void> {
+  const store = await cookies();
+  store.set(COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: MAX_AGE,
+  });
+}
+
+export async function getBetaAccessCookie(): Promise<string | undefined> {
+  const store = await cookies();
+  return store.get(COOKIE_NAME)?.value;
+}
+
+export async function clearBetaAccessCookie(): Promise<void> {
+  const store = await cookies();
+  store.delete(COOKIE_NAME);
+}

--- a/apps/qaground/src/shared/magic-link/token.test.ts
+++ b/apps/qaground/src/shared/magic-link/token.test.ts
@@ -1,0 +1,44 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { createMagicToken, verifyMagicToken } from './token';
+
+beforeAll(() => {
+  process.env.QAGROUND_MAGIC_SECRET = 'test-secret-for-magic-link';
+});
+
+describe('magic-link token', () => {
+  it('발급한 토큰을 검증하면 이메일을 돌려준다', async () => {
+    const token = await createMagicToken('user@example.com');
+    const result = await verifyMagicToken(token);
+    expect(result).toEqual({ valid: true, email: 'user@example.com' });
+  });
+
+  it('만료된 토큰은 EXPIRED 로 거부된다', async () => {
+    const token = await createMagicToken('user@example.com', -1);
+    const result = await verifyMagicToken(token);
+    expect(result).toEqual({ valid: false, error: 'EXPIRED' });
+  });
+
+  it('서명이 변조된 토큰은 INVALID 로 거부된다', async () => {
+    const token = await createMagicToken('user@example.com');
+    const lastChar = token.slice(-1);
+    const tampered = token.slice(0, -1) + (lastChar === 'A' ? 'B' : 'A');
+    const result = await verifyMagicToken(tampered);
+    expect(result.valid).toBe(false);
+  });
+
+  it('페이로드만 바꾸고 서명을 유지하면 INVALID (위조 차단)', async () => {
+    const real = await createMagicToken('user@example.com');
+    const forged = await createMagicToken('attacker@evil.com');
+    const [header, , signature] = real.split('.');
+    const forgedPayload = forged.split('.')[1];
+    const tampered = `${header}.${forgedPayload}.${signature}`;
+    const result = await verifyMagicToken(tampered);
+    expect(result.valid).toBe(false);
+  });
+
+  it('형식이 틀린 문자열은 INVALID', async () => {
+    const result = await verifyMagicToken('not-a-token');
+    expect(result).toEqual({ valid: false, error: 'INVALID' });
+  });
+});

--- a/apps/qaground/src/shared/magic-link/token.ts
+++ b/apps/qaground/src/shared/magic-link/token.ts
@@ -1,0 +1,108 @@
+/**
+ * qaground 베타 매직링크 토큰 (HMAC-SHA256 JWT).
+ *
+ * apps/web 의 access-token(`src/access/lib/access-token.ts`) 패턴을 그대로 따르되,
+ * 페이로드를 이메일 기반으로 한다. 계정(social-login) 정식 도입 전, 베타 신청자가
+ * 이메일로 받은 일회용 링크로만 진입(소유 증명)하도록 하는 용도.
+ *
+ * 시크릿은 `QAGROUND_MAGIC_SECRET`(apps/qaground/.env.local) 필요.
+ */
+
+const TOKEN_TYPE = 'qaground_beta' as const;
+/** 매직링크 기본 만료: 30분 (단기·일회성. 엄격한 일회용 used 추적은 후속). */
+const DEFAULT_EXPIRES_IN = 30 * 60;
+
+export type MagicTokenPayload = {
+  type: typeof TOKEN_TYPE;
+  email: string;
+  issuedAt: number;
+  expiresAt: number;
+};
+
+function base64UrlEncode(str: string): string {
+  return Buffer.from(str, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64ToBase64Url(base64: string): string {
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(str: string): string {
+  let base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  while (base64.length % 4) base64 += '=';
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+async function createSignature(data: string, secret: string): Promise<string> {
+  const { createHmac } = await import('crypto');
+  return base64ToBase64Url(createHmac('sha256', secret).update(data).digest('base64'));
+}
+
+async function timingSafeStringEqual(a: string, b: string): Promise<boolean> {
+  const { timingSafeEqual } = await import('crypto');
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function getSecret(): string {
+  const secret = process.env.QAGROUND_MAGIC_SECRET;
+  if (!secret) {
+    throw new Error(
+      'QAGROUND_MAGIC_SECRET environment variable is required. ' +
+        'Set it in apps/qaground/.env.local for development.'
+    );
+  }
+  return secret;
+}
+
+/** 이메일 기반 매직링크 토큰 발급. */
+export async function createMagicToken(
+  email: string,
+  expiresIn: number = DEFAULT_EXPIRES_IN
+): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  const payload: MagicTokenPayload = {
+    type: TOKEN_TYPE,
+    email,
+    issuedAt: now,
+    expiresAt: now + expiresIn,
+  };
+  const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64UrlEncode(JSON.stringify(payload));
+  const signature = await createSignature(`${header}.${body}`, getSecret());
+  return `${header}.${body}.${signature}`;
+}
+
+export type MagicVerifyResult =
+  | { valid: true; email: string }
+  | { valid: false; error: 'INVALID' | 'EXPIRED' };
+
+/** 매직링크 토큰 검증 (서명·타입·만료). */
+export async function verifyMagicToken(token: string): Promise<MagicVerifyResult> {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return { valid: false, error: 'INVALID' };
+
+    const [header, body, signature] = parts;
+    const expected = await createSignature(`${header}.${body}`, getSecret());
+    if (!(await timingSafeStringEqual(signature, expected))) {
+      return { valid: false, error: 'INVALID' };
+    }
+
+    const payload = JSON.parse(base64UrlDecode(body)) as MagicTokenPayload;
+    if (payload.type !== TOKEN_TYPE) return { valid: false, error: 'INVALID' };
+
+    const now = Math.floor(Date.now() / 1000);
+    if (payload.expiresAt < now) return { valid: false, error: 'EXPIRED' };
+
+    return { valid: true, email: payload.email };
+  } catch {
+    return { valid: false, error: 'INVALID' };
+  }
+}

--- a/apps/qaground/src/view/beta/beta-view.tsx
+++ b/apps/qaground/src/view/beta/beta-view.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+
+type BetaViewProps = {
+  /** 매직링크 검증으로 확인된 이메일. null 이면 접근 권한 없음. */
+  email: string | null;
+  /** 검증 실패 사유(missing/invalid/expired). */
+  error: string | null;
+};
+
+const ERROR_MESSAGES: Record<string, string> = {
+  missing: '접근 토큰이 없습니다. 이메일로 받은 매직링크로 들어와 주세요.',
+  invalid: '유효하지 않은 링크입니다. 베타 신청을 다시 해주세요.',
+  expired: '링크가 만료되었습니다(30분). 베타 신청을 다시 하면 새 링크를 보내드립니다.',
+};
+
+export function BetaView({ email, error }: BetaViewProps) {
+  if (!email) {
+    return (
+      <main className="bg-bg-1 flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center text-white">
+        <h1 className="text-2xl font-bold">QAground 비공개 베타</h1>
+        <p className="max-w-md text-white/70">
+          {error
+            ? (ERROR_MESSAGES[error] ?? '접근할 수 없습니다.')
+            : '이메일로 받은 매직링크로 접근해 주세요.'}
+        </p>
+        <Link href="/" className="rounded-lg bg-[#0bb57f] px-5 py-2 font-medium text-black">
+          홈으로 가기
+        </Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="bg-bg-1 flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center text-white">
+      <h1 className="text-2xl font-bold">QAground 베타에 오신 것을 환영합니다</h1>
+      <p className="text-white/80">
+        <span className="font-semibold text-[#0bb57f]">{email}</span> 님, 비공개 베타 대기 명단에
+        등록되어 있습니다.
+      </p>
+      <ul className="space-y-2 text-sm text-white/60">
+        <li>출시되면 이 이메일로 가장 먼저 안내해 드립니다.</li>
+        <li>대기 현황·진행 소식은 준비되는 대로 이 페이지에 표시됩니다.</li>
+      </ul>
+    </main>
+  );
+}

--- a/apps/qaground/src/view/beta/index.ts
+++ b/apps/qaground/src/view/beta/index.ts
@@ -1,0 +1,1 @@
+export { BetaView } from './beta-view';


### PR DESCRIPTION
## 배경

qaground 비공개 베타 신청(#238)에 매직링크 접근을 얹는다. 계정 체계 도입 전, 신청자가 이메일로 받은 일회용 링크로만 베타 페이지에 진입하도록 한다. 이슈 #242.

## 변경 사항

- 베타 신청 시 신청한 이메일로 단기 만료(30분) 매직링크 토큰을 발급한다. 토큰은 서명된 형식이라 이메일 주소만으로는 진입할 수 없고, 링크 소유를 증명해야 들어올 수 있다.
- 매직링크를 클릭하면 토큰을 검증해 접근 쿠키를 주입하고 베타 페이지로 보낸다. 만료·위조·형식 오류는 사유별 안내 화면으로 떨어진다.
- 베타 페이지는 쿠키를 다시 검증해, 유효하면 환영과 대기 현황을, 아니면 안내를 보여준다.
- 메일 발송 인프라는 이번 범위에서 제외했다. 개발 중에는 생성된 링크를 서버 로그와 비프로덕션 응답으로만 노출해 폐루프를 확인할 수 있게 했다.

## 검증

- 빌드·린트·포맷 통과
- 토큰 발급·검증 단위 테스트(유효·만료·변조·위조 차단·형식 오류) 5건 통과

## 남은 작업

- 메일 발송 서비스 연동(보류)
- 운영 배포용 시크릿 주입
- 일회용 토큰 추적(현재는 단기 만료로 대체)