### PR TITLE
feat(#234): qaground 베타 익명 CTA + 챌린지 목록 Testea 홍보 섹션

### DIFF
--- a/apps/qaground/src/view/challenges/challenges-view.tsx
+++ b/apps/qaground/src/view/challenges/challenges-view.tsx
@@ -101,6 +101,21 @@ export const ChallengesView = ({ selectedCategory }: { selectedCategory?: string
             ))}
           </div>
         </div>
+
+        <section className="border-line-2 bg-bg-2 mt-16 flex flex-col items-center gap-3 rounded-2xl border px-6 py-10 text-center">
+          <p className="text-text-3 text-sm">여기서 연습한 테스트, 실무에선 어떻게 관리하시나요?</p>
+          <h2 className="text-xl font-semibold">
+            테스트 케이스·실행·리포트는 <span className="text-primary">Testea</span>로
+          </h2>
+          <a
+            href="https://gettestea.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-2 rounded-lg bg-[#0bb57f] px-5 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+          >
+            Testea 둘러보기
+          </a>
+        </section>
       </main>
     </div>
   );

--- a/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
+++ b/apps/qaground/src/view/landing-beta/landing-beta-view.tsx
@@ -1,7 +1,5 @@
 import Link from 'next/link';
 
-import { WaitlistForm } from './waitlist-form';
-
 export const BetaLandingView = () => {
   return (
     <div className="bg-bg-1 text-text-1 relative flex h-screen w-full flex-col overflow-hidden font-sans">
@@ -42,14 +40,13 @@ export const BetaLandingView = () => {
           QA 연습 플레이그라운드
         </h1>
         <p className="text-text-2 max-w-xl text-base leading-[170%] sm:text-lg">
-          곧 공개됩니다. 가장 먼저 연습을 시작하고 싶다면 베타를 신청하세요.
+          로그인·가입 없이 지금 바로 연습을 시작할 수 있어요.
         </p>
-        <WaitlistForm />
         <Link
           href="/challenges"
-          className="text-text-3 hover:text-text-1 text-sm transition-colors"
+          className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-8 text-sm font-medium text-white transition-colors"
         >
-          또는 지금 연습 챌린지 둘러보기 →
+          바로 챌린지 시작하기 →
         </Link>
       </main>
 


### PR DESCRIPTION
﻿## 개요

qaground 베타를 개인정보 없이 익명으로 바로 쓰게 정리하고, 연습 화면에서 Testea로 자연스럽게 이어지도록 홍보 섹션을 둔다.

## 변경 사항

- 베타 스플래시에서 대기자 이메일 폼을 없애고, 로그인이나 가입 없이 지금 바로 시작하도록 챌린지로 가는 기본 버튼을 두었다.
- 챌린지 목록 하단에 Testea 홍보 섹션을 추가했다. 여기서 연습한 테스트를 실무에서 어떻게 관리하는지 묻고 Testea로 연결한다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
