### PR TITLE
feat(#234): qaground GA4 이벤트 수집 + 이슈 어사인·라벨 자동 부착

### DIFF
--- a/apps/qaground/app/api/issues/route.ts
+++ b/apps/qaground/app/api/issues/route.ts
@@ -16,6 +16,13 @@ const BodySchema = z
 
 const TYPE_LABEL: Record<string, string> = { bug: '버그', idea: '제안', etc: '기타' };
 
+// 유형 → 레포 라벨(레포에 이미 존재하는 라벨만 사용. 없는 라벨이면 422). 빈 값은 미부착.
+const TYPE_GH_LABEL: Record<string, string> = {
+  bug: '🐛 type: bug',
+  idea: '✨ type: feature',
+  etc: '',
+};
+
 // 간단 인메모리 레이트리밋. 서버 인스턴스별이라 콜드스타트 시 리셋되는 약한 방어지만,
 // 공개 엔드포인트의 1차 남용 차단용. 운영 스케일 시 Redis 등으로 교체.
 const WINDOW_MS = 60 * 60 * 1000; // 1시간
@@ -72,6 +79,9 @@ export async function POST(request: Request) {
 
   const typeLabel = type ? TYPE_LABEL[type] : '기타';
   const issueTitle = `[제보/${typeLabel}] ${title}`;
+  const typeGhLabel = type ? TYPE_GH_LABEL[type] : '';
+  const labels = ['qaground', ...(typeGhLabel ? [typeGhLabel] : [])];
+  const assignee = process.env.QAGROUND_GH_ISSUE_ASSIGNEE ?? 'JangHwanPark';
   const issueBody = [body, '', '---', '_qaground 사용자 제보_', pageUrl ? `페이지: ${pageUrl}` : '']
     .filter(Boolean)
     .join('\n');
@@ -85,7 +95,12 @@ export async function POST(request: Request) {
         'X-GitHub-Api-Version': '2022-11-28',
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ title: issueTitle, body: issueBody }),
+      body: JSON.stringify({
+        title: issueTitle,
+        body: issueBody,
+        labels,
+        assignees: [assignee],
+      }),
     });
     if (!res.ok) {
       console.error('[issues] GitHub 이슈 생성 실패', res.status, await res.text().catch(() => ''));

--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import '@/app-shell/globals.css';
+import { GoogleAnalytics } from '@next/third-parties/google';
 
 const SITE_URL = 'https://qaground.gettestea.com';
 
@@ -92,9 +93,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // GA는 production 배포에서만 로드. preview(dev 브랜치)·로컬은 GA_ID가 주입돼도 차단.
+  const gaId = process.env.NEXT_PUBLIC_GA_ID;
+  const gaEnabled = !!gaId && process.env.VERCEL_ENV === 'production';
+
   return (
     <html lang="ko" className="h-full antialiased">
       <body className="bg-bg-1 text-text-1 flex min-h-full flex-col">{children}</body>
+      {gaEnabled && <GoogleAnalytics gaId={gaId} />}
     </html>
   );
 }

--- a/apps/qaground/package.json
+++ b/apps/qaground/package.json
@@ -20,7 +20,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "zod": "^4.2.1",
-    "@monaco-editor/react": "^4.6.0"
+    "@monaco-editor/react": "^4.6.0",
+    "@next/third-parties": "^16.2.9"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/apps/qaground/src/shared/analytics/track.ts
+++ b/apps/qaground/src/shared/analytics/track.ts
@@ -1,0 +1,23 @@
+import { sendGAEvent } from '@next/third-parties/google';
+
+type EventParams = Record<string, string | number | boolean | undefined | null>;
+
+/**
+ * GA4 커스텀 이벤트 전송.
+ *
+ * production 외(로컬·preview)에서는 GoogleAnalytics 스크립트가 로드되지 않으므로
+ * dataLayer 로 push 돼도 실제 전송되지 않는다(무해). 개인정보는 보내지 않고,
+ * 어떤 챌린지에서 무엇을 제출했는지 같은 비식별 사용 데이터만 수집한다.
+ *
+ * @example track('issue_submit', { type: 'bug' });
+ */
+export function track(event: string, params?: EventParams): void {
+  if (typeof window === 'undefined') return;
+  const clean = params
+    ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null))
+    : {};
+  sendGAEvent('event', event, clean);
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[GA] ${event}`, clean);
+  }
+}

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 
 import dynamic from 'next/dynamic';
 
+import { track } from '@/shared/analytics/track';
+
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
   loading: () => (
@@ -252,6 +254,10 @@ export const ApiTesterExercise = ({ apiBase }: { apiBase: string }) => {
 
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
       setResult({ status: res.status, bodyText: pretty, checks, scriptResults });
+      track('api_run', {
+        passed: checks.filter((c) => c.pass).length + scriptResults.filter((r) => r.pass).length,
+        total: checks.length + scriptResults.length,
+      });
     } catch (e) {
       setError(e instanceof Error ? e.message : '요청 실패');
     } finally {

--- a/apps/qaground/src/view/challenges/automation-code-exercise.tsx
+++ b/apps/qaground/src/view/challenges/automation-code-exercise.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 
+import { track } from '@/shared/analytics/track';
 import type { ChallengeSelector } from '@/shared/challenges/registry';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
@@ -75,6 +76,7 @@ export const AutomationCodeExercise = ({
       }
       setResult(data);
       setStatus('result');
+      track('code_submit', { slug, status: data.status, ok: data.ok });
     } catch {
       setStatus('error');
       setMessage('제출에 실패했습니다.');

--- a/apps/qaground/src/view/challenges/defect-report-exercise.tsx
+++ b/apps/qaground/src/view/challenges/defect-report-exercise.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 
 import Link from 'next/link';
 
+import { track } from '@/shared/analytics/track';
+
 interface Defect {
   title: string;
   detail: string;
@@ -117,7 +119,10 @@ export const DefectReportExercise = ({
         data-testid="report-submit"
         type="button"
         disabled={!canSubmit || submitted}
-        onClick={() => setSubmitted(true)}
+        onClick={() => {
+          track('defect_submit');
+          setSubmitted(true);
+        }}
         className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
       >
         제출하고 정답 확인

--- a/apps/qaground/src/view/challenges/issue-report-button.tsx
+++ b/apps/qaground/src/view/challenges/issue-report-button.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { track } from '@/shared/analytics/track';
+
 type IssueType = 'bug' | 'idea' | 'etc';
 type Status = 'idle' | 'submitting' | 'done' | 'error' | 'unavailable';
 
@@ -129,6 +131,7 @@ export const IssueReportButton = () => {
         setMessage(data?.error ?? '이슈 등록에 실패했습니다.');
         return;
       }
+      track('issue_submit', { issue_type: type });
       setStatus('done');
     } catch {
       setStatus('error');

--- a/apps/qaground/src/view/challenges/test-case-exercise.tsx
+++ b/apps/qaground/src/view/challenges/test-case-exercise.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { track } from '@/shared/analytics/track';
+
 interface ModelCase {
   title: string;
   detail: string;
@@ -80,7 +82,10 @@ export const TestCaseExercise = ({ modelTestCases }: { modelTestCases: ModelCase
           data-testid="cases-submit"
           type="button"
           disabled={!canSubmit || submitted}
-          onClick={() => setSubmitted(true)}
+          onClick={() => {
+            track('testcase_submit');
+            setSubmitted(true);
+          }}
           className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50"
         >
           제출하고 모범 답안 확인

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       '@monaco-editor/react':
         specifier: ^4.6.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@next/third-parties':
+        specifier: ^16.2.9
+        version: 16.2.9(next@16.2.9(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       '@testea/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -14853,7 +14856,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -14910,7 +14913,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -14950,7 +14953,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
﻿## 개요

qaground 사용 데이터를 GA4로 수집하고, 사용자 제보 이슈에 담당자와 라벨을 자동으로 붙인다.

## 변경 사항

- GA4를 붙였다. 운영 배포에서만 로드되고, 로컬과 프리뷰에서는 측정 ID가 주입돼도 동작하지 않는다.
- 사용 이벤트를 수집한다. 이슈 제출, 코드 채점 제출, API 테스터 실행, 결함 리포트 제출, 테스트 케이스 제출 시 어느 챌린지에서 무엇을 했는지 같은 비식별 데이터만 보낸다. 개인정보는 수집하지 않는다.
- 이슈 제보로 생성되는 GitHub 이슈에 담당자를 지정하고 라벨을 붙인다. 모든 제보에 qaground 라벨을, 버그는 버그 타입, 제안은 기능 타입 라벨을 함께 붙인다.

## 검증

- 프로덕션 빌드, 타입체크, 포매팅 검사 통과.
- 버그 제보를 실제로 보내 담당자 지정과 라벨 부착이 적용되는 것을 확인했다(확인 후 닫음).

## 비고

- GA가 실제로 수집하려면 운영 환경변수에 GA4 측정 ID를 주입해야 한다. 없으면 로드되지 않는다.
- 담당자와 라벨은 환경변수로도 바꿀 수 있고, 사용하는 라벨은 저장소에 이미 존재해야 한다(qaground 라벨은 신규 생성함).
