### PR TITLE
feat(#234): qaground 브라우저 트랙 코드 에디터(Monaco) + 2단 레이아웃

### DIFF
--- a/apps/qaground/app/api/challenges/[slug]/run/route.ts
+++ b/apps/qaground/app/api/challenges/[slug]/run/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+
+import { getChallenge } from '@/shared/challenges/registry';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs';
+
+const BodySchema = z
+  .object({
+    code: z.string().min(1).max(20_000),
+  })
+  .strict();
+
+/**
+ * POST /api/challenges/[slug]/run
+ *
+ * Automation 트랙 코드 채점 오케스트레이터. 사용자가 작성한 Playwright spec 을
+ * 격리 러너로 보내 연습 대상(샌드박스)에서 실행시키고 통과/실패를 돌려준다.
+ *
+ * - MVP 채점(모델 A): 사용자 spec 의 단언이 통과하면 합격.
+ * - 러너 미연결(QAGROUND_RUNNER_URL/SECRET 미설정): 503 으로 안내(배포 후 연결).
+ * - 보안: 러너는 비신뢰 코드 실행이므로 일회용 격리 컨테이너 전제(러너 배포 측 책임).
+ */
+export async function POST(request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const challenge = getChallenge(slug);
+  if (!challenge || !challenge.sandboxSlug) {
+    return NextResponse.json({ error: '챌린지를 찾을 수 없습니다.' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: '제출 코드가 올바르지 않습니다.' }, { status: 400 });
+  }
+
+  const runnerUrl = process.env.QAGROUND_RUNNER_URL;
+  const runnerSecret = process.env.QAGROUND_RUNNER_SECRET;
+  if (!runnerUrl || !runnerSecret) {
+    return NextResponse.json({ error: '채점 서버가 아직 연결되지 않았습니다.' }, { status: 503 });
+  }
+
+  // 러너가 spec 을 실행할 대상 URL. 현재는 qaground 가 서빙하는 샌드박스 주소.
+  // (하드닝 단계에서 샌드박스를 러너 이미지에 번들 + network=none 으로 전환 예정.)
+  const origin = new URL(request.url).origin;
+  const baseUrl = `${origin}/sandbox/${challenge.sandboxSlug}`;
+
+  try {
+    const res = await fetch(`${runnerUrl.replace(/\/$/, '')}/run`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Runner-Secret': runnerSecret,
+      },
+      body: JSON.stringify({ spec: parsed.data.code, baseUrl, timeoutMs: 30_000 }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data) {
+      return NextResponse.json({ error: '러너 실행에 실패했습니다.' }, { status: 502 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('[challenges/run] 러너 호출 실패', error);
+    return NextResponse.json({ error: '채점 서버에 연결하지 못했습니다.' }, { status: 502 });
+  }
+}

--- a/apps/qaground/package.json
+++ b/apps/qaground/package.json
@@ -19,7 +19,8 @@
     "next": "16.2.9",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "zod": "^4.2.1"
+    "zod": "^4.2.1",
+    "@monaco-editor/react": "^4.6.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -57,6 +57,8 @@ export interface Challenge {
   knownDefects?: { title: string; detail: string }[];
   /** Manual(테스트 케이스 작성): 제출 후 공개할 모범 답안(핵심 케이스) 목록. */
   modelTestCases?: { title: string; detail: string }[];
+  /** Automation 코드 채점: 코드 에디터 초기 Playwright 스펙 템플릿. */
+  starterSpec?: string;
 }
 
 export const TRACK_LABEL: Record<ChallengeTrack, string> = {
@@ -112,6 +114,16 @@ export const CHALLENGES: Challenge[] = [
       { name: '성공 메시지', testid: 'login-success', desc: '로그인 성공 시 노출' },
       { name: '에러 메시지', testid: 'login-error', desc: '실패·검증 에러 시 노출' },
     ],
+    starterSpec: `import { test, expect } from '@playwright/test';
+
+test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다', async ({ page }) => {
+  await page.goto('/');
+  await page.getByTestId('username').fill('tester');
+  await page.getByTestId('password').fill('qaground123');
+  await page.getByTestId('login-submit').click();
+  await expect(page.getByTestId('login-success')).toBeVisible();
+});
+`,
   },
   {
     slug: 'signup-validation',

--- a/apps/qaground/src/view/challenges/automation-code-exercise.tsx
+++ b/apps/qaground/src/view/challenges/automation-code-exercise.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+
+import type { ChallengeSelector } from '@/shared/challenges/registry';
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+  loading: () => (
+    <div className="border-line-2 bg-bg-1 text-text-3 flex h-[340px] items-center justify-center rounded-xl border text-sm">
+      에디터를 불러오는 중...
+    </div>
+  ),
+});
+
+type Status = 'idle' | 'submitting' | 'result' | 'unavailable' | 'error';
+interface RunResult {
+  ok: boolean;
+  status: string;
+  durationMs?: number;
+  errorMessage?: string;
+}
+
+function genStarter(selectors: ChallengeSelector[]): string {
+  const ids = selectors.map((s) => s.testid).join(', ');
+  return `import { test, expect } from '@playwright/test';
+
+// 참고 셀렉터: ${ids}
+test('내 테스트', async ({ page }) => {
+  await page.goto('/');
+  // page.getByTestId('...') 로 동작을 수행하고 expect 로 검증하세요.
+});
+`;
+}
+
+export const AutomationCodeExercise = ({
+  slug,
+  sandboxSlug,
+  selectors,
+  starterSpec,
+}: {
+  slug: string;
+  sandboxSlug: string;
+  selectors: ChallengeSelector[];
+  starterSpec?: string;
+}) => {
+  const [code, setCode] = useState(starterSpec ?? genStarter(selectors));
+  const [status, setStatus] = useState<Status>('idle');
+  const [result, setResult] = useState<RunResult | null>(null);
+  const [message, setMessage] = useState('');
+
+  const submit = async () => {
+    setStatus('submitting');
+    setResult(null);
+    setMessage('');
+    try {
+      const res = await fetch(`/api/challenges/${slug}/run`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      const data = (await res.json().catch(() => null)) as (RunResult & { error?: string }) | null;
+      if (res.status === 503) {
+        setStatus('unavailable');
+        setMessage(data?.error ?? '채점 서버가 아직 연결되지 않았습니다.');
+        return;
+      }
+      if (!res.ok || !data) {
+        setStatus('error');
+        setMessage(data?.error ?? '제출에 실패했습니다.');
+        return;
+      }
+      setResult(data);
+      setStatus('result');
+    } catch {
+      setStatus('error');
+      setMessage('제출에 실패했습니다.');
+    }
+  };
+
+  return (
+    <section className="border-line-2 bg-bg-2 mt-8 rounded-2xl border p-6">
+      <h2 className="text-base font-semibold">코드 작성 · 자동 채점</h2>
+      <p className="text-text-2 mt-2 text-sm leading-relaxed">
+        아래 에디터에 Playwright 테스트를 작성해 제출하면, 격리된 러너가 연습 대상에서 실행해
+        통과/실패를 채점합니다.
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <Link
+          href={`/sandbox/${sandboxSlug}`}
+          target="_blank"
+          className="text-primary text-sm hover:underline"
+        >
+          연습 대상 열기 ↗
+        </Link>
+        <span className="text-text-3 text-xs">
+          셀렉터: {selectors.map((s) => s.testid).join(', ')}
+        </span>
+      </div>
+
+      <div className="border-line-2 mt-4 overflow-hidden rounded-xl border">
+        <MonacoEditor
+          height="340px"
+          defaultLanguage="typescript"
+          theme="vs-dark"
+          value={code}
+          onChange={(value) => setCode(value ?? '')}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 13,
+            tabSize: 2,
+            scrollBeyondLastLine: false,
+            automaticLayout: true,
+            padding: { top: 12, bottom: 12 },
+          }}
+        />
+      </div>
+
+      <button
+        data-testid="code-submit"
+        type="button"
+        onClick={submit}
+        disabled={status === 'submitting'}
+        className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:opacity-60"
+      >
+        {status === 'submitting' ? '채점 중...' : '제출하고 채점'}
+      </button>
+
+      {status === 'unavailable' && (
+        <p className="border-line-3 text-text-3 mt-4 rounded-xl border border-dashed px-4 py-3 text-sm">
+          {message} (러너 배포 후 연결됩니다.)
+        </p>
+      )}
+      {status === 'error' && (
+        <p className="text-system-red mt-4 text-sm" role="alert">
+          {message}
+        </p>
+      )}
+      {status === 'result' && result && (
+        <div
+          data-testid="code-result"
+          className="border-line-2 bg-bg-3 mt-5 flex flex-col gap-2 rounded-xl border p-4"
+        >
+          <div className="flex items-center gap-2">
+            <span
+              className={`text-sm font-semibold ${result.ok ? 'text-primary' : 'text-system-red'}`}
+            >
+              {result.ok ? '통과' : '실패'}
+            </span>
+            <span className="text-text-3 text-xs">
+              {result.status}
+              {typeof result.durationMs === 'number' ? ` · ${result.durationMs}ms` : ''}
+            </span>
+          </div>
+          {result.errorMessage && (
+            <pre className="text-text-2 max-h-48 overflow-auto font-mono text-xs whitespace-pre-wrap">
+              {result.errorMessage}
+            </pre>
+          )}
+        </div>
+      )}
+    </section>
+  );
+};

--- a/apps/qaground/src/view/challenges/automation-code-exercise.tsx
+++ b/apps/qaground/src/view/challenges/automation-code-exercise.tsx
@@ -82,7 +82,7 @@ export const AutomationCodeExercise = ({
   };
 
   return (
-    <section className="border-line-2 bg-bg-2 mt-8 rounded-2xl border p-6">
+    <section className="border-line-2 bg-bg-2 rounded-2xl border p-6">
       <h2 className="text-base font-semibold">코드 작성 · 자동 채점</h2>
       <p className="text-text-2 mt-2 text-sm leading-relaxed">
         아래 에디터에 Playwright 테스트를 작성해 제출하면, 격리된 러너가 연습 대상에서 실행해
@@ -104,7 +104,7 @@ export const AutomationCodeExercise = ({
 
       <div className="border-line-2 mt-4 overflow-hidden rounded-xl border">
         <MonacoEditor
-          height="340px"
+          height="460px"
           defaultLanguage="typescript"
           theme="vs-dark"
           value={code}

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/shared/challenges/registry';
 
 import { ApiTesterExercise } from './api-tester-exercise';
+import { AutomationCodeExercise } from './automation-code-exercise';
 import { DefectReportExercise } from './defect-report-exercise';
 import { PlaygroundHeader } from './playground-header';
 import { TestCaseExercise } from './test-case-exercise';
@@ -22,6 +23,9 @@ const METHOD_COLOR: Record<HttpMethod, string> = {
 };
 
 export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => {
+  const isAutomationCode =
+    challenge.track === 'automation' && !!challenge.sandboxSlug && !!challenge.selectors?.length;
+
   return (
     <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
       <PlaygroundHeader />
@@ -112,6 +116,13 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           />
         ) : challenge.modelTestCases ? (
           <TestCaseExercise modelTestCases={challenge.modelTestCases} />
+        ) : isAutomationCode ? (
+          <AutomationCodeExercise
+            slug={challenge.slug}
+            sandboxSlug={challenge.sandboxSlug!}
+            selectors={challenge.selectors!}
+            starterSpec={challenge.starterSpec}
+          />
         ) : challenge.sandboxSlug ? (
           <section className="mt-8">
             <h2 className="text-lg font-semibold">연습 대상</h2>
@@ -150,18 +161,21 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           </section>
         ) : null}
 
-        {!challenge.knownDefects && !challenge.modelTestCases && !challenge.endpoints && (
-          <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
-            <h2 className="text-base font-semibold">
-              {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
-            </h2>
-            <p className="text-text-3 mt-2 text-sm leading-relaxed">
-              {challenge.track === 'manual'
-                ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
-                : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
-            </p>
-          </section>
-        )}
+        {!challenge.knownDefects &&
+          !challenge.modelTestCases &&
+          !challenge.endpoints &&
+          !isAutomationCode && (
+            <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
+              <h2 className="text-base font-semibold">
+                {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
+              </h2>
+              <p className="text-text-3 mt-2 text-sm leading-relaxed">
+                {challenge.track === 'manual'
+                  ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
+                  : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
+              </p>
+            </section>
+          )}
       </main>
     </div>
   );

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -81,7 +81,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
         <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-12 sm:px-6">
           {backLink}
           <ChallengeMeta challenge={challenge} />
-          <div className="mt-8 grid gap-8 lg:grid-cols-[20rem_1fr] lg:gap-10">
+          <div className="mt-8 grid gap-8 lg:grid-cols-[4fr_6fr] lg:gap-10">
             <div className="lg:sticky lg:top-24 lg:self-start">
               <h2 className="text-lg font-semibold">요구사항</h2>
               <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -78,10 +78,10 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
     return (
       <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
         <PlaygroundHeader />
-        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-12 sm:px-6">
+        <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-12 sm:px-6">
           {backLink}
           <ChallengeMeta challenge={challenge} />
-          <div className="mt-8 grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:gap-10">
+          <div className="mt-8 grid gap-8 lg:grid-cols-[20rem_1fr] lg:gap-10">
             <div className="lg:sticky lg:top-24 lg:self-start">
               <h2 className="text-lg font-semibold">요구사항</h2>
               <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -22,49 +22,95 @@ const METHOD_COLOR: Record<HttpMethod, string> = {
   DELETE: 'text-system-red',
 };
 
+function ChallengeMeta({ challenge }: { challenge: Challenge }) {
+  return (
+    <>
+      <div className="mb-3 flex items-center gap-2">
+        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+          {TRACK_LABEL[challenge.track]}
+        </span>
+        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+          {CATEGORY_LABEL[challenge.category]}
+        </span>
+        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+          {DIFFICULTY_LABEL[challenge.difficulty]}
+        </span>
+        {challenge.tools.map((tool) => (
+          <span key={tool} className="text-text-3 text-xs">
+            {tool}
+          </span>
+        ))}
+      </div>
+      <h1 className="text-2xl font-bold sm:text-3xl">{challenge.title}</h1>
+      <p className="text-text-2 mt-3 text-sm leading-relaxed">{challenge.summary}</p>
+    </>
+  );
+}
+
+function Requirements({ challenge }: { challenge: Challenge }) {
+  return (
+    <section className="mt-8">
+      <h2 className="text-lg font-semibold">요구사항</h2>
+      <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
+        {challenge.requirement.map((r) => (
+          <li key={r}>{r}</li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
 export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => {
   const isAutomationCode =
     challenge.track === 'automation' && !!challenge.sandboxSlug && !!challenge.selectors?.length;
+
+  const backLink = (
+    <Link
+      href="/challenges"
+      className="text-text-3 hover:text-text-1 mb-6 inline-block text-sm transition-colors"
+    >
+      ← 챌린지 목록
+    </Link>
+  );
+
+  // 프로그래머스식 2단: 좌 요구사항 / 우 코드 에디터
+  if (isAutomationCode) {
+    return (
+      <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
+        <PlaygroundHeader />
+        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-12 sm:px-6">
+          {backLink}
+          <ChallengeMeta challenge={challenge} />
+          <div className="mt-8 grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:gap-10">
+            <div className="lg:sticky lg:top-24 lg:self-start">
+              <h2 className="text-lg font-semibold">요구사항</h2>
+              <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
+                {challenge.requirement.map((r) => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ol>
+            </div>
+            <div>
+              <AutomationCodeExercise
+                slug={challenge.slug}
+                sandboxSlug={challenge.sandboxSlug!}
+                selectors={challenge.selectors!}
+                starterSpec={challenge.starterSpec}
+              />
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  }
 
   return (
     <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
       <PlaygroundHeader />
       <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-12 sm:px-6">
-        <Link
-          href="/challenges"
-          className="text-text-3 hover:text-text-1 mb-6 inline-block text-sm transition-colors"
-        >
-          ← 챌린지 목록
-        </Link>
-
-        <div className="mb-3 flex items-center gap-2">
-          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
-            {TRACK_LABEL[challenge.track]}
-          </span>
-          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
-            {CATEGORY_LABEL[challenge.category]}
-          </span>
-          <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
-            {DIFFICULTY_LABEL[challenge.difficulty]}
-          </span>
-          {challenge.tools.map((tool) => (
-            <span key={tool} className="text-text-3 text-xs">
-              {tool}
-            </span>
-          ))}
-        </div>
-
-        <h1 className="text-2xl font-bold sm:text-3xl">{challenge.title}</h1>
-        <p className="text-text-2 mt-3 text-sm leading-relaxed">{challenge.summary}</p>
-
-        <section className="mt-10">
-          <h2 className="text-lg font-semibold">요구사항</h2>
-          <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
-            {challenge.requirement.map((r) => (
-              <li key={r}>{r}</li>
-            ))}
-          </ol>
-        </section>
+        {backLink}
+        <ChallengeMeta challenge={challenge} />
+        <Requirements challenge={challenge} />
 
         {challenge.endpoints ? (
           <>
@@ -116,20 +162,11 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           />
         ) : challenge.modelTestCases ? (
           <TestCaseExercise modelTestCases={challenge.modelTestCases} />
-        ) : isAutomationCode ? (
-          <AutomationCodeExercise
-            slug={challenge.slug}
-            sandboxSlug={challenge.sandboxSlug!}
-            selectors={challenge.selectors!}
-            starterSpec={challenge.starterSpec}
-          />
         ) : challenge.sandboxSlug ? (
           <section className="mt-8">
             <h2 className="text-lg font-semibold">연습 대상</h2>
             <p className="text-text-2 mt-2 text-sm leading-relaxed">
-              {challenge.selectors?.length
-                ? '아래 페이지를 열어 테스트를 작성하세요. 안정적인 셀렉터(data-testid)가 심어져 있습니다.'
-                : '아래 페이지를 열어 직접 살펴보며 결함을 찾거나 테스트를 진행하세요.'}
+              아래 페이지를 열어 직접 살펴보며 결함을 찾거나 테스트를 진행하세요.
             </p>
             <Link
               href={`/sandbox/${challenge.sandboxSlug}`}
@@ -138,44 +175,21 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             >
               연습 대상 열기
             </Link>
-
-            {challenge.selectors?.length ? (
-              <div className="border-line-2 bg-bg-2 mt-5 overflow-hidden rounded-xl border">
-                <div className="border-line-2 text-text-3 grid grid-cols-[1fr_1.4fr] gap-4 border-b px-5 py-3 text-xs">
-                  <span>셀렉터</span>
-                  <span>설명</span>
-                </div>
-                {challenge.selectors.map((s) => (
-                  <div
-                    key={s.testid}
-                    className="border-line-2 grid grid-cols-[1fr_1.4fr] items-center gap-4 border-b px-5 py-3 text-sm last:border-b-0"
-                  >
-                    <code className="text-primary font-mono text-xs">
-                      [data-testid=&quot;{s.testid}&quot;]
-                    </code>
-                    <span className="text-text-2 text-sm">{s.desc}</span>
-                  </div>
-                ))}
-              </div>
-            ) : null}
           </section>
         ) : null}
 
-        {!challenge.knownDefects &&
-          !challenge.modelTestCases &&
-          !challenge.endpoints &&
-          !isAutomationCode && (
-            <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
-              <h2 className="text-base font-semibold">
-                {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
-              </h2>
-              <p className="text-text-3 mt-2 text-sm leading-relaxed">
-                {challenge.track === 'manual'
-                  ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
-                  : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
-              </p>
-            </section>
-          )}
+        {!challenge.knownDefects && !challenge.modelTestCases && !challenge.endpoints && (
+          <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
+            <h2 className="text-base font-semibold">
+              {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
+            </h2>
+            <p className="text-text-3 mt-2 text-sm leading-relaxed">
+              {challenge.track === 'manual'
+                ? '작성한 테스트 케이스와 결함 리포트를 제출·리뷰하는 기능은 곧 제공됩니다.'
+                : '작성한 테스트를 제출하면 격리된 러너가 실행해 통과/실패를 채점합니다. 곧 제공됩니다.'}
+            </p>
+          </section>
+        )}
       </main>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
 
   apps/qaground:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.6.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@testea/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -2706,6 +2709,16 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mswjs/interceptors@0.41.6':
     resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
     engines: {node: '>=18'}
@@ -4375,6 +4388,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -5543,6 +5559,9 @@ packages:
   domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -6989,6 +7008,11 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -7234,6 +7258,9 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   motion-dom@12.38.0:
     resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
@@ -8303,6 +8330,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -11441,6 +11471,17 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.3
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@mswjs/interceptors@0.41.6':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -13169,6 +13210,9 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -14431,6 +14475,10 @@ snapshots:
   domhandler@4.3.1:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@2.8.0:
     dependencies:
@@ -16184,6 +16232,8 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   md5.js@1.3.5:
@@ -16625,6 +16675,11 @@ snapshots:
       obliterator: 1.6.1
 
   module-details-from-path@1.0.4: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   motion-dom@12.38.0:
     dependencies:
@@ -17845,6 +17900,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
﻿## 개요

브라우저(자동화) 트랙에 온라인 저지(프로그래머스/백준) 스타일의 코드 작성 채점을 도입한다. 사용자가 브라우저 에디터에 Playwright 테스트를 작성해 제출하면, 격리 러너가 연습 대상에서 실행해 통과/실패를 채점하는 흐름이다.

## 변경 사항

- 자동화 챌린지 상세에 코드 에디터(Monaco)를 추가했다. 챌린지마다 시작 템플릿을 채워 두고, 다크 테마·문법 강조로 작성한다.
- 제출 라우트를 추가했다. 작성한 코드를 격리 러너로 보내 연습 대상에서 실행하고 결과를 돌려준다. 러너가 아직 연결되지 않은 동안은 안내만 보여준다.
- 자동화 챌린지 화면을 좌우 2단으로 배치했다. 제목과 요약은 위 전체 폭에, 그 아래 왼쪽에 요구사항, 오른쪽에 코드 작성 폼을 둔다.
- MVP 채점은 사용자가 작성한 테스트의 단언이 통과하면 합격으로 본다. 채점 모델 고도화는 이후 작업이다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 에디터가 로드되고 시작 템플릿이 채워지는 것, 제출 시 러너 미연결 상태가 안내로 표시되는 것, 좌우 2단 배치를 로컬 브라우저에서 확인했다.

## 비고

- 러너 배포(격리 실행 인프라)는 별도 작업이며, 그 전까지 제출은 안내 상태로 동작한다. 배포 설계는 docs/issues/qaground/qaground-자동채점-러너-배포.md 참조.
