### PR TITLE
feat(#234): qaground API 테스터 Postman pm.test 스크립트 + 2단 레이아웃

### DIFF
--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -2,6 +2,17 @@
 
 import { useState } from 'react';
 
+import dynamic from 'next/dynamic';
+
+const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
+  ssr: false,
+  loading: () => (
+    <div className="border-line-2 bg-bg-1 text-text-3 flex h-[180px] items-center justify-center rounded-xl border text-sm">
+      에디터를 불러오는 중...
+    </div>
+  ),
+});
+
 type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
 type AssertKind = 'status' | 'json';
 interface Assertion {
@@ -15,10 +26,16 @@ interface Check {
   pass: boolean;
   actual: string;
 }
+interface PmResult {
+  name: string;
+  pass: boolean;
+  error?: string;
+}
 interface RunResult {
   status: number;
   bodyText: string;
   checks: Check[];
+  scriptResults: PmResult[];
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'DELETE'];
@@ -32,13 +49,142 @@ function getByPath(obj: unknown, path: string): unknown {
   }, obj);
 }
 
+/** 포스트맨 pm.expect 의 chai 유사 단언 (필요한 부분만). 실패 시 throw. */
+interface Expectation {
+  eql: (exp: unknown) => Expectation;
+  equal: (exp: unknown) => Expectation;
+  above: (n: number) => Expectation;
+  below: (n: number) => Expectation;
+  include: (x: unknown) => Expectation;
+  lengthOf: (n: number) => Expectation;
+  property: (k: string) => Expectation;
+  a: (t: string) => Expectation;
+  to: Expectation;
+  be: Expectation;
+  have: Expectation;
+  that: Expectation;
+}
+
+function makeExpect(actual: unknown): Expectation {
+  const fail = (msg: string): never => {
+    throw new Error(msg);
+  };
+  const exp: Expectation = {
+    eql: (e) =>
+      JSON.stringify(actual) === JSON.stringify(e)
+        ? exp
+        : fail(`expected ${JSON.stringify(actual)} to deeply equal ${JSON.stringify(e)}`),
+    equal: (e) =>
+      actual === e ? exp : fail(`expected ${JSON.stringify(actual)} to equal ${JSON.stringify(e)}`),
+    above: (n) =>
+      typeof actual === 'number' && actual > n
+        ? exp
+        : fail(`expected ${String(actual)} to be above ${n}`),
+    below: (n) =>
+      typeof actual === 'number' && actual < n
+        ? exp
+        : fail(`expected ${String(actual)} to be below ${n}`),
+    include: (x) => {
+      const ok =
+        typeof actual === 'string'
+          ? actual.includes(String(x))
+          : Array.isArray(actual)
+            ? actual.includes(x)
+            : false;
+      return ok ? exp : fail(`expected ${JSON.stringify(actual)} to include ${JSON.stringify(x)}`);
+    },
+    lengthOf: (n) => {
+      const len = Array.isArray(actual) || typeof actual === 'string' ? actual.length : NaN;
+      return len === n ? exp : fail(`expected length ${n} but got ${String(len)}`);
+    },
+    property: (k) =>
+      actual != null && typeof actual === 'object' && k in actual
+        ? exp
+        : fail(`expected object to have property ${k}`),
+    a: (t) => (typeof actual === t ? exp : fail(`expected type ${t} but got ${typeof actual}`)),
+    get to() {
+      return exp;
+    },
+    get be() {
+      return exp;
+    },
+    get have() {
+      return exp;
+    },
+    get that() {
+      return exp;
+    },
+  };
+  return exp;
+}
+
+/**
+ * 포스트맨 스타일 테스트 스크립트를 사용자 브라우저 안에서 평가한다.
+ * 사용자 본인 세션에서 본인 코드를 돌리는 것이라(멀티테넌트 RCE 아님) 격리 러너가 필요 없다.
+ */
+function runPmScript(
+  script: string,
+  ctx: { status: number; json: unknown; bodyText: string }
+): PmResult[] {
+  const results: PmResult[] = [];
+  const pm = {
+    response: {
+      code: ctx.status,
+      json: (): unknown => {
+        if (ctx.json === undefined) throw new Error('응답이 JSON 형식이 아닙니다.');
+        return ctx.json;
+      },
+      text: (): string => ctx.bodyText,
+      to: {
+        have: {
+          status: (n: number): void => {
+            if (ctx.status !== n) throw new Error(`expected status ${n} but got ${ctx.status}`);
+          },
+        },
+      },
+    },
+    expect: makeExpect,
+    test: (name: string, fn: () => void): void => {
+      try {
+        fn();
+        results.push({ name, pass: true });
+      } catch (e) {
+        results.push({ name, pass: false, error: e instanceof Error ? e.message : String(e) });
+      }
+    },
+  };
+  try {
+    // eslint-disable-next-line no-new-func
+    new Function('pm', script)(pm);
+  } catch (e) {
+    results.push({
+      name: '스크립트 실행',
+      pass: false,
+      error: e instanceof Error ? e.message : String(e),
+    });
+  }
+  return results;
+}
+
+const DEFAULT_SCRIPT = `// Postman 스타일 테스트 스크립트 (선택)
+// 응답을 받은 뒤 pm.test 로 검증합니다.
+pm.test('상태 코드는 200', () => {
+  pm.response.to.have.status(200);
+});
+
+// TODO: 응답 JSON 도 검증해 보세요. 예:
+// pm.test('상품 총 개수', () => {
+//   pm.expect(pm.response.json().total).to.eql(12);
+// });
+`;
+
 let nextId = 2;
 
 /**
  * 인앱 API 테스터 + 자동 채점 (API 트랙).
  *
- * 포스트맨처럼 요청을 구성하고 단언을 추가해 실행한다. 사용자 코드를 실행하지 않고
- * (통제된 HTTP 호출 + 구조적 단언 비교만) 채점하므로 격리 러너·임의 코드 실행이 필요 없다.
+ * 포스트맨처럼 요청을 구성하고, (1) 구조화된 단언 또는 (2) pm.test 스크립트로 응답을 검증한다.
+ * 스크립트는 사용자 브라우저에서만 평가하므로 격리 러너·서버 코드 실행이 필요 없다.
  */
 export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
   const [method, setMethod] = useState<Method>('GET');
@@ -48,6 +194,7 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
   const [assertions, setAssertions] = useState<Assertion[]>([
     { id: 1, kind: 'status', path: '', expected: '200' },
   ]);
+  const [script, setScript] = useState(DEFAULT_SCRIPT);
   const [running, setRunning] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
@@ -99,8 +246,12 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
         };
       });
 
+      const scriptResults = script.trim()
+        ? runPmScript(script, { status: res.status, json, bodyText })
+        : [];
+
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
-      setResult({ status: res.status, bodyText: pretty, checks });
+      setResult({ status: res.status, bodyText: pretty, checks, scriptResults });
     } catch (e) {
       setError(e instanceof Error ? e.message : '요청 실패');
     } finally {
@@ -110,15 +261,17 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
 
   const fieldClass =
     'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary border px-3 text-sm transition-colors outline-none';
-  const passCount = result?.checks.filter((c) => c.pass).length ?? 0;
-  const total = result?.checks.length ?? 0;
+  const passCount =
+    (result?.checks.filter((c) => c.pass).length ?? 0) +
+    (result?.scriptResults.filter((r) => r.pass).length ?? 0);
+  const total = (result?.checks.length ?? 0) + (result?.scriptResults.length ?? 0);
 
   return (
-    <section className="border-line-2 bg-bg-2 mt-8 rounded-2xl border p-6">
+    <section className="border-line-2 bg-bg-2 rounded-2xl border p-6">
       <h2 className="text-base font-semibold">API 테스터 · 자동 채점</h2>
       <p className="text-text-2 mt-2 text-sm leading-relaxed">
-        요청을 구성하고 단언을 추가해 실행하면 응답을 채점합니다. 코드를 작성하지 않고 포스트맨처럼
-        검증합니다.
+        요청을 구성하고, 구조화된 단언이나 포스트맨 스타일{' '}
+        <code className="font-mono">pm.test</code> 스크립트로 응답을 검증해 채점합니다.
       </p>
 
       {/* 요청 */}
@@ -225,6 +378,36 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
         </button>
       </div>
 
+      {/* 테스트 스크립트 (Postman 스타일) */}
+      <div className="mt-6">
+        <span className="text-text-2 text-sm font-medium">
+          테스트 스크립트 (Postman 스타일, 선택)
+        </span>
+        <p className="text-text-3 mt-1 text-xs leading-relaxed">
+          <code className="font-mono">pm.response</code>,{' '}
+          <code className="font-mono">pm.expect</code>, <code className="font-mono">pm.test</code>{' '}
+          로 응답을 검증합니다. 비워 두면 단언만 채점합니다.
+        </p>
+        <div className="border-line-2 mt-2 overflow-hidden rounded-xl border">
+          <MonacoEditor
+            height="180px"
+            defaultLanguage="javascript"
+            theme="vs-dark"
+            value={script}
+            onChange={(value) => setScript(value ?? '')}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              tabSize: 2,
+              scrollBeyondLastLine: false,
+              automaticLayout: true,
+              lineNumbers: 'off',
+              padding: { top: 10, bottom: 10 },
+            }}
+          />
+        </div>
+      </div>
+
       <button
         data-testid="api-run"
         type="button"
@@ -253,20 +436,44 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
             </span>
           </div>
 
-          <ul className="mt-3 flex flex-col gap-2">
-            {result.checks.map((c, i) => (
-              <li
-                key={i}
-                className="border-line-2 bg-bg-3 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
-              >
-                <span className={c.pass ? 'text-primary' : 'text-system-red'}>
-                  {c.pass ? '통과' : '실패'}
-                </span>
-                <span className="text-text-1 font-mono text-xs">{c.label}</span>
-                <span className="text-text-3 ml-auto font-mono text-xs">실제: {c.actual}</span>
-              </li>
-            ))}
-          </ul>
+          {result.checks.length > 0 && (
+            <ul className="mt-3 flex flex-col gap-2">
+              {result.checks.map((c, i) => (
+                <li
+                  key={i}
+                  className="border-line-2 bg-bg-3 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
+                >
+                  <span className={c.pass ? 'text-primary' : 'text-system-red'}>
+                    {c.pass ? '통과' : '실패'}
+                  </span>
+                  <span className="text-text-1 font-mono text-xs">{c.label}</span>
+                  <span className="text-text-3 ml-auto font-mono text-xs">실제: {c.actual}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {result.scriptResults.length > 0 && (
+            <ul className="mt-3 flex flex-col gap-2">
+              {result.scriptResults.map((r, i) => (
+                <li
+                  key={i}
+                  className="border-line-2 bg-bg-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-sm"
+                >
+                  <span className={r.pass ? 'text-primary' : 'text-system-red'}>
+                    {r.pass ? '통과' : '실패'}
+                  </span>
+                  <span className="flex flex-col gap-0.5">
+                    <span className="text-text-1 text-xs">{r.name}</span>
+                    {r.error && (
+                      <span className="text-system-red font-mono text-xs">{r.error}</span>
+                    )}
+                  </span>
+                  <span className="text-text-3 ml-auto font-mono text-xs">pm.test</span>
+                </li>
+              ))}
+            </ul>
+          )}
 
           <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-72 overflow-auto rounded-xl border p-4 font-mono text-xs">
             {result.bodyText}

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -47,22 +47,63 @@ function ChallengeMeta({ challenge }: { challenge: Challenge }) {
   );
 }
 
-function Requirements({ challenge }: { challenge: Challenge }) {
+function RequirementList({ challenge }: { challenge: Challenge }) {
   return (
-    <section className="mt-8">
+    <>
       <h2 className="text-lg font-semibold">요구사항</h2>
       <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
         {challenge.requirement.map((r) => (
           <li key={r}>{r}</li>
         ))}
       </ol>
-    </section>
+    </>
+  );
+}
+
+function ApiEndpoints({ challenge }: { challenge: Challenge }) {
+  if (!challenge.endpoints) return null;
+  return (
+    <div className="mt-6">
+      <h3 className="text-base font-semibold">연습 대상 API</h3>
+      <p className="text-text-2 mt-2 text-sm">
+        베이스 경로 <code className="text-primary font-mono text-xs">{challenge.apiBase}</code>
+      </p>
+      <div className="border-line-2 bg-bg-2 mt-3 overflow-hidden rounded-xl border">
+        <div className="border-line-2 text-text-3 grid grid-cols-[3.5rem_1fr_2.5rem] gap-3 border-b px-4 py-2.5 text-xs">
+          <span>메서드</span>
+          <span>경로</span>
+          <span>인증</span>
+        </div>
+        {challenge.endpoints.map((ep) => (
+          <div
+            key={`${ep.method} ${ep.path}`}
+            className="border-line-2 grid grid-cols-[3.5rem_1fr_2.5rem] items-start gap-3 border-b px-4 py-2.5 text-sm last:border-b-0"
+          >
+            <span className={`font-mono text-xs font-semibold ${METHOD_COLOR[ep.method]}`}>
+              {ep.method}
+            </span>
+            <span className="flex flex-col gap-1">
+              <code className="text-text-1 font-mono text-xs break-all">{ep.path}</code>
+              <span className="text-text-3 text-xs">{ep.desc}</span>
+            </span>
+            <span className="text-text-3 text-xs">{ep.auth ? '필요' : '-'}</span>
+          </div>
+        ))}
+      </div>
+      {challenge.apiNote && (
+        <p className="border-line-2 bg-bg-2 text-text-2 mt-3 rounded-xl border px-4 py-3 text-xs leading-relaxed">
+          {challenge.apiNote}
+        </p>
+      )}
+    </div>
   );
 }
 
 export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => {
   const isAutomationCode =
     challenge.track === 'automation' && !!challenge.sandboxSlug && !!challenge.selectors?.length;
+  const isApiTester = !!challenge.endpoints && !!challenge.apiBase;
+  const isSplit = isAutomationCode || isApiTester;
 
   const backLink = (
     <Link
@@ -73,8 +114,8 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
     </Link>
   );
 
-  // 프로그래머스식 2단: 좌 요구사항 / 우 코드 에디터
-  if (isAutomationCode) {
+  // 프로그래머스식 2단: 좌 요구사항(+API 엔드포인트) / 우 작성·실행 폼
+  if (isSplit) {
     return (
       <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
         <PlaygroundHeader />
@@ -83,20 +124,20 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           <ChallengeMeta challenge={challenge} />
           <div className="mt-8 grid gap-8 lg:grid-cols-[4fr_6fr] lg:gap-10">
             <div className="lg:sticky lg:top-24 lg:self-start">
-              <h2 className="text-lg font-semibold">요구사항</h2>
-              <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
-                {challenge.requirement.map((r) => (
-                  <li key={r}>{r}</li>
-                ))}
-              </ol>
+              <RequirementList challenge={challenge} />
+              {isApiTester && <ApiEndpoints challenge={challenge} />}
             </div>
             <div>
-              <AutomationCodeExercise
-                slug={challenge.slug}
-                sandboxSlug={challenge.sandboxSlug!}
-                selectors={challenge.selectors!}
-                starterSpec={challenge.starterSpec}
-              />
+              {isAutomationCode ? (
+                <AutomationCodeExercise
+                  slug={challenge.slug}
+                  sandboxSlug={challenge.sandboxSlug!}
+                  selectors={challenge.selectors!}
+                  starterSpec={challenge.starterSpec}
+                />
+              ) : (
+                <ApiTesterExercise apiBase={challenge.apiBase!} />
+              )}
             </div>
           </div>
         </main>
@@ -110,52 +151,11 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
       <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-12 sm:px-6">
         {backLink}
         <ChallengeMeta challenge={challenge} />
-        <Requirements challenge={challenge} />
+        <section className="mt-8">
+          <RequirementList challenge={challenge} />
+        </section>
 
-        {challenge.endpoints ? (
-          <>
-            <section className="mt-8">
-              <h2 className="text-lg font-semibold">연습 대상 API</h2>
-              <p className="text-text-2 mt-2 text-sm leading-relaxed">
-                아래 엔드포인트에 HTTP 요청을 보내 응답 본문과 상태 코드를 검증하세요.
-              </p>
-              <p className="text-text-2 mt-3 text-sm">
-                베이스 경로{' '}
-                <code className="text-primary font-mono text-xs">{challenge.apiBase}</code>
-              </p>
-
-              <div className="border-line-2 bg-bg-2 mt-4 overflow-hidden rounded-xl border">
-                <div className="border-line-2 text-text-3 grid grid-cols-[3.5rem_1fr_2.5rem] gap-3 border-b px-5 py-3 text-xs">
-                  <span>메서드</span>
-                  <span>경로</span>
-                  <span>인증</span>
-                </div>
-                {challenge.endpoints.map((ep) => (
-                  <div
-                    key={`${ep.method} ${ep.path}`}
-                    className="border-line-2 grid grid-cols-[3.5rem_1fr_2.5rem] items-start gap-3 border-b px-5 py-3 text-sm last:border-b-0"
-                  >
-                    <span className={`font-mono text-xs font-semibold ${METHOD_COLOR[ep.method]}`}>
-                      {ep.method}
-                    </span>
-                    <span className="flex flex-col gap-1">
-                      <code className="text-text-1 font-mono text-xs break-all">{ep.path}</code>
-                      <span className="text-text-3 text-xs">{ep.desc}</span>
-                    </span>
-                    <span className="text-text-3 text-xs">{ep.auth ? '필요' : '-'}</span>
-                  </div>
-                ))}
-              </div>
-
-              {challenge.apiNote && (
-                <p className="border-line-2 bg-bg-2 text-text-2 mt-4 rounded-xl border px-4 py-3 text-xs leading-relaxed">
-                  {challenge.apiNote}
-                </p>
-              )}
-            </section>
-            {challenge.apiBase && <ApiTesterExercise apiBase={challenge.apiBase} />}
-          </>
-        ) : challenge.knownDefects ? (
+        {challenge.knownDefects ? (
           <DefectReportExercise
             sandboxSlug={challenge.sandboxSlug}
             knownDefects={challenge.knownDefects}
@@ -178,7 +178,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
           </section>
         ) : null}
 
-        {!challenge.knownDefects && !challenge.modelTestCases && !challenge.endpoints && (
+        {!challenge.knownDefects && !challenge.modelTestCases && (
           <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
             <h2 className="text-base font-semibold">
               {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}


### PR DESCRIPTION
﻿## 개요

API 테스터에 포스트맨의 Tests 탭처럼 스크립트로 응답을 검증하는 방식을 더하고, 화면을 코드 챌린지와 같은 좌우 2단으로 맞춘다.

## 변경 사항

- API 테스터에 포스트맨 스타일 테스트 스크립트를 추가했다. 요청을 보낸 뒤 pm.test, pm.expect, pm.response 로 응답을 검증하는 스크립트를 코드 에디터에 작성할 수 있다. 기존의 구조화된 단언과 함께 쓰거나 단독으로 쓸 수 있다.
- 스크립트는 사용자 브라우저 안에서만 평가한다. 사용자 본인 세션에서 본인 코드를 돌리는 것이라 격리 러너나 서버 코드 실행이 필요 없다.
- API 챌린지 화면을 좌우 2단으로 배치했다. 제목과 요약은 위 전체 폭에, 그 아래 왼쪽에 요구사항과 연습 대상 API 엔드포인트, 오른쪽에 테스터를 둔다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 상품 목록 요청에 구조화된 단언과 pm.test 스크립트를 함께 걸어 모두 통과하는 것, 좌우 2단 배치를 로컬 브라우저에서 확인했다.
