### PR TITLE
feat(#234): qaground 이슈 등록 버튼 + GitHub 이슈 생성 (버그 구조화 폼)

### DIFF
--- a/apps/qaground/app/api/issues/route.ts
+++ b/apps/qaground/app/api/issues/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const BodySchema = z
+  .object({
+    title: z.string().trim().min(3).max(120),
+    type: z.enum(['bug', 'idea', 'etc']).optional(),
+    body: z.string().trim().min(5).max(4000),
+    pageUrl: z.string().trim().max(300).optional(),
+  })
+  .strict();
+
+const TYPE_LABEL: Record<string, string> = { bug: '버그', idea: '제안', etc: '기타' };
+
+// 간단 인메모리 레이트리밋. 서버 인스턴스별이라 콜드스타트 시 리셋되는 약한 방어지만,
+// 공개 엔드포인트의 1차 남용 차단용. 운영 스케일 시 Redis 등으로 교체.
+const WINDOW_MS = 60 * 60 * 1000; // 1시간
+const MAX_PER_WINDOW = 5;
+const hits = new Map<string, number[]>();
+
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const recent = (hits.get(ip) ?? []).filter((t) => now - t < WINDOW_MS);
+  if (recent.length >= MAX_PER_WINDOW) {
+    hits.set(ip, recent);
+    return true;
+  }
+  recent.push(now);
+  hits.set(ip, recent);
+  return false;
+}
+
+/**
+ * POST /api/issues
+ *
+ * qaground 사용자 제보를 GitHub 이슈로 등록한다.
+ * - 토큰은 서버 환경변수(QAGROUND_GH_ISSUE_TOKEN)로만 사용, 클라이언트에 노출하지 않는다.
+ * - 공개 엔드포인트이므로 입력 검증 + 길이 제한 + 레이트리밋으로 남용을 막는다.
+ * - 레포는 private 이므로 생성된 이슈 URL 을 클라이언트에 반환하지 않는다.
+ * - 토큰 미설정 시 503 으로 안내(배포 측에서 주입).
+ */
+export async function POST(request: Request) {
+  const token = process.env.QAGROUND_GH_ISSUE_TOKEN;
+  const repo = process.env.QAGROUND_GH_ISSUE_REPO ?? 'DataArts-Studio/web-mvp-front';
+  if (!token) {
+    return NextResponse.json({ error: '이슈 등록이 아직 설정되지 않았습니다.' }, { status: 503 });
+  }
+
+  const ip = (request.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() || 'unknown';
+  if (rateLimited(ip)) {
+    return NextResponse.json(
+      { error: '요청이 많습니다. 잠시 후 다시 시도해 주세요.' },
+      { status: 429 }
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = BodySchema.safeParse(raw);
+  if (!parsed.success) {
+    return NextResponse.json({ error: '제목과 내용을 확인해 주세요.' }, { status: 400 });
+  }
+  const { title, type, body, pageUrl } = parsed.data;
+
+  const typeLabel = type ? TYPE_LABEL[type] : '기타';
+  const issueTitle = `[제보/${typeLabel}] ${title}`;
+  const issueBody = [body, '', '---', '_qaground 사용자 제보_', pageUrl ? `페이지: ${pageUrl}` : '']
+    .filter(Boolean)
+    .join('\n');
+
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title: issueTitle, body: issueBody }),
+    });
+    if (!res.ok) {
+      console.error('[issues] GitHub 이슈 생성 실패', res.status, await res.text().catch(() => ''));
+      return NextResponse.json({ error: '이슈 등록에 실패했습니다.' }, { status: 502 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    console.error('[issues] GitHub 호출 오류', error);
+    return NextResponse.json({ error: '이슈 등록에 실패했습니다.' }, { status: 502 });
+  }
+}

--- a/apps/qaground/src/view/challenges/issue-report-button.tsx
+++ b/apps/qaground/src/view/challenges/issue-report-button.tsx
@@ -216,31 +216,43 @@ export const IssueReportButton = () => {
 
                     {type === 'bug' ? (
                       <>
-                        <div className="flex gap-2">
-                          <select
-                            value={severity}
-                            onChange={(e) => setSeverity(e.target.value)}
-                            className={`${fieldClass} flex-1`}
-                            aria-label="심각도"
-                          >
+                        <div>
+                          <span className="text-text-3 text-xs">심각도</span>
+                          <div className="mt-1 flex gap-2">
                             {['낮음', '보통', '높음', '심각'].map((s) => (
-                              <option key={s} value={s}>
-                                심각도: {s}
-                              </option>
+                              <button
+                                key={s}
+                                type="button"
+                                onClick={() => setSeverity(s)}
+                                className={`rounded-button h-9 flex-1 border text-sm transition-colors ${
+                                  severity === s
+                                    ? 'border-primary text-primary'
+                                    : 'border-line-3 text-text-2 hover:text-text-1'
+                                }`}
+                              >
+                                {s}
+                              </button>
                             ))}
-                          </select>
-                          <select
-                            value={priority}
-                            onChange={(e) => setPriority(e.target.value)}
-                            className={`${fieldClass} flex-1`}
-                            aria-label="우선순위"
-                          >
+                          </div>
+                        </div>
+                        <div>
+                          <span className="text-text-3 text-xs">우선순위</span>
+                          <div className="mt-1 flex gap-2">
                             {['낮음', '보통', '높음', '긴급'].map((p) => (
-                              <option key={p} value={p}>
-                                우선순위: {p}
-                              </option>
+                              <button
+                                key={p}
+                                type="button"
+                                onClick={() => setPriority(p)}
+                                className={`rounded-button h-9 flex-1 border text-sm transition-colors ${
+                                  priority === p
+                                    ? 'border-primary text-primary'
+                                    : 'border-line-3 text-text-2 hover:text-text-1'
+                                }`}
+                              >
+                                {p}
+                              </button>
                             ))}
-                          </select>
+                          </div>
                         </div>
                         <div className="flex gap-2">
                           <select

--- a/apps/qaground/src/view/challenges/issue-report-button.tsx
+++ b/apps/qaground/src/view/challenges/issue-report-button.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type IssueType = 'bug' | 'idea' | 'etc';
+type Status = 'idle' | 'submitting' | 'done' | 'error' | 'unavailable';
+
+const TYPES: { value: IssueType; label: string }[] = [
+  { value: 'bug', label: '버그' },
+  { value: 'idea', label: '제안' },
+  { value: 'etc', label: '기타' },
+];
+
+const fieldClass =
+  'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary w-full border px-3 py-2 text-sm transition-colors outline-none';
+
+export const IssueReportButton = () => {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [type, setType] = useState<IssueType>('bug');
+  const [body, setBody] = useState('');
+  const [status, setStatus] = useState<Status>('idle');
+  const [message, setMessage] = useState('');
+
+  const reset = () => {
+    setTitle('');
+    setType('bug');
+    setBody('');
+    setStatus('idle');
+    setMessage('');
+  };
+  const close = () => {
+    setOpen(false);
+    reset();
+  };
+
+  const submit = async () => {
+    if (title.trim().length < 3 || body.trim().length < 5) {
+      setStatus('error');
+      setMessage('제목(3자 이상)과 내용(5자 이상)을 적어주세요.');
+      return;
+    }
+    setStatus('submitting');
+    setMessage('');
+    try {
+      const res = await fetch('/api/issues', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          type,
+          body: body.trim(),
+          pageUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+        }),
+      });
+      const data = (await res.json().catch(() => null)) as { error?: string } | null;
+      if (res.status === 503) {
+        setStatus('unavailable');
+        setMessage(data?.error ?? '이슈 등록이 아직 설정되지 않았습니다.');
+        return;
+      }
+      if (!res.ok) {
+        setStatus('error');
+        setMessage(data?.error ?? '이슈 등록에 실패했습니다.');
+        return;
+      }
+      setStatus('done');
+    } catch {
+      setStatus('error');
+      setMessage('이슈 등록에 실패했습니다.');
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="border-line-3 text-text-2 hover:text-text-1 hover:border-line-2 rounded-button h-9 border px-3 text-sm transition-colors"
+      >
+        이슈 등록
+      </button>
+
+      {open &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[100] flex items-center justify-center p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="이슈 등록"
+          >
+            <div className="absolute inset-0 bg-black/60" onClick={close} />
+            <div className="border-line-2 bg-bg-2 relative z-10 w-full max-w-lg rounded-2xl border p-6 shadow-xl">
+              {status === 'done' ? (
+                <div className="flex flex-col items-center gap-3 py-4 text-center">
+                  <h2 className="text-base font-semibold">제보가 등록되었습니다</h2>
+                  <p className="text-text-2 text-sm leading-relaxed">
+                    소중한 의견 감사합니다. 검토 후 반영하겠습니다.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={close}
+                    className="bg-primary rounded-button h-button-md hover:bg-primary/90 mt-2 px-5 text-sm font-medium text-white transition-colors"
+                  >
+                    닫기
+                  </button>
+                </div>
+              ) : (
+                <>
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-base font-semibold">이슈 등록</h2>
+                    <button
+                      type="button"
+                      onClick={close}
+                      className="text-text-3 hover:text-text-1 text-lg transition-colors"
+                      aria-label="닫기"
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <p className="text-text-3 mt-1 text-xs leading-relaxed">
+                    버그나 개선 아이디어를 남겨주세요. 운영팀에 바로 전달됩니다.
+                  </p>
+
+                  <div className="mt-4 flex flex-col gap-3">
+                    <div className="flex gap-2">
+                      {TYPES.map((t) => (
+                        <button
+                          key={t.value}
+                          type="button"
+                          onClick={() => setType(t.value)}
+                          className={`rounded-button h-9 flex-1 border text-sm transition-colors ${
+                            type === t.value
+                              ? 'border-primary text-primary'
+                              : 'border-line-3 text-text-2 hover:text-text-1'
+                          }`}
+                        >
+                          {t.label}
+                        </button>
+                      ))}
+                    </div>
+
+                    <input
+                      value={title}
+                      onChange={(e) => setTitle(e.target.value)}
+                      placeholder="제목"
+                      maxLength={120}
+                      className={fieldClass}
+                    />
+                    <textarea
+                      value={body}
+                      onChange={(e) => setBody(e.target.value)}
+                      placeholder="무엇이 문제이거나 어떤 점이 좋아지면 좋을지 적어주세요."
+                      rows={5}
+                      maxLength={4000}
+                      className={`${fieldClass} resize-none`}
+                    />
+                  </div>
+
+                  {(status === 'error' || status === 'unavailable') && (
+                    <p
+                      className={`mt-3 text-sm ${status === 'unavailable' ? 'text-text-3' : 'text-system-red'}`}
+                      role="alert"
+                    >
+                      {message}
+                    </p>
+                  )}
+
+                  <div className="mt-5 flex justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={close}
+                      className="text-text-2 hover:text-text-1 rounded-button h-button-md px-4 text-sm transition-colors"
+                    >
+                      취소
+                    </button>
+                    <button
+                      type="button"
+                      onClick={submit}
+                      disabled={status === 'submitting'}
+                      className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 px-5 text-sm font-medium text-white transition-colors disabled:opacity-60"
+                    >
+                      {status === 'submitting' ? '등록 중...' : '등록'}
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};

--- a/apps/qaground/src/view/challenges/issue-report-button.tsx
+++ b/apps/qaground/src/view/challenges/issue-report-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 type IssueType = 'bug' | 'idea' | 'etc';
@@ -12,6 +12,22 @@ const TYPES: { value: IssueType; label: string }[] = [
   { value: 'etc', label: '기타' },
 ];
 
+const BROWSERS = ['Chrome', 'Edge', 'Whale', 'Safari', 'Firefox', 'Opera', '기타'];
+
+/** userAgent 로 브라우저 이름과 버전(빌드번호)을 감지한다. 순서 중요(Edge>Chrome 등). */
+function detectBrowser(): { name: string; version: string } {
+  if (typeof navigator === 'undefined') return { name: 'Chrome', version: '' };
+  const ua = navigator.userAgent;
+  const pick = (re: RegExp): string => ua.match(re)?.[1] ?? '';
+  if (/Edg\//.test(ua)) return { name: 'Edge', version: pick(/Edg\/([\d.]+)/) };
+  if (/Whale\//.test(ua)) return { name: 'Whale', version: pick(/Whale\/([\d.]+)/) };
+  if (/OPR\//.test(ua)) return { name: 'Opera', version: pick(/OPR\/([\d.]+)/) };
+  if (/Firefox\//.test(ua)) return { name: 'Firefox', version: pick(/Firefox\/([\d.]+)/) };
+  if (/Chrome\//.test(ua)) return { name: 'Chrome', version: pick(/Chrome\/([\d.]+)/) };
+  if (/Safari\//.test(ua)) return { name: 'Safari', version: pick(/Version\/([\d.]+)/) };
+  return { name: '기타', version: '' };
+}
+
 const fieldClass =
   'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary w-full border px-3 py-2 text-sm transition-colors outline-none';
 
@@ -20,13 +36,31 @@ export const IssueReportButton = () => {
   const [title, setTitle] = useState('');
   const [type, setType] = useState<IssueType>('bug');
   const [body, setBody] = useState('');
+  const [steps, setSteps] = useState('');
+  const [expected, setExpected] = useState('');
+  const [actual, setActual] = useState('');
+  const [severity, setSeverity] = useState('보통');
+  const [priority, setPriority] = useState('보통');
+  const [browser, setBrowser] = useState('Chrome');
+  const [browserVersion, setBrowserVersion] = useState('');
   const [status, setStatus] = useState<Status>('idle');
   const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const d = detectBrowser();
+    setBrowser(d.name);
+    setBrowserVersion(d.version);
+  }, []);
 
   const reset = () => {
     setTitle('');
     setType('bug');
     setBody('');
+    setSteps('');
+    setExpected('');
+    setActual('');
+    setSeverity('보통');
+    setPriority('보통');
     setStatus('idle');
     setMessage('');
   };
@@ -36,10 +70,40 @@ export const IssueReportButton = () => {
   };
 
   const submit = async () => {
-    if (title.trim().length < 3 || body.trim().length < 5) {
-      setStatus('error');
-      setMessage('제목(3자 이상)과 내용(5자 이상)을 적어주세요.');
-      return;
+    const isBug = type === 'bug';
+    let composed: string;
+    if (isBug) {
+      if (title.trim().length < 3 || steps.trim().length < 5 || actual.trim().length < 3) {
+        setStatus('error');
+        setMessage('제목·재현 절차·실제 결과를 적어주세요.');
+        return;
+      }
+      composed = [
+        '## 재현 절차',
+        steps.trim(),
+        '',
+        '## 기대 결과',
+        expected.trim() || '(작성 안 함)',
+        '',
+        '## 실제 결과',
+        actual.trim(),
+        '',
+        '## 심각도',
+        severity,
+        '',
+        '## 우선순위',
+        priority,
+        '',
+        '## 환경',
+        `브라우저: ${browser}${browserVersion ? ` ${browserVersion}` : ''}`,
+      ].join('\n');
+    } else {
+      if (title.trim().length < 3 || body.trim().length < 5) {
+        setStatus('error');
+        setMessage('제목(3자 이상)과 내용(5자 이상)을 적어주세요.');
+        return;
+      }
+      composed = body.trim();
     }
     setStatus('submitting');
     setMessage('');
@@ -50,7 +114,7 @@ export const IssueReportButton = () => {
         body: JSON.stringify({
           title: title.trim(),
           type,
-          body: body.trim(),
+          body: composed,
           pageUrl: typeof window !== 'undefined' ? window.location.href : undefined,
         }),
       });
@@ -92,7 +156,7 @@ export const IssueReportButton = () => {
             aria-label="이슈 등록"
           >
             <div className="absolute inset-0 bg-black/60" onClick={close} />
-            <div className="border-line-2 bg-bg-2 relative z-10 w-full max-w-lg rounded-2xl border p-6 shadow-xl">
+            <div className="border-line-2 bg-bg-2 relative z-10 max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border p-6 shadow-xl">
               {status === 'done' ? (
                 <div className="flex flex-col items-center gap-3 py-4 text-center">
                   <h2 className="text-base font-semibold">제보가 등록되었습니다</h2>
@@ -149,14 +213,96 @@ export const IssueReportButton = () => {
                       maxLength={120}
                       className={fieldClass}
                     />
-                    <textarea
-                      value={body}
-                      onChange={(e) => setBody(e.target.value)}
-                      placeholder="무엇이 문제이거나 어떤 점이 좋아지면 좋을지 적어주세요."
-                      rows={5}
-                      maxLength={4000}
-                      className={`${fieldClass} resize-none`}
-                    />
+
+                    {type === 'bug' ? (
+                      <>
+                        <div className="flex gap-2">
+                          <select
+                            value={severity}
+                            onChange={(e) => setSeverity(e.target.value)}
+                            className={`${fieldClass} flex-1`}
+                            aria-label="심각도"
+                          >
+                            {['낮음', '보통', '높음', '심각'].map((s) => (
+                              <option key={s} value={s}>
+                                심각도: {s}
+                              </option>
+                            ))}
+                          </select>
+                          <select
+                            value={priority}
+                            onChange={(e) => setPriority(e.target.value)}
+                            className={`${fieldClass} flex-1`}
+                            aria-label="우선순위"
+                          >
+                            {['낮음', '보통', '높음', '긴급'].map((p) => (
+                              <option key={p} value={p}>
+                                우선순위: {p}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="flex gap-2">
+                          <select
+                            value={browser}
+                            onChange={(e) => setBrowser(e.target.value)}
+                            className={`${fieldClass} flex-1`}
+                            aria-label="브라우저"
+                          >
+                            {BROWSERS.map((b) => (
+                              <option key={b} value={b}>
+                                {b}
+                              </option>
+                            ))}
+                          </select>
+                          <input
+                            value={browserVersion}
+                            onChange={(e) => setBrowserVersion(e.target.value)}
+                            placeholder="버전 (빌드번호)"
+                            maxLength={40}
+                            className={`${fieldClass} flex-1`}
+                            aria-label="브라우저 버전"
+                          />
+                        </div>
+                        <textarea
+                          value={steps}
+                          onChange={(e) => setSteps(e.target.value)}
+                          placeholder="재현 절차 (예: 1. 로그인 페이지 진입  2. 빈 값으로 제출  3. ...)"
+                          rows={3}
+                          maxLength={2000}
+                          className={`${fieldClass} resize-none`}
+                        />
+                        <textarea
+                          value={expected}
+                          onChange={(e) => setExpected(e.target.value)}
+                          placeholder="기대 결과 (어떻게 동작해야 하나요?)"
+                          rows={2}
+                          maxLength={1000}
+                          className={`${fieldClass} resize-none`}
+                        />
+                        <textarea
+                          value={actual}
+                          onChange={(e) => setActual(e.target.value)}
+                          placeholder="실제 결과 (실제로 어떻게 됐나요?)"
+                          rows={2}
+                          maxLength={1000}
+                          className={`${fieldClass} resize-none`}
+                        />
+                      </>
+                    ) : (
+                      <textarea
+                        value={body}
+                        onChange={(e) => setBody(e.target.value)}
+                        placeholder={
+                          type === 'idea'
+                            ? '어떤 점이 좋아지면 좋을지 적어주세요.'
+                            : '내용을 적어주세요.'
+                        }
+                        rows={5}
+                        maxLength={4000}
+                        className={`${fieldClass} resize-none`}
+                      />
+                    )}
                   </div>
 
                   {(status === 'error' || status === 'unavailable') && (

--- a/apps/qaground/src/view/challenges/playground-header.tsx
+++ b/apps/qaground/src/view/challenges/playground-header.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
 
+import { IssueReportButton } from './issue-report-button';
+
 export const PlaygroundHeader = () => {
   return (
     <header className="border-line-2 bg-bg-1/80 sticky top-0 z-50 border-b backdrop-blur">
@@ -7,12 +9,15 @@ export const PlaygroundHeader = () => {
         <Link href="/" className="text-lg font-bold tracking-tight">
           qa<span className="text-primary">ground</span>
         </Link>
-        <Link
-          href="/challenges"
-          className="text-text-2 hover:text-text-1 text-sm transition-colors"
-        >
-          챌린지
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/challenges"
+            className="text-text-2 hover:text-text-1 text-sm transition-colors"
+          >
+            챌린지
+          </Link>
+          <IssueReportButton />
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
﻿## 개요

qaground 상단 네비게이션에 이슈 등록 버튼을 두고, 제출하면 GitHub 이슈로 등록되게 한다. 버그 유형은 실제 버그 트래커처럼 구조화된 양식으로 받는다.

## 변경 사항

- 상단 네비게이션에 이슈 등록 버튼을 추가했다. 누르면 모달이 열린다.
- 유형을 버그·제안·기타로 나눴다. 버그는 심각도와 우선순위, 브라우저와 버전, 재현 절차, 기대 결과, 실제 결과를 받는 구조화된 양식으로 보여 준다. 제안과 기타는 제목과 내용만 받는다.
- 브라우저와 버전은 접속한 브라우저에서 자동으로 감지해 채우고, 사용자가 고치거나 다른 브라우저로 바꿀 수 있다.
- 제출하면 입력을 정리해 GitHub 이슈로 등록한다. 토큰은 서버에서만 쓰고 클라이언트에 노출하지 않는다. 공개 경로이므로 입력 검증과 길이 제한, 시간당 요청 제한으로 남용을 막는다. 저장소가 비공개라 생성된 이슈 주소는 사용자에게 돌려주지 않는다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 버튼과 모달, 유형별 양식 전환, 브라우저 자동 감지, 토큰 미설정 시 안내 동작을 로컬 브라우저에서 확인했다.

## 비고

- 운영에서 동작하려면 GitHub 토큰 환경변수를 주입해야 한다. 토큰이 없으면 안내만 보여 준다.
- 시간당 요청 제한은 서버 인스턴스별 인메모리라, 운영 스케일 시 공유 저장소로 교체가 필요하다.
