### PR TITLE
feat(#234): qaground SEO 강화 (메타데이터·키워드·robots·sitemap)

### DIFF
--- a/apps/qaground/app/challenges/[slug]/page.tsx
+++ b/apps/qaground/app/challenges/[slug]/page.tsx
@@ -15,10 +15,18 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const challenge = getChallenge(slug);
-  if (!challenge) return { title: '챌린지를 찾을 수 없음 — qaground' };
+  if (!challenge) return { title: '챌린지를 찾을 수 없음' };
+  const url = `https://qaground.gettestea.com/challenges/${challenge.slug}`;
   return {
-    title: `${challenge.title} — qaground`,
+    title: challenge.title,
     description: challenge.summary,
+    alternates: { canonical: `/challenges/${challenge.slug}` },
+    keywords: [challenge.title, ...challenge.tools, 'QA 연습', '테스트 연습', '테스티아'],
+    openGraph: {
+      title: `${challenge.title} | qaground`,
+      description: challenge.summary,
+      url,
+    },
   };
 }
 

--- a/apps/qaground/app/challenges/page.tsx
+++ b/apps/qaground/app/challenges/page.tsx
@@ -2,9 +2,27 @@ import type { Metadata } from 'next';
 
 import { ChallengesView } from '@/view/challenges';
 
+const DESCRIPTION =
+  'QA 자동화·API·테스트 케이스 연습 챌린지. 로그인 없이 로그인 폼·결제·게시판 같은 실제형 연습 대상에 Playwright·Postman 테스트를 직접 작성해 실행하고 채점받으세요. QA 과제전형 준비에도 좋습니다.';
+
 export const metadata: Metadata = {
-  title: '연습 챌린지 — qaground',
-  description: 'QA 자동화 연습 챌린지. 로그인 없이 연습 대상에 직접 테스트를 작성해 보세요.',
+  title: '연습 챌린지',
+  description: DESCRIPTION,
+  alternates: { canonical: '/challenges' },
+  keywords: [
+    'QA 연습 챌린지',
+    'QA 과제',
+    '과제 테스트',
+    'Playwright 연습',
+    'Postman 연습',
+    '테스트 케이스 연습',
+    '테스티아',
+  ],
+  openGraph: {
+    title: '연습 챌린지 | qaground',
+    description: DESCRIPTION,
+    url: 'https://qaground.gettestea.com/challenges',
+  },
 };
 
 export default async function ChallengesPage({

--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -2,10 +2,89 @@ import type { Metadata } from 'next';
 
 import '@/app-shell/globals.css';
 
+const SITE_URL = 'https://qaground.gettestea.com';
+
+const DESCRIPTION =
+  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 로그인 폼·API·결제 같은 실제형 연습 대상에 Playwright·Postman 테스트를 직접 작성해 실행하고 채점받으세요. QA 과제전형·과제 테스트 준비에도 활용할 수 있습니다.';
+
+const TITLE = 'qaground — QA 자동화 연습 플레이그라운드 | 테스티아';
+
 export const metadata: Metadata = {
-  title: 'qaground — QA 자동화 연습 플레이그라운드',
-  description:
-    'QA 엔지니어를 위한 자동화 테스트 연습 그라운드. 직접 작성한 테스트를 실행하고 채점받으세요.',
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: TITLE,
+    template: '%s | qaground',
+  },
+  description: DESCRIPTION,
+  keywords: [
+    // 브랜드
+    '테스티아',
+    'Testea',
+    'qaground',
+    '큐에이그라운드',
+    '큐에이',
+    // 과제전형·채용
+    'QA 과제',
+    '과제 테스트',
+    'QA 과제전형',
+    'QA 채용 과제',
+    'QA 채용',
+    '개발자 과제전형',
+    '코딩 과제전형',
+    // 연습·학습
+    'QA 자동화 연습',
+    '테스트 자동화 연습',
+    'QA 연습',
+    '테스트 케이스 연습',
+    'QA 실습',
+    'QA 입문',
+    'QA 공부',
+    'QA 독학',
+    'QA 포트폴리오',
+    '웹 테스트 연습',
+    // 도구
+    'Playwright',
+    'Playwright 연습',
+    'Postman',
+    'Postman 연습',
+    'API 테스트',
+    'API 테스트 연습',
+    'Selenium 대안',
+    'E2E 테스트',
+    // 역할·일반
+    'QA 엔지니어',
+    '테스터',
+    '테스트',
+    'QA',
+    '소프트웨어 테스트',
+    '테스트 자동화',
+    '자동화 테스트',
+    '품질 보증',
+    'SQA',
+  ],
+  applicationName: 'qaground',
+  authors: [{ name: 'Testea', url: 'https://gettestea.com' }],
+  creator: 'Testea',
+  publisher: 'Testea',
+  alternates: { canonical: SITE_URL },
+  openGraph: {
+    type: 'website',
+    locale: 'ko_KR',
+    url: SITE_URL,
+    siteName: 'qaground',
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: TITLE,
+    description: DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true },
+  },
 };
 
 export default function RootLayout({

--- a/apps/qaground/app/page.tsx
+++ b/apps/qaground/app/page.tsx
@@ -2,9 +2,19 @@ import type { Metadata } from 'next';
 
 import { BetaLandingView } from '@/view/landing-beta';
 
+const TITLE = 'qaground — 로그인 없이 시작하는 QA 자동화 연습 | 테스티아';
+const DESCRIPTION =
+  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 바로 Playwright·Postman·테스트 케이스 연습을 시작하세요. QA 과제전형·과제 테스트 준비에도 좋습니다.';
+
 export const metadata: Metadata = {
-  title: 'qaground — QA 자동화 연습 플레이그라운드 (비공개 베타)',
-  description: 'QA 자동화 연습 플레이그라운드 qaground. 비공개 베타 신청.',
+  title: { absolute: TITLE },
+  description: DESCRIPTION,
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: 'https://qaground.gettestea.com',
+  },
 };
 
 export default function Home() {

--- a/apps/qaground/app/robots.ts
+++ b/apps/qaground/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+const SITE_URL = 'https://qaground.gettestea.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/apps/qaground/app/sitemap.ts
+++ b/apps/qaground/app/sitemap.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from 'next';
+
+import { CHALLENGES } from '@/shared/challenges/registry';
+
+const SITE_URL = 'https://qaground.gettestea.com';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: SITE_URL, changeFrequency: 'weekly', priority: 1 },
+    { url: `${SITE_URL}/preview`, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${SITE_URL}/challenges`, changeFrequency: 'weekly', priority: 0.9 },
+  ];
+
+  const challengePages: MetadataRoute.Sitemap = CHALLENGES.map((c) => ({
+    url: `${SITE_URL}/challenges/${c.slug}`,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }));
+
+  return [...staticPages, ...challengePages];
+}


### PR DESCRIPTION
﻿## 개요

qaground가 검색에 잡히도록 SEO 기반을 갖춘다. 테스티아 브랜드와 함께 노출되고, QA 과제·과제 테스트·QA 자동화 연습 같은 검색어로도 찾을 수 있게 한다.

## 변경 사항

- 루트 메타데이터를 강화했다. 제목과 설명에 제품명과 테스티아 브랜드, 핵심 가치를 담고, 한국어 QA 검색 의도를 망라한 키워드(브랜드·과제전형·연습·도구·역할·일반)를 넣었다. 오픈그래프와 트위터 카드, 정규 주소, 색인 허용도 함께 설정했다.
- robots와 sitemap을 추가했다. 검색 엔진이 전체 페이지를 크롤링하고, 홈·챌린지 목록·각 챌린지 상세를 사이트맵으로 안내한다.
- 홈, 챌린지 목록, 챌린지 상세에 페이지별 제목·설명·키워드·오픈그래프·정규 주소를 더했다. 각 챌린지 상세는 제목과 도구를 키워드로 활용해 롱테일 검색에 대응한다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- robots.txt와 sitemap.xml이 생성되는 것, 홈의 제목·설명·키워드·오픈그래프 메타 태그가 렌더되는 것을 로컬에서 확인했다.

## 비고

- 색인 허용은 운영 배포 기준이다. 프리뷰/개발 환경이 색인되지 않도록 하려면 후속으로 환경별 noindex 게이팅을 둘 수 있다.
- 테스티아(gettestea.com)에서 qaground로 향하는 링크를 추가하면 브랜드 연관 검색 노출이 더 강해진다. 별도 앱이라 후속 작업으로 둔다.
