### PR TITLE
feat(#234): qaground 버그찾기 결함 리포트 제출 + 정답·피드백

### DIFF
--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -53,6 +53,8 @@ export interface Challenge {
   endpoints?: ApiEndpoint[];
   /** API 트랙: 데모 계정·토큰 등 안내. */
   apiNote?: string;
+  /** Manual(버그 찾기): 리포트 제출 후 공개할 정답(의도적으로 심은 결함) 목록. */
+  knownDefects?: { title: string; detail: string }[];
 }
 
 export const TRACK_LABEL: Record<ChallengeTrack, string> = {
@@ -277,14 +279,29 @@ export const CHALLENGES: Challenge[] = [
     difficulty: 'medium',
     tools: ['Testea'],
     summary:
-      '주문 폼에 의도적으로 심은 결함을 탐색적 테스트로 찾아내세요. 자동화가 아니라 직접 살펴보는 수동 테스트입니다.',
+      '주문 폼에 의도적으로 심은 결함을 탐색적 테스트로 찾고, 결함 리포트를 작성해 제출하세요. 제출하면 정답과 피드백을 보여줍니다.',
     requirement: [
       '합계 금액이 단가·수량·배송비와 맞는지 계산을 확인하세요.',
       '수량 입력에 0이나 음수 같은 비정상 값을 넣어 보세요.',
       '받는 사람을 비운 채로 주문이 완료되는지 확인하세요.',
-      '발견한 결함을 재현 절차·기대 결과·실제 결과로 정리해 보세요.',
+      '발견한 결함을 아래 양식(재현 절차·기대 결과·실제 결과)으로 작성해 제출하세요.',
     ],
     sandboxSlug: 'order-form',
+    knownDefects: [
+      {
+        title: '합계가 배송비를 더하지 않음',
+        detail:
+          '합계가 단가 × 수량만 계산하고 배송비(3,000원)를 빠뜨린다. 수량 1일 때 15,000원이어야 하지만 12,000원으로 표시된다.',
+      },
+      {
+        title: '수량에 0·음수 입력 허용',
+        detail: '수량 입력에 최소값 제한이 없어 0이나 음수를 넣을 수 있고, 합계가 음수가 된다.',
+      },
+      {
+        title: '받는 사람 필수 입력 검증 누락',
+        detail: '받는 사람을 비운 채로도 주문하기가 성공한다. 필수 입력 검증이 없다.',
+      },
+    ],
   },
   {
     slug: 'test-design-password-reset',
@@ -317,23 +334,6 @@ export const CHALLENGES: Challenge[] = [
       '경계값(19,999원·20,000원)을 분리해 케이스를 만드세요.',
       '각 케이스를 제목·사전조건·절차·입력·기대 결과로 정리하세요.',
     ],
-  },
-  {
-    slug: 'bug-report-order',
-    title: '버그 리포트 작성: 주문 폼',
-    track: 'manual',
-    category: 'fundamentals',
-    difficulty: 'easy',
-    tools: ['Testea'],
-    summary:
-      '주문 폼에서 발견한 결함 하나를 골라, 다른 사람이 그대로 재현할 수 있는 정식 버그 리포트로 작성하세요.',
-    requirement: [
-      '연습 대상에서 결함을 하나 재현하세요.',
-      '제목은 무엇이·어디서·어떻게 잘못되는지 한 줄로 요약하세요.',
-      '재현 절차를 번호로 적고, 기대 결과와 실제 결과를 분리해 작성하세요.',
-      '심각도·우선순위와 환경(브라우저·화면)을 덧붙이세요.',
-    ],
-    sandboxSlug: 'order-form',
   },
   {
     slug: 'exploratory-charter',

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -8,6 +8,7 @@ import {
   TRACK_LABEL,
 } from '@/shared/challenges/registry';
 
+import { DefectReportExercise } from './defect-report-exercise';
 import { PlaygroundHeader } from './playground-header';
 
 const METHOD_COLOR: Record<HttpMethod, string> = {
@@ -99,56 +100,61 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
               </p>
             )}
           </section>
-        ) : (
-          challenge.sandboxSlug && (
-            <section className="mt-8">
-              <h2 className="text-lg font-semibold">연습 대상</h2>
-              <p className="text-text-2 mt-2 text-sm leading-relaxed">
-                {challenge.selectors?.length
-                  ? '아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.'
-                  : '아래 페이지를 열어 직접 살펴보며 결함을 찾거나 테스트를 진행하세요.'}
-              </p>
-              <Link
-                href={`/sandbox/${challenge.sandboxSlug}`}
-                target="_blank"
-                className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
-              >
-                연습 대상 열기
-              </Link>
+        ) : challenge.knownDefects ? (
+          <DefectReportExercise
+            sandboxSlug={challenge.sandboxSlug}
+            knownDefects={challenge.knownDefects}
+          />
+        ) : challenge.sandboxSlug ? (
+          <section className="mt-8">
+            <h2 className="text-lg font-semibold">연습 대상</h2>
+            <p className="text-text-2 mt-2 text-sm leading-relaxed">
+              {challenge.selectors?.length
+                ? '아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.'
+                : '아래 페이지를 열어 직접 살펴보며 결함을 찾거나 테스트를 진행하세요.'}
+            </p>
+            <Link
+              href={`/sandbox/${challenge.sandboxSlug}`}
+              target="_blank"
+              className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
+            >
+              연습 대상 열기
+            </Link>
 
-              {challenge.selectors?.length ? (
-                <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
-                  <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
-                    <span>셀렉터</span>
-                    <span>설명</span>
-                  </div>
-                  {challenge.selectors.map((s) => (
-                    <div
-                      key={s.testid}
-                      className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
-                    >
-                      <code className="text-primary font-mono text-xs">
-                        [data-testid=&quot;{s.testid}&quot;]
-                      </code>
-                      <span className="text-text-2 text-sm">{s.desc}</span>
-                    </div>
-                  ))}
+            {challenge.selectors?.length ? (
+              <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
+                <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
+                  <span>셀렉터</span>
+                  <span>설명</span>
                 </div>
-              ) : null}
-            </section>
-          )
-        )}
+                {challenge.selectors.map((s) => (
+                  <div
+                    key={s.testid}
+                    className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
+                  >
+                    <code className="text-primary font-mono text-xs">
+                      [data-testid=&quot;{s.testid}&quot;]
+                    </code>
+                    <span className="text-text-2 text-sm">{s.desc}</span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </section>
+        ) : null}
 
-        <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
-          <h2 className="text-base font-semibold">
-            {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
-          </h2>
-          <p className="text-text-3 mt-2 text-sm leading-relaxed">
-            {challenge.track === 'manual'
-              ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
-              : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
-          </p>
-        </section>
+        {!challenge.knownDefects && (
+          <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
+            <h2 className="text-base font-semibold">
+              {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
+            </h2>
+            <p className="text-text-3 mt-2 text-sm leading-relaxed">
+              {challenge.track === 'manual'
+                ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
+                : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
+            </p>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/apps/qaground/src/view/challenges/defect-report-exercise.tsx
+++ b/apps/qaground/src/view/challenges/defect-report-exercise.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+
+import Link from 'next/link';
+
+interface Defect {
+  title: string;
+  detail: string;
+}
+
+const SEVERITIES = ['낮음', '보통', '높음', '긴급'] as const;
+
+/**
+ * 버그 찾기 결함 리포트 제출 + 정답/피드백 (Manual 트랙).
+ *
+ * 자동 채점이 아니라, 우리가 제공하는 리포트 양식으로 제출하면
+ * 의도적으로 심은 결함(정답)과 자가비교 피드백을 보여준다.
+ */
+export const DefectReportExercise = ({
+  sandboxSlug,
+  knownDefects,
+}: {
+  sandboxSlug?: string;
+  knownDefects: Defect[];
+}) => {
+  const [title, setTitle] = useState('');
+  const [steps, setSteps] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [severity, setSeverity] = useState<string>('보통');
+  const [submitted, setSubmitted] = useState(false);
+
+  const canSubmit = title.trim() && steps.trim() && actual.trim();
+
+  const fieldClass =
+    'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary border px-3 py-2 text-sm transition-colors outline-none';
+
+  return (
+    <section className="border-line-2 bg-bg-2 mt-8 rounded-2xl border p-6">
+      <h2 className="text-base font-semibold">결함 리포트 제출</h2>
+      <p className="text-text-2 mt-2 text-sm leading-relaxed">
+        연습 대상에서 결함을 찾아 아래 양식으로 리포트를 작성해 제출하세요. 제출하면 정답과 피드백이
+        나타납니다.
+      </p>
+
+      {sandboxSlug && (
+        <Link
+          href={`/sandbox/${sandboxSlug}`}
+          target="_blank"
+          className="border-line-3 rounded-button text-text-1 hover:bg-bg-3 mt-4 inline-flex h-9 items-center justify-center px-4 text-sm transition-colors"
+        >
+          연습 대상 열기
+        </Link>
+      )}
+
+      <div className="mt-5 flex flex-col gap-4">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-text-2 text-sm">제목</span>
+          <input
+            data-testid="report-title"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
+            placeholder="무엇이 어디서 어떻게 잘못되는지 한 줄로"
+            className={`h-button-md ${fieldClass}`}
+          />
+        </label>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-text-2 text-sm">재현 절차</span>
+          <textarea
+            data-testid="report-steps"
+            value={steps}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setSteps(e.target.value)}
+            rows={3}
+            placeholder={'1. ...\n2. ...\n3. ...'}
+            className={fieldClass}
+          />
+        </label>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-text-2 text-sm">기대 결과</span>
+            <input
+              data-testid="report-expected"
+              value={expected}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setExpected(e.target.value)}
+              className={`h-button-md ${fieldClass}`}
+            />
+          </label>
+          <label className="flex flex-col gap-1.5">
+            <span className="text-text-2 text-sm">실제 결과</span>
+            <input
+              data-testid="report-actual"
+              value={actual}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setActual(e.target.value)}
+              className={`h-button-md ${fieldClass}`}
+            />
+          </label>
+        </div>
+        <label className="flex flex-col gap-1.5">
+          <span className="text-text-2 text-sm">심각도</span>
+          <select
+            data-testid="report-severity"
+            value={severity}
+            onChange={(e: React.ChangeEvent<HTMLSelectElement>) => setSeverity(e.target.value)}
+            className={`h-button-md w-32 ${fieldClass}`}
+          >
+            {SEVERITIES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <button
+        data-testid="report-submit"
+        type="button"
+        disabled={!canSubmit || submitted}
+        onClick={() => setSubmitted(true)}
+        className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        제출하고 정답 확인
+      </button>
+
+      {submitted && (
+        <div data-testid="report-answer" className="border-line-2 mt-6 border-t pt-6">
+          <h3 className="text-primary text-sm font-semibold">
+            정답 · 이 페이지의 결함 {knownDefects.length}개
+          </h3>
+          <p className="text-text-2 mt-2 text-sm leading-relaxed">
+            작성하신 리포트를 아래와 비교해 보세요. {knownDefects.length}개를 모두 찾으셨나요?
+            빠뜨린 결함이 있다면 어떤 단서를 놓쳤는지 되짚어 보세요.
+          </p>
+          <ul className="mt-4 flex flex-col gap-3">
+            {knownDefects.map((d) => (
+              <li key={d.title} className="border-line-2 bg-bg-3 rounded-xl border p-4">
+                <span className="text-text-1 text-sm font-medium">{d.title}</span>
+                <p className="text-text-2 mt-1 text-sm leading-relaxed">{d.detail}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+};


### PR DESCRIPTION
﻿## 개요

버그 찾기 챌린지를 결함 발견에서 끝내지 않고, 결함 리포트 제출까지 이어지는 완결된 연습으로 만든다. 우리가 제공하는 리포트 양식으로 제출하면 의도적으로 심은 결함(정답)과 자가비교 피드백을 보여준다.

## 변경 사항

- 버그 찾기 챌린지에 결함 리포트 제출 양식을 추가했다. 제목, 재현 절차, 기대 결과, 실제 결과, 심각도를 받는다.
- 제출하면 이 페이지에 심어 둔 결함 목록을 정답으로 공개하고, 작성한 리포트와 비교해 보라는 피드백을 함께 보여준다.
- 결함이 정의된 챌린지는 기존의 안내 문구 대신 이 제출 양식과 정답을 보여주도록 상세 화면을 분기했다.
- 별도로 두었던 버그 리포트 작성 챌린지는 버그 찾기에 흡수해 정리했다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 상세 화면에서 필수 입력 전에는 제출이 막히고, 양식을 채워 제출하면 정답 세 가지와 피드백이 나타나는 것을 로컬 브라우저에서 확인했다.
