### PR TITLE
feat(#234): qaground 자동화 챌린지 4종 추가 + 로그인 에디터 스켈레톤화

### DIFF
--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -118,10 +118,8 @@ export const CHALLENGES: Challenge[] = [
 
 test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다', async ({ page }) => {
   await page.goto('/');
-  await page.getByTestId('username').fill('tester');
-  await page.getByTestId('password').fill('qaground123');
-  await page.getByTestId('login-submit').click();
-  await expect(page.getByTestId('login-success')).toBeVisible();
+  // TODO: username·password 를 채우고 로그인 버튼을 클릭한 뒤,
+  //       login-success 가 보이는지 expect 로 검증하세요.
 });
 `,
   },
@@ -149,6 +147,36 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
       { name: '비밀번호 에러', testid: 'password-error', desc: '비밀번호 검증 실패 시 노출' },
       { name: '확인 에러', testid: 'confirm-error', desc: '비밀번호 불일치 시 노출' },
       { name: '성공 메시지', testid: 'signup-success', desc: '가입 완료 시 노출' },
+    ],
+  },
+  {
+    slug: 'profile-form',
+    title: '프로필 등록 폼 다중 검증',
+    track: 'automation',
+    category: 'forms',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary:
+      '이름 길이, 전화번호 형식, 나이 범위, 약관 동의 등 서로 다른 유형의 유효성 규칙을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '이름이 2자 미만이거나 20자를 초과하면 이름 에러가 보인다.',
+      '전화번호가 010-0000-0000 형식이 아니면 전화 에러가 보인다.',
+      '나이가 14 미만이거나 120 초과 또는 숫자가 아니면 나이 에러가 보인다.',
+      '약관에 동의하지 않고 제출하면 약관 에러가 보인다.',
+      '모든 필드가 유효하면 등록 완료 메시지가 보인다.',
+    ],
+    sandboxSlug: 'profile-form',
+    selectors: [
+      { name: '이름 입력', testid: 'name', desc: '이름 입력 필드' },
+      { name: '전화 입력', testid: 'phone', desc: '전화번호 입력 필드' },
+      { name: '나이 입력', testid: 'age', desc: '나이 입력 필드' },
+      { name: '약관 동의', testid: 'terms', desc: '약관 동의 체크박스' },
+      { name: '등록 버튼', testid: 'profile-submit', desc: '제출 버튼' },
+      { name: '이름 에러', testid: 'name-error', desc: '이름 검증 실패 시 노출' },
+      { name: '전화 에러', testid: 'phone-error', desc: '전화 검증 실패 시 노출' },
+      { name: '나이 에러', testid: 'age-error', desc: '나이 검증 실패 시 노출' },
+      { name: '약관 에러', testid: 'terms-error', desc: '약관 미동의 시 노출' },
+      { name: '성공 메시지', testid: 'profile-success', desc: '등록 완료 시 노출' },
     ],
   },
   {
@@ -252,6 +280,166 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
       { name: '파일 이름', testid: 'file-name', desc: '선택한 파일 이름' },
       { name: '업로드 버튼', testid: 'upload-submit', desc: '업로드 제출 버튼' },
       { name: '업로드 결과', testid: 'upload-result', desc: '업로드 완료 시 노출' },
+    ],
+  },
+  {
+    slug: 'session-expiry',
+    title: '세션 만료와 재로그인',
+    track: 'automation',
+    category: 'auth',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary: '로그인·세션 만료·재로그인으로 이어지는 상태 전이를 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '로그인 버튼을 누르면 로그인 상태 메시지가 보인다.',
+      '세션 만료를 시뮬레이트하면 만료 배너가 보인다.',
+      '다시 로그인을 누르면 로그인 상태로 돌아온다.',
+    ],
+    sandboxSlug: 'session-expiry',
+    selectors: [
+      { name: '로그인 버튼', testid: 'login-btn', desc: '로그인 버튼' },
+      { name: '세션 상태', testid: 'session-status', desc: '로그인 상태 메시지' },
+      { name: '만료 버튼', testid: 'expire-btn', desc: '세션 만료 시뮬레이트' },
+      { name: '만료 배너', testid: 'expired-banner', desc: '세션 만료 시 노출' },
+      { name: '재로그인 버튼', testid: 'relogin-btn', desc: '다시 로그인 버튼' },
+    ],
+  },
+  {
+    slug: 'infinite-scroll',
+    title: '무한 스크롤 더 불러오기',
+    track: 'automation',
+    category: 'async',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary:
+      '더 불러오기로 항목이 비동기 추가되고 끝에 도달하면 멈추는 목록을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '처음에는 10개 항목이 보인다.',
+      '더 불러오기를 누르면 로딩 표시 후 항목이 10개씩 추가된다.',
+      '최대(30개)에 도달하면 더 불러오기 버튼이 사라지고 마지막 안내가 보인다.',
+    ],
+    sandboxSlug: 'infinite-scroll',
+    selectors: [
+      { name: '목록', testid: 'scroll-list', desc: '항목 목록 컨테이너' },
+      { name: '항목', testid: 'list-item', desc: '각 목록 항목 (여러 개)' },
+      { name: '로딩', testid: 'loading', desc: '불러오는 중 노출' },
+      { name: '더 불러오기', testid: 'load-more', desc: '추가 로딩 버튼' },
+      { name: '목록 끝', testid: 'list-end', desc: '마지막 도달 시 노출' },
+    ],
+  },
+  {
+    slug: 'wizard-form',
+    title: '다단계 위저드 폼',
+    track: 'automation',
+    category: 'forms',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary: '단계별 검증·이동·이전 복귀가 있는 3단계 위저드 폼을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '1단계에서 이름·이메일이 유효하지 않으면 에러가 보이고 다음 단계로 넘어가지 않는다.',
+      '유효하면 2단계 확인 화면에 입력한 값이 보인다.',
+      '이전을 누르면 1단계로 돌아간다.',
+      '제출을 누르면 3단계 완료 메시지가 보인다.',
+      '단계 표시가 현재 단계에 맞게 갱신된다.',
+    ],
+    sandboxSlug: 'wizard-form',
+    selectors: [
+      { name: '단계 표시', testid: 'step-indicator', desc: '현재 / 전체 단계' },
+      { name: '이름 입력', testid: 'name', desc: '1단계 이름 필드' },
+      { name: '이메일 입력', testid: 'email', desc: '1단계 이메일 필드' },
+      { name: '이름 에러', testid: 'name-error', desc: '이름 검증 실패 시' },
+      { name: '이메일 에러', testid: 'email-error', desc: '이메일 검증 실패 시' },
+      { name: '다음 버튼', testid: 'next-btn', desc: '다음 단계' },
+      { name: '확인 이름', testid: 'confirm-name', desc: '2단계 이름 확인' },
+      { name: '확인 이메일', testid: 'confirm-email', desc: '2단계 이메일 확인' },
+      { name: '이전 버튼', testid: 'prev-btn', desc: '이전 단계' },
+      { name: '제출 버튼', testid: 'submit-btn', desc: '제출' },
+      { name: '완료 메시지', testid: 'complete', desc: '3단계 완료 시' },
+    ],
+  },
+  {
+    slug: 'toast-notification',
+    title: '토스트 자동 소멸',
+    track: 'automation',
+    category: 'async',
+    difficulty: 'easy',
+    tools: ['Playwright'],
+    summary: '액션 후 나타났다 잠시 뒤 사라지는 토스트를 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '저장하기를 누르면 토스트가 나타난다.',
+      '잠시(약 2초) 후 토스트가 자동으로 사라진다.',
+    ],
+    sandboxSlug: 'toast-notification',
+    selectors: [
+      { name: '저장 버튼', testid: 'show-toast', desc: '토스트를 띄우는 버튼' },
+      { name: '토스트', testid: 'toast', desc: '나타났다 사라지는 알림' },
+    ],
+  },
+  {
+    slug: 'tabs',
+    title: '탭 전환',
+    track: 'automation',
+    category: 'interaction',
+    difficulty: 'easy',
+    tools: ['Playwright'],
+    summary:
+      '탭을 클릭하면 콘텐츠가 바뀌고 활성 탭이 표시되는 동작을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '탭(개요·사양·리뷰)을 클릭하면 해당 콘텐츠가 패널에 보인다.',
+      '선택한 탭은 활성(aria-selected) 상태로 표시된다.',
+    ],
+    sandboxSlug: 'tabs',
+    selectors: [
+      { name: '개요 탭', testid: 'tab-overview', desc: '개요 탭' },
+      { name: '사양 탭', testid: 'tab-specs', desc: '사양 탭' },
+      { name: '리뷰 탭', testid: 'tab-reviews', desc: '리뷰 탭' },
+      { name: '탭 패널', testid: 'tab-panel', desc: '활성 탭의 콘텐츠' },
+    ],
+  },
+  {
+    slug: 'realtime-validation',
+    title: '실시간 인라인 검증',
+    track: 'automation',
+    category: 'forms',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary:
+      '입력 즉시 이메일 형식·비밀번호 강도를 표시하고 둘 다 유효할 때만 제출이 활성화되는 폼을 검증하세요.',
+    requirement: [
+      '이메일을 입력하면 형식 유효 여부가 즉시 표시된다.',
+      '비밀번호를 입력하면 강도(약함·보통·강함)가 표시된다.',
+      '이메일 형식이 맞고 비밀번호가 8자 이상이면 제출 버튼이 활성화된다.',
+      '둘 중 하나라도 유효하지 않으면 제출 버튼이 비활성화된다.',
+    ],
+    sandboxSlug: 'realtime-validation',
+    selectors: [
+      { name: '이메일 입력', testid: 'email', desc: '이메일 필드' },
+      { name: '이메일 상태', testid: 'email-status', desc: '형식 유효 여부 즉시 표시' },
+      { name: '비밀번호 입력', testid: 'password', desc: '비밀번호 필드' },
+      { name: '비밀번호 강도', testid: 'password-strength', desc: '강도 표시' },
+      { name: '제출 버튼', testid: 'submit', desc: '둘 다 유효할 때만 활성' },
+    ],
+  },
+  {
+    slug: 'date-picker',
+    title: '날짜 선택기',
+    track: 'automation',
+    category: 'interaction',
+    difficulty: 'medium',
+    tools: ['Playwright'],
+    summary:
+      '입력을 누르면 달력이 열리고 날짜를 고르면 입력에 반영되는 동작을 검증하는 테스트를 작성하세요.',
+    requirement: [
+      '날짜 입력을 누르면 달력이 열린다.',
+      '달력에서 날짜를 선택하면 입력에 날짜가 반영되고 달력이 닫힌다.',
+      '선택한 날짜가 표시된다.',
+    ],
+    sandboxSlug: 'date-picker',
+    selectors: [
+      { name: '날짜 입력', testid: 'date-input', desc: '클릭하면 달력 열림' },
+      { name: '달력', testid: 'calendar', desc: '날짜 그리드' },
+      { name: '날짜 셀', testid: 'day-cell', desc: '각 날짜 (여러 개)' },
+      { name: '선택 날짜', testid: 'selected-date', desc: '선택 후 표시' },
     ],
   },
   {

--- a/apps/qaground/src/view/sandbox/index.ts
+++ b/apps/qaground/src/view/sandbox/index.ts
@@ -2,12 +2,20 @@ import type { ComponentType } from 'react';
 
 import { AsyncLoadSandbox } from './async-load-sandbox';
 import { DataTableSandbox } from './data-table-sandbox';
+import { DatePickerSandbox } from './date-picker-sandbox';
 import { DndSandbox } from './dnd-sandbox';
 import { FileUploadSandbox } from './file-upload-sandbox';
+import { InfiniteScrollSandbox } from './infinite-scroll-sandbox';
 import { LoginSandbox } from './login-sandbox';
 import { ModalSandbox } from './modal-sandbox';
 import { OrderFormSandbox } from './order-form-sandbox';
+import { ProfileFormSandbox } from './profile-form-sandbox';
+import { RealtimeValidationSandbox } from './realtime-validation-sandbox';
+import { SessionExpirySandbox } from './session-expiry-sandbox';
 import { SignupSandbox } from './signup-sandbox';
+import { TabsSandbox } from './tabs-sandbox';
+import { ToastSandbox } from './toast-sandbox';
+import { WizardFormSandbox } from './wizard-form-sandbox';
 
 /** 샌드박스 슬러그 → 테스트 대상 컴포넌트. 챌린지 레지스트리의 sandboxSlug 와 매칭. */
 export const SANDBOXES: Record<string, ComponentType> = {
@@ -19,4 +27,12 @@ export const SANDBOXES: Record<string, ComponentType> = {
   'drag-and-drop': DndSandbox,
   'file-upload': FileUploadSandbox,
   'order-form': OrderFormSandbox,
+  'profile-form': ProfileFormSandbox,
+  'session-expiry': SessionExpirySandbox,
+  'infinite-scroll': InfiniteScrollSandbox,
+  'wizard-form': WizardFormSandbox,
+  'toast-notification': ToastSandbox,
+  tabs: TabsSandbox,
+  'realtime-validation': RealtimeValidationSandbox,
+  'date-picker': DatePickerSandbox,
 };

--- a/apps/qaground/src/view/sandbox/infinite-scroll-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/infinite-scroll-sandbox.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useState } from 'react';
+
+const PAGE = 10;
+const MAX = 30;
+
+/**
+ * 무한 스크롤(더 불러오기) 샌드박스 (테스트 대상).
+ * - 더 불러오면 로딩 표시 후 항목이 추가되고, 끝에 도달하면 버튼이 사라진다.
+ *   비동기 대기를 적절히 처리하는 연습.
+ */
+export const InfiniteScrollSandbox = () => {
+  const [count, setCount] = useState(PAGE);
+  const [loading, setLoading] = useState(false);
+
+  const loadMore = () => {
+    if (loading) return;
+    setLoading(true);
+    setTimeout(() => {
+      setCount((c) => Math.min(c + PAGE, MAX));
+      setLoading(false);
+    }, 600);
+  };
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full justify-center px-4 py-10 font-sans">
+      <div className="w-full max-w-md">
+        <h1 className="mb-4 text-xl font-bold">상품 목록</h1>
+        <ul data-testid="scroll-list" className="flex flex-col gap-2">
+          {Array.from({ length: count }, (_, i) => (
+            <li
+              key={i}
+              data-testid="list-item"
+              className="border-line-2 bg-bg-2 rounded-xl border px-4 py-3 text-sm"
+            >
+              상품 {i + 1}
+            </li>
+          ))}
+        </ul>
+        {loading && (
+          <p data-testid="loading" className="text-text-3 py-3 text-center text-sm">
+            불러오는 중...
+          </p>
+        )}
+        {count < MAX && !loading && (
+          <button
+            data-testid="load-more"
+            onClick={loadMore}
+            className="border-line-3 text-text-2 hover:bg-bg-2 mt-3 w-full rounded-xl border py-2 text-sm transition-colors"
+          >
+            더 불러오기
+          </button>
+        )}
+        {count >= MAX && (
+          <p data-testid="list-end" className="text-text-3 py-3 text-center text-sm">
+            마지막입니다.
+          </p>
+        )}
+      </div>
+    </main>
+  );
+};

--- a/apps/qaground/src/view/sandbox/profile-form-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/profile-form-sandbox.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useState } from 'react';
+
+const PHONE_RE = /^010-\d{4}-\d{4}$/;
+
+type Errors = { name?: string; phone?: string; age?: string; terms?: string };
+
+/**
+ * 프로필 등록 폼 검증 샌드박스 (테스트 대상).
+ * - 이름 길이(2~20), 전화 형식(010-0000-0000), 나이 범위(14~120 정수),
+ *   약관 동의(필수)를 검증한다. 서로 다른 유형의 유효성 규칙을 한 폼에서 연습.
+ */
+export const ProfileFormSandbox = () => {
+  const [name, setName] = useState('');
+  const [phone, setPhone] = useState('');
+  const [age, setAge] = useState('');
+  const [terms, setTerms] = useState(false);
+  const [errors, setErrors] = useState<Errors>({});
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const next: Errors = {};
+    const trimmed = name.trim();
+    if (trimmed.length < 2 || trimmed.length > 20)
+      next.name = '이름은 2자 이상 20자 이하여야 합니다.';
+    if (!PHONE_RE.test(phone)) next.phone = '전화번호는 010-0000-0000 형식이어야 합니다.';
+    const ageNum = Number(age);
+    if (!age || !Number.isInteger(ageNum) || ageNum < 14 || ageNum > 120)
+      next.age = '나이는 14세 이상 120세 이하의 숫자여야 합니다.';
+    if (!terms) next.terms = '약관에 동의해야 합니다.';
+    setErrors(next);
+    setSuccess(Object.keys(next).length === 0);
+  };
+
+  const field = (
+    testid: string,
+    label: string,
+    value: string,
+    onChange: (v: string) => void,
+    errorTestid: string,
+    placeholder: string,
+    error?: string
+  ) => (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-text-2 text-sm">{label}</span>
+      <input
+        data-testid={testid}
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        className="border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none"
+      />
+      {error && (
+        <span data-testid={errorTestid} role="alert" className="text-system-red text-xs">
+          {error}
+        </span>
+      )}
+    </label>
+  );
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 w-full max-w-sm rounded-2xl border p-8">
+        <h1 className="mb-6 text-xl font-bold">프로필 등록</h1>
+        {success ? (
+          <p
+            data-testid="profile-success"
+            role="status"
+            className="border-primary/30 bg-primary/10 text-primary rounded-xl border px-4 py-3 text-sm font-medium"
+          >
+            프로필이 등록되었습니다.
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4" noValidate>
+            {field('name', '이름', name, setName, 'name-error', '2~20자', errors.name)}
+            {field(
+              'phone',
+              '전화번호',
+              phone,
+              setPhone,
+              'phone-error',
+              '010-0000-0000',
+              errors.phone
+            )}
+            {field('age', '나이', age, setAge, 'age-error', '14~120', errors.age)}
+            <label className="flex items-center gap-2">
+              <input
+                data-testid="terms"
+                type="checkbox"
+                checked={terms}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTerms(e.target.checked)}
+                className="accent-primary h-4 w-4"
+              />
+              <span className="text-text-2 text-sm">이용약관에 동의합니다.</span>
+            </label>
+            {errors.terms && (
+              <span data-testid="terms-error" role="alert" className="text-system-red text-xs">
+                {errors.terms}
+              </span>
+            )}
+            <button
+              data-testid="profile-submit"
+              type="submit"
+              className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-1 inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-colors"
+            >
+              등록하기
+            </button>
+          </form>
+        )}
+      </div>
+    </main>
+  );
+};

--- a/apps/qaground/src/view/sandbox/session-expiry-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/session-expiry-sandbox.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+
+/**
+ * 세션 만료 샌드박스 (테스트 대상).
+ * - 로그인 → 만료 시뮬레이트 → 만료 배너 → 재로그인의 상태 전이를 검증한다.
+ */
+export const SessionExpirySandbox = () => {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [expired, setExpired] = useState(false);
+
+  const btn =
+    'bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-colors';
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 flex w-full max-w-sm flex-col gap-4 rounded-2xl border p-8">
+        <h1 className="text-xl font-bold">세션 관리</h1>
+        {!loggedIn ? (
+          <button
+            data-testid="login-btn"
+            className={btn}
+            onClick={() => {
+              setLoggedIn(true);
+              setExpired(false);
+            }}
+          >
+            로그인
+          </button>
+        ) : expired ? (
+          <>
+            <p
+              data-testid="expired-banner"
+              role="alert"
+              className="border-system-red/30 bg-system-red/10 text-system-red rounded-xl border px-4 py-3 text-sm"
+            >
+              세션이 만료되었습니다. 다시 로그인해 주세요.
+            </p>
+            <button data-testid="relogin-btn" className={btn} onClick={() => setExpired(false)}>
+              다시 로그인
+            </button>
+          </>
+        ) : (
+          <>
+            <p
+              data-testid="session-status"
+              className="border-primary/30 bg-primary/10 text-primary rounded-xl border px-4 py-3 text-sm font-medium"
+            >
+              로그인 상태입니다.
+            </p>
+            <button data-testid="expire-btn" className={btn} onClick={() => setExpired(true)}>
+              세션 만료 시뮬레이트
+            </button>
+          </>
+        )}
+      </div>
+    </main>
+  );
+};

--- a/apps/qaground/src/view/sandbox/wizard-form-sandbox.tsx
+++ b/apps/qaground/src/view/sandbox/wizard-form-sandbox.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState } from 'react';
+
+const EMAIL_RE = /^\S+@\S+\.\S+$/;
+
+type Errors = { name?: string; email?: string };
+
+/**
+ * 다단계 위저드 폼 샌드박스 (테스트 대상).
+ * - 1단계 입력 검증 → 2단계 확인(입력값 표시·이전 가능) → 3단계 완료.
+ *   단계 이동과 단계별 검증, 이전 단계 복귀를 검증하는 연습.
+ */
+export const WizardFormSandbox = () => {
+  const [step, setStep] = useState(1);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [errors, setErrors] = useState<Errors>({});
+
+  const goNext = () => {
+    const next: Errors = {};
+    if (name.trim().length < 2) next.name = '이름을 2자 이상 입력하세요.';
+    if (!EMAIL_RE.test(email)) next.email = '올바른 이메일을 입력하세요.';
+    setErrors(next);
+    if (Object.keys(next).length === 0) setStep(2);
+  };
+
+  const input =
+    'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary h-button-md border px-3 text-sm transition-colors outline-none';
+  const btn =
+    'bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-4 text-sm font-medium text-white transition-colors';
+  const ghost =
+    'border-line-3 text-text-2 hover:bg-bg-3 rounded-button h-button-md inline-flex items-center justify-center border px-4 text-sm transition-colors';
+
+  return (
+    <main className="bg-bg-1 text-text-1 flex min-h-screen w-full items-center justify-center px-4 font-sans">
+      <div className="border-line-2 bg-bg-2 flex w-full max-w-sm flex-col gap-4 rounded-2xl border p-8">
+        <p data-testid="step-indicator" className="text-text-3 text-sm">
+          {step} / 3 단계
+        </p>
+        {step === 1 && (
+          <>
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">이름</span>
+              <input
+                data-testid="name"
+                type="text"
+                value={name}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+                className={input}
+              />
+              {errors.name && (
+                <span data-testid="name-error" role="alert" className="text-system-red text-xs">
+                  {errors.name}
+                </span>
+              )}
+            </label>
+            <label className="flex flex-col gap-1.5">
+              <span className="text-text-2 text-sm">이메일</span>
+              <input
+                data-testid="email"
+                type="text"
+                value={email}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value)}
+                className={input}
+              />
+              {errors.email && (
+                <span data-testid="email-error" role="alert" className="text-system-red text-xs">
+                  {errors.email}
+                </span>
+              )}
+            </label>
+            <button data-testid="next-btn" className={btn} onClick={goNext}>
+              다음
+            </button>
+          </>
+        )}
+        {step === 2 && (
+          <>
+            <div className="border-line-2 bg-bg-3 flex flex-col gap-1 rounded-xl border px-4 py-3 text-sm">
+              <span data-testid="confirm-name">이름: {name}</span>
+              <span data-testid="confirm-email">이메일: {email}</span>
+            </div>
+            <div className="flex gap-2">
+              <button data-testid="prev-btn" className={ghost} onClick={() => setStep(1)}>
+                이전
+              </button>
+              <button data-testid="submit-btn" className={btn} onClick={() => setStep(3)}>
+                제출
+              </button>
+            </div>
+          </>
+        )}
+        {step === 3 && (
+          <p
+            data-testid="complete"
+            role="status"
+            className="border-primary/30 bg-primary/10 text-primary rounded-xl border px-4 py-3 text-sm font-medium"
+          >
+            신청이 완료되었습니다.
+          </p>
+        )}
+      </div>
+    </main>
+  );
+};


### PR DESCRIPTION
﻿## 개요

브라우저(자동화) 트랙 연습 챌린지를 4종 추가하고, 코드 에디터가 처음부터 정답을 보여 주던 문제를 고친다.

## 변경 사항

- 자동화 연습 챌린지를 4종 추가했다. 프로필 등록 폼 다중 검증, 세션 만료와 재로그인, 무한 스크롤 더 불러오기, 다단계 위저드 폼이다. 각각 안정적인 셀렉터를 심은 연습 대상 페이지를 함께 둔다.
- 로그인 챌린지의 코드 에디터 시작 코드를 정답 전체에서 골격으로 바꿨다. 테스트 이름과 시작 줄, 무엇을 하라는 안내만 두고, 실제 입력과 클릭, 검증은 사용자가 직접 작성하도록 비워 두었다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 새 챌린지 4종이 목록과 상세에서 생성되는 것, 로그인 에디터가 골격 상태로 시작하는 것을 확인했다.
