### PR TITLE
feat(qaground): 미사용 베타 라우트(waitlist·magic) 직접 접근 404 차단

### DIFF
--- a/apps/qaground/middleware.ts
+++ b/apps/qaground/middleware.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * 미사용 베타 라우트(waitlist·magic) 직접 접근 차단.
+ *
+ * 베타 신청 폼·매직링크는 현재 보류(계정/알림 도입 시 재개)라 앱에서 호출되지 않는다.
+ * 라우트 코드는 남겨 두되, 외부에서 직접 요청하면 404 로 막아 노출·오작동을 방지한다.
+ * 챌린지가 쓰는 /api/practice, /api/challenges 는 막지 않는다(matcher 에서 제외).
+ */
+export function middleware() {
+  return new NextResponse(null, { status: 404 });
+}
+
+export const config = {
+  matcher: ['/api/waitlist', '/api/magic/:path*'],
+};


### PR DESCRIPTION
## 배경

qaground 베타 폼 제거(#256)·SEO(#257) 이후 `/api/waitlist`·`/api/magic` 라우트가 미사용으로 남았다. 직접 접근 시 환경 변수가 없으면 500이 나거나 라우트가 노출될 수 있어, 미들웨어로 404 차단한다.

## 변경 사항

- 미사용 베타 라우트(waitlist·magic)를 외부에서 직접 요청하면 404로 막는다.
- 챌린지가 사용하는 practice·challenges 라우트는 그대로 둔다.
- 이로써 qaground는 환경 변수 없이 정적 배포가 안전해진다 (차단된 라우트의 DB 연결 코드가 실행되지 않음).

## 검증

- build에서 미들웨어 인식 확인
- production 서버 스모크: waitlist·magic 404, 페이지·practice API 정상 동작 확인