### PR TITLE
fix(#234): qaground lint·test 정리 (배포 전 검증)

### DIFF
--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -156,7 +156,6 @@ function runPmScript(
     },
   };
   try {
-    // eslint-disable-next-line no-new-func
     new Function('pm', script)(pm);
   } catch (e) {
     results.push({

--- a/apps/qaground/src/view/challenges/issue-report-button.tsx
+++ b/apps/qaground/src/view/challenges/issue-report-button.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { track } from '@/shared/analytics/track';
@@ -48,11 +48,12 @@ export const IssueReportButton = () => {
   const [status, setStatus] = useState<Status>('idle');
   const [message, setMessage] = useState('');
 
-  useEffect(() => {
+  const openModal = () => {
     const d = detectBrowser();
     setBrowser(d.name);
     setBrowserVersion(d.version);
-  }, []);
+    setOpen(true);
+  };
 
   const reset = () => {
     setTitle('');
@@ -143,7 +144,7 @@ export const IssueReportButton = () => {
     <>
       <button
         type="button"
-        onClick={() => setOpen(true)}
+        onClick={openModal}
         className="border-line-3 text-text-2 hover:text-text-1 hover:border-line-2 rounded-button h-9 border px-3 text-sm transition-colors"
       >
         이슈 등록

--- a/apps/qaground/vitest.config.ts
+++ b/apps/qaground/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/shared/test/setup-tests.ts'],
     include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    passWithNoTests: true,
     // jsdom 환경 콜드 스타트(첫 파일 import/transform)가 기본 5초를 넘겨 첫 테스트가
     // 간헐 타임아웃되는 것을 방지한다.
     testTimeout: 15000,


### PR DESCRIPTION
﻿## 개요

배포 전 전체 검증에서 나온 qaground의 lint·test 잔여 항목을 정리한다.

## 변경 사항

- 이슈 등록 모달의 브라우저 자동 감지를 마운트 시점 effect에서 모달을 여는 동작 시점으로 옮겼다. 동작은 같고, effect 안에서 상태를 바로 바꾸지 않게 해 린트 규칙을 만족한다.
- qaground에 단위 테스트 파일이 아직 없어 테스트 명령이 실패로 끝나던 것을, 테스트가 없을 때 통과하도록 설정했다.
- 동작하지 않는 린트 비활성 주석을 제거했다.

## 검증

- 린트, 테스트, 프로덕션 빌드, 포매팅 검사 모두 통과.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Issue report details are now gathered when the modal is opened, improving responsiveness at page load.
  - Script execution handling was cleaned up with no change to the user-facing flow.
- **Tests**
  - Test runs now pass even when no tests are found, making CI behavior more flexible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->