### PR TITLE
feat(web): 푸터에 qaground(QA 연습) 백링크 추가

### DIFF
--- a/apps/web/src/i18n/messages/en.json
+++ b/apps/web/src/i18n/messages/en.json
@@ -85,7 +85,9 @@
     "privacy": "Privacy Policy",
     "terms": "Terms of Service",
     "team": "Team testea",
-    "teamAria": "About the team"
+    "teamAria": "About the team",
+    "qaground": "QA Practice",
+    "qagroundAria": "qaground - QA automation practice playground"
   },
   "lending": {
     "documentAria": "Testea landing page",

--- a/apps/web/src/i18n/messages/ko.json
+++ b/apps/web/src/i18n/messages/ko.json
@@ -85,7 +85,9 @@
     "privacy": "개인정보 처리방침",
     "terms": "이용약관",
     "team": "팀 테스티아",
-    "teamAria": "팀 소개"
+    "teamAria": "팀 소개",
+    "qaground": "QA 자동화 연습",
+    "qagroundAria": "qaground - QA 자동화 연습 플레이그라운드"
   },
   "lending": {
     "documentAria": "Testea 랜딩 페이지",

--- a/apps/web/src/widgets/footer/footer.tsx
+++ b/apps/web/src/widgets/footer/footer.tsx
@@ -38,6 +38,19 @@ export const Footer = () => {
         <Link href="/team" aria-label={t('teamAria')} className="hover:text-teal-400">
           {t('team')}
         </Link>
+        <span aria-hidden="true" className="mx-2">
+          {' '}
+          |{' '}
+        </span>
+        <a
+          href="https://qaground.gettestea.com"
+          target="_blank"
+          rel="noopener"
+          aria-label={t('qagroundAria')}
+          className="hover:text-teal-400"
+        >
+          {t('qaground')}
+        </a>
       </nav>
     </footer>
   );


### PR DESCRIPTION
## 배경

qaground(QA 연습 플레이그라운드, qaground.gettestea.com)의 검색 발견·색인·전환 유입을 돕기 위해, Testea 본 사이트 푸터에 qaground 백링크를 추가한다. 검색엔진이 qaground를 발견하고 신뢰도를 주는 가장 큰 신호다.

## 변경 사항

- 푸터 링크 목록에 qaground(QA 자동화 연습) 외부 링크 추가 (dofollow)
- i18n 메시지(한국어·영어)에 qaground 항목 추가
- 본 사이트 방문자가 QA 연습으로 자연 유입되는 경로도 함께 생긴다