### PR TITLE
feat(#234): qaground 랜딩→/challenges 연결 + Manual 챌린지 추가

### DIFF
--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -261,6 +261,39 @@ export const CHALLENGES: Challenge[] = [
     apiNote:
       '데모 계정 tester@qaground.dev / qaground123 로 로그인해 토큰을 받고, 보호된 요청에 Authorization: Bearer <token> 헤더를 붙이세요.',
   },
+  {
+    slug: 'bug-hunt-order',
+    title: '버그 찾기: 주문 폼',
+    track: 'manual',
+    category: 'forms',
+    difficulty: 'medium',
+    tools: ['Testea'],
+    summary:
+      '주문 폼에 의도적으로 심은 결함을 탐색적 테스트로 찾아내세요. 자동화가 아니라 직접 살펴보는 수동 테스트입니다.',
+    requirement: [
+      '합계 금액이 단가·수량·배송비와 맞는지 계산을 확인하세요.',
+      '수량 입력에 0이나 음수 같은 비정상 값을 넣어 보세요.',
+      '받는 사람을 비운 채로 주문이 완료되는지 확인하세요.',
+      '발견한 결함을 재현 절차·기대 결과·실제 결과로 정리해 보세요.',
+    ],
+    sandboxSlug: 'order-form',
+  },
+  {
+    slug: 'test-design-password-reset',
+    title: '테스트 케이스 설계: 비밀번호 재설정',
+    track: 'manual',
+    category: 'auth',
+    difficulty: 'medium',
+    tools: ['Testea'],
+    summary:
+      '비밀번호 재설정 기능의 테스트 케이스를 설계하세요. 정상·예외·경계 시나리오를 빠짐없이 도출하는 수동 테스트 연습입니다.',
+    requirement: [
+      '기능 규칙: 가입된 이메일로 재설정 링크를 발송하고, 링크는 24시간 동안만 유효하며, 새 비밀번호는 8자 이상이어야 한다.',
+      '정상 흐름과 함께 만료된 링크, 이미 사용한 링크, 미가입 이메일, 비밀번호 규칙 위반을 케이스로 도출하세요.',
+      '동등 분할과 경계값 분석을 적용해 입력 케이스를 정리하세요.',
+      '각 케이스를 사전 조건·절차·기대 결과로 작성해 보세요.',
+    ],
+  },
 ];
 
 export function getChallenge(slug: string): Challenge | undefined {

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -104,8 +104,9 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             <section className="mt-8">
               <h2 className="text-lg font-semibold">연습 대상</h2>
               <p className="text-text-2 mt-2 text-sm leading-relaxed">
-                아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져
-                있습니다.
+                {challenge.selectors?.length
+                  ? '아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.'
+                  : '아래 페이지를 열어 직접 살펴보며 결함을 찾거나 테스트를 진행하세요.'}
               </p>
               <Link
                 href={`/sandbox/${challenge.sandboxSlug}`}
@@ -115,31 +116,37 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
                 연습 대상 열기
               </Link>
 
-              <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
-                <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
-                  <span>셀렉터</span>
-                  <span>설명</span>
-                </div>
-                {(challenge.selectors ?? []).map((s) => (
-                  <div
-                    key={s.testid}
-                    className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
-                  >
-                    <code className="text-primary font-mono text-xs">
-                      [data-testid=&quot;{s.testid}&quot;]
-                    </code>
-                    <span className="text-text-2 text-sm">{s.desc}</span>
+              {challenge.selectors?.length ? (
+                <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
+                  <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
+                    <span>셀렉터</span>
+                    <span>설명</span>
                   </div>
-                ))}
-              </div>
+                  {challenge.selectors.map((s) => (
+                    <div
+                      key={s.testid}
+                      className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
+                    >
+                      <code className="text-primary font-mono text-xs">
+                        [data-testid=&quot;{s.testid}&quot;]
+                      </code>
+                      <span className="text-text-2 text-sm">{s.desc}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
             </section>
           )
         )}
 
         <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
-          <h2 className="text-base font-semibold">자동 채점 제출</h2>
+          <h2 className="text-base font-semibold">
+            {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
+          </h2>
           <p className="text-text-3 mt-2 text-sm leading-relaxed">
-            작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.
+            {challenge.track === 'manual'
+              ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
+              : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
           </p>
         </section>
       </main>

--- a/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
+++ b/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { WaitlistForm } from './waitlist-form';
 
 export const BetaLandingView = () => {
@@ -43,6 +45,12 @@ export const BetaLandingView = () => {
           곧 공개됩니다. 가장 먼저 연습을 시작하고 싶다면 베타를 신청하세요.
         </p>
         <WaitlistForm />
+        <Link
+          href="/challenges"
+          className="text-text-3 hover:text-text-1 text-sm transition-colors"
+        >
+          또는 지금 연습 챌린지 둘러보기 →
+        </Link>
       </main>
 
       {/* 푸터 */}

--- a/apps/qaground/src/view/landing/landing-header.tsx
+++ b/apps/qaground/src/view/landing/landing-header.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 const NAV = [
   { label: '연습', href: '#playground' },
   { label: '작동 방식', href: '#how' },
@@ -32,12 +34,12 @@ export const LandingHeader = () => {
               {item.label}
             </a>
           ))}
-          <a
-            href="#playground"
+          <Link
+            href="/challenges"
             className="bg-primary rounded-button hover:bg-primary/90 active:bg-primary/80 ml-1 inline-flex h-9 items-center justify-center px-4 text-sm font-medium text-white transition-colors"
           >
             연습 시작하기
-          </a>
+          </Link>
         </nav>
       </div>
     </header>

--- a/apps/qaground/src/view/landing/landing-hero.tsx
+++ b/apps/qaground/src/view/landing/landing-hero.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 const DIFFERENTIATORS = [
   '연습 페이지 제공',
   '내 코드 실행',
@@ -35,12 +37,12 @@ export const LandingHero = () => {
         </p>
 
         <div className="animate-fade-in-up-delay-2 flex flex-col items-center gap-3 sm:flex-row">
-          <a
-            href="#playground"
+          <Link
+            href="/challenges"
             className="bg-primary rounded-button h-button-lg hover:bg-primary/90 active:bg-primary/80 inline-flex w-full items-center justify-center px-8 font-medium text-white transition-colors sm:w-auto"
           >
             연습 시작하기
-          </a>
+          </Link>
           <a
             href="#how"
             className="border-line-3 rounded-button h-button-lg text-text-1 hover:bg-bg-3 inline-flex w-full items-center justify-center border px-8 font-medium transition-colors sm:w-auto"

--- a/apps/qaground/src/view/landing/landing-view.tsx
+++ b/apps/qaground/src/view/landing/landing-view.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { LandingAssessment } from './landing-assessment';
 import { LandingComparison } from './landing-comparison';
 import { LandingFooter } from './landing-footer';
@@ -27,12 +29,12 @@ export const LandingView = () => {
             <p className="text-text-2 text-sm leading-relaxed sm:text-base">
               연습 페이지를 고르고, 테스트를 작성해 제출하면 바로 채점 결과를 받습니다.
             </p>
-            <a
-              href="#playground"
+            <Link
+              href="/challenges"
               className="bg-primary rounded-button h-button-lg hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-8 font-medium text-white transition-colors"
             >
               연습 시작하기
-            </a>
+            </Link>
           </div>
         </section>
 

--- a/apps/qaground/src/view/sandbox/index.ts
+++ b/apps/qaground/src/view/sandbox/index.ts
@@ -6,6 +6,7 @@ import { DndSandbox } from './dnd-sandbox';
 import { FileUploadSandbox } from './file-upload-sandbox';
 import { LoginSandbox } from './login-sandbox';
 import { ModalSandbox } from './modal-sandbox';
+import { OrderFormSandbox } from './order-form-sandbox';
 import { SignupSandbox } from './signup-sandbox';
 
 /** 샌드박스 슬러그 → 테스트 대상 컴포넌트. 챌린지 레지스트리의 sandboxSlug 와 매칭. */
@@ -17,4 +18,5 @@ export const SANDBOXES: Record<string, ComponentType> = {
   modal: ModalSandbox,
   'drag-and-drop': DndSandbox,
   'file-upload': FileUploadSandbox,
+  'order-form': OrderFormSandbox,
 };

--- a/apps/qaground/src/view/sandbox/order-form-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/order-form-sandbox.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+
+const UNIT_PRICE = 12000;
+const SHIPPING = 3000;
+
+/**
+ * 주문 폼 샌드박스 (Manual 트랙 · 탐색적 테스트 대상).
+ *
+ * 의도적으로 결함을 심어 두었다. 탐색적 테스트로 찾는 연습용이다.
+ * - 결함 1: 합계가 배송비를 더하지 않는다 (계산 오류).
+ * - 결함 2: 수량에 0·음수를 넣을 수 있다 (입력 제한 누락).
+ * - 결함 3: 이름을 비워도 주문이 완료된다 (필수 입력 검증 누락).
+ */
+export const OrderFormSandbox = () => {
+  const [name, setName] = useState('');
+  const [qty, setQty] = useState(1);
+  const [ordered, setOrdered] = useState(false);
+
+  // 결함 1: 배송비 누락
+  const total = UNIT_PRICE * qty;
+
+  const placeOrder = () => {
+    // 결함 3: 이름 필수 검증 없음
+    setOrdered(true);
+  };
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-sm rounded-2xl border p-8">
+        <h1 className="mb-5 text-xl font-bold">주문</h1>
+
+        {ordered ? (
+          <p
+            data-testid="order-success"
+            role="status"
+            className="border-primary/30 bg-primary/10 text-primary rounded-xl border px-4 py-3 text-sm font-medium"
+          >
+            주문이 완료되었습니다.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">받는 사람</span>
+              <input
+                data-testid="order-name"
+                type="text"
+                value={name}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+                className="border-line-3 bg-bg-3 rounded-button text-text-1 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">수량</span>
+              {/* 결함 2: min 제한 없음 → 0·음수 허용 */}
+              <input
+                data-testid="order-qty"
+                type="number"
+                value={qty}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setQty(Number(e.target.value))
+                }
+                className="border-line-3 bg-bg-3 rounded-button text-text-1 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none"
+              />
+            </label>
+
+            <dl className="border-line-2 mt-1 flex flex-col gap-1.5 border-t pt-4 text-sm">
+              <div className="text-text-2 flex justify-between">
+                <dt>단가</dt>
+                <dd>{UNIT_PRICE.toLocaleString()}원</dd>
+              </div>
+              <div className="text-text-2 flex justify-between">
+                <dt>배송비</dt>
+                <dd>{SHIPPING.toLocaleString()}원</dd>
+              </div>
+              <div className="text-text-1 flex justify-between font-semibold">
+                <dt>합계</dt>
+                <dd data-testid="order-total">{total.toLocaleString()}원</dd>
+              </div>
+            </dl>
+
+            <button
+              data-testid="order-submit"
+              type="button"
+              onClick={placeOrder}
+              className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-1 inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-colors"
+            >
+              주문하기
+            </button>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+};


### PR DESCRIPTION
﻿## 개요

랜딩에서 연습 챌린지로 이어지는 동선을 추가하고, 자동화에 치우쳐 있던 챌린지에 수동 테스트(Manual) 트랙을 더한다.

## 변경 사항

- 홈 베타 스플래시와 정식 랜딩의 시작 버튼이 연습 챌린지 목록으로 이어지도록 연결했다. 홈에는 지금 바로 둘러보는 보조 링크도 더했다.
- 수동 테스트 챌린지를 두 가지 추가했다. 하나는 주문 폼에 의도적으로 심은 결함을 탐색적으로 찾는 연습이고, 다른 하나는 비밀번호 재설정 기능의 테스트 케이스를 설계하는 연습이다.
- 결함을 심은 주문 폼 연습 대상을 추가했다. 합계 계산, 수량 입력 제한, 필수 입력 검증에 의도적 결함이 있다.
- 챌린지 상세가 트랙 성격에 맞게 보이도록 다듬었다. 셀렉터 표는 자동화 챌린지에서만 보여주고, 수동 챌린지는 직접 살펴보라는 안내와 그에 맞는 제출 안내를 보여준다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 홈과 랜딩의 연결, 수동 챌린지 상세 화면, 주문 폼의 세 가지 결함(합계 오류·음수 수량 허용·빈 이름 주문 완료)을 로컬 브라우저에서 확인했다.
