### PR TITLE
feat(qaground): 네이버 서치어드바이저 사이트 소유확인 메타태그

### DIFF
--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -86,6 +86,9 @@ export const metadata: Metadata = {
     follow: true,
     googleBot: { index: true, follow: true },
   },
+  verification: {
+    other: { 'naver-site-verification': '2a41c60503088ea4c2589bb5f5fdf7861b3306e9' },
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## 배경

네이버 서치어드바이저에 qaground 사이트를 등록하기 위한 소유 확인 메타태그를 추가한다.

## 변경 사항

- 루트 레이아웃 메타데이터에 네이버 사이트 소유확인 태그를 추가한다.
- 배포 후 네이버 서치어드바이저에서 소유 확인 → sitemap 제출이 가능해진다.