### PR TITLE
feat(qaground): API 연습 챌린지 세트 추가

### DIFF
--- a/apps/qaground/app/api/practice/admin/reports/route.ts
+++ b/apps/qaground/app/api/practice/admin/reports/route.ts
@@ -1,14 +1,21 @@
 import { NextResponse } from 'next/server';
 
+import { DEMO_TOKEN } from '@/shared/practice-api/auth';
+
 export const dynamic = 'force-dynamic';
+
+const ADMIN_TOKEN = 'qaground-admin-token';
 
 export async function GET(request: Request) {
   const auth = request.headers.get('authorization');
   if (!auth) {
     return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
   }
-  if (auth !== 'Bearer qaground-admin-token') {
+  if (auth === `Bearer ${DEMO_TOKEN}`) {
     return NextResponse.json({ error: '관리자 권한이 필요합니다.' }, { status: 403 });
+  }
+  if (auth !== `Bearer ${ADMIN_TOKEN}`) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
   }
   return NextResponse.json({ activeUsers: 128, failedJobs: 2, abuseReports: 3 });
 }

--- a/apps/qaground/app/api/practice/admin/reports/route.ts
+++ b/apps/qaground/app/api/practice/admin/reports/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const auth = request.headers.get('authorization');
+  if (!auth) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+  }
+  if (auth !== 'Bearer qaground-admin-token') {
+    return NextResponse.json({ error: '관리자 권한이 필요합니다.' }, { status: 403 });
+  }
+  return NextResponse.json({ activeUsers: 128, failedJobs: 2, abuseReports: 3 });
+}

--- a/apps/qaground/app/api/practice/articles/route.ts
+++ b/apps/qaground/app/api/practice/articles/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const ARTICLES = [
+  { id: 1, title: 'API 테스트 입문', tag: 'api', author: 'qa-team', views: 150 },
+  { id: 2, title: 'Playwright locator 전략', tag: 'automation', author: 'qa-team', views: 240 },
+  { id: 3, title: '결함 리포트 잘 쓰는 법', tag: 'manual', author: 'support', views: 90 },
+  { id: 4, title: '웹훅 테스트 체크리스트', tag: 'api', author: 'platform', views: 180 },
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get('q') ?? '').trim().toLowerCase();
+  const tag = searchParams.get('tag');
+  const sort = searchParams.get('sort');
+  const order = searchParams.get('order') === 'desc' ? 'desc' : 'asc';
+
+  let data = ARTICLES.slice();
+  if (q) data = data.filter((article) => article.title.toLowerCase().includes(q));
+  if (tag) data = data.filter((article) => article.tag === tag);
+  if (sort === 'views' || sort === 'title') {
+    data.sort((a, b) => {
+      const cmp = sort === 'views' ? a.views - b.views : a.title.localeCompare(b.title, 'ko');
+      return order === 'desc' ? -cmp : cmp;
+    });
+  }
+
+  return NextResponse.json({ total: data.length, data });
+}

--- a/apps/qaground/app/api/practice/auth/me/route.ts
+++ b/apps/qaground/app/api/practice/auth/me/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+import { DEMO_TOKEN } from '@/shared/practice-api/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const auth = request.headers.get('authorization');
+  if (auth === 'Bearer expired-token') {
+    return NextResponse.json({ error: 'token_expired' }, { status: 401 });
+  }
+  if (auth !== `Bearer ${DEMO_TOKEN}`) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+  }
+  return NextResponse.json({ id: 1, email: 'tester@qaground.dev', role: 'member' });
+}

--- a/apps/qaground/app/api/practice/auth/refresh/route.ts
+++ b/apps/qaground/app/api/practice/auth/refresh/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+import { DEMO_TOKEN } from '@/shared/practice-api/auth';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const refreshToken = (body as { refreshToken?: unknown } | null)?.refreshToken;
+  if (refreshToken !== 'qaground-refresh-token') {
+    return NextResponse.json({ error: 'invalid_refresh_token' }, { status: 401 });
+  }
+
+  return NextResponse.json({ token: DEMO_TOKEN, expiresIn: 3600 });
+}

--- a/apps/qaground/app/api/practice/files/[id]/route.ts
+++ b/apps/qaground/app/api/practice/files/[id]/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const FILES = new Map([
+  [
+    'file-1001',
+    { id: 'file-1001', fileName: 'report.pdf', mimeType: 'application/pdf', size: 204800 },
+  ],
+]);
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const file = FILES.get(id);
+  if (!file) {
+    return NextResponse.json({ error: '파일을 찾을 수 없습니다.' }, { status: 404 });
+  }
+  return NextResponse.json(file);
+}

--- a/apps/qaground/app/api/practice/files/route.ts
+++ b/apps/qaground/app/api/practice/files/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const ALLOWED_TYPES = new Set(['image/png', 'image/jpeg', 'application/pdf']);
+const MAX_SIZE = 5 * 1024 * 1024;
+
+const UploadSchema = z
+  .object({
+    fileName: z.string().trim().min(1).max(120),
+    mimeType: z.string().trim().min(1),
+    size: z.number().int().positive(),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = UploadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (!ALLOWED_TYPES.has(parsed.data.mimeType)) {
+    return NextResponse.json({ error: 'unsupported_mime_type' }, { status: 415 });
+  }
+  if (parsed.data.size > MAX_SIZE) {
+    return NextResponse.json({ error: 'file_too_large', maxSize: MAX_SIZE }, { status: 413 });
+  }
+
+  return NextResponse.json(
+    { id: 'file-1001', status: 'uploaded', ...parsed.data },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/health/route.ts
+++ b/apps/qaground/app/api/practice/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const mode = new URL(request.url).searchParams.get('mode');
+  if (mode === 'degraded') {
+    return NextResponse.json(
+      { status: 'degraded', checks: { database: 'ok', queue: 'slow' } },
+      { status: 503 }
+    );
+  }
+  return NextResponse.json({ status: 'ok', checks: { database: 'ok', queue: 'ok' } });
+}

--- a/apps/qaground/app/api/practice/notifications/[id]/read/route.ts
+++ b/apps/qaground/app/api/practice/notifications/[id]/read/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const IDS = new Set(['301', '302', '303']);
+
+export async function PATCH(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!/^\d+$/.test(id)) {
+    return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
+  }
+  if (!IDS.has(id)) {
+    return NextResponse.json({ error: '알림을 찾을 수 없습니다.' }, { status: 404 });
+  }
+  return NextResponse.json({
+    id: Number(id),
+    read: true,
+    unreadCount: id === '301' || id === '302' ? 1 : 2,
+  });
+}

--- a/apps/qaground/app/api/practice/notifications/route.ts
+++ b/apps/qaground/app/api/practice/notifications/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const NOTIFICATIONS = [
+  { id: 301, title: '새 댓글이 등록되었습니다', read: false, type: 'comment' },
+  { id: 302, title: '예약이 확정되었습니다', read: false, type: 'reservation' },
+  { id: 303, title: '리포트 생성이 완료되었습니다', read: true, type: 'report' },
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const unreadOnly = searchParams.get('unreadOnly') === 'true';
+  const data = unreadOnly ? NOTIFICATIONS.filter((n) => !n.read) : NOTIFICATIONS;
+  return NextResponse.json({ unreadCount: NOTIFICATIONS.filter((n) => !n.read).length, data });
+}

--- a/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
+++ b/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const CommentSchema = z.object({ body: z.string().trim().min(1).max(300) }).strict();
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  if (!/^\d+$/.test(id)) {
+    return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
+  }
+  if (id === '999') {
+    return NextResponse.json({ error: '게시글을 찾을 수 없습니다.' }, { status: 404 });
+  }
+  if (id === '702') {
+    return NextResponse.json({ error: 'deleted_post' }, { status: 409 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = CommentSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(
+    { id: 8001, postId: Number(id), body: parsed.data.body },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
+++ b/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
+const POSTS = [
+  { id: 701, deleted: false },
+  { id: 702, deleted: true },
+];
+
 const CommentSchema = z.object({ body: z.string().trim().min(1).max(300) }).strict();
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -11,10 +16,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   if (!/^\d+$/.test(id)) {
     return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
   }
-  if (id === '999') {
+
+  const post = POSTS.find((item) => item.id === Number(id));
+  if (!post) {
     return NextResponse.json({ error: '게시글을 찾을 수 없습니다.' }, { status: 404 });
   }
-  if (id === '702') {
+  if (post.deleted) {
     return NextResponse.json({ error: 'deleted_post' }, { status: 409 });
   }
 

--- a/apps/qaground/app/api/practice/posts/route.ts
+++ b/apps/qaground/app/api/practice/posts/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const POSTS = [
+  { id: 701, title: 'QA 회고 공유', author: 'tester', deleted: false },
+  { id: 702, title: '삭제된 게시글', author: 'admin', deleted: true },
+];
+
+const CreateSchema = z.object({ title: z.string().trim().min(2).max(80) }).strict();
+
+export async function GET() {
+  return NextResponse.json({
+    total: POSTS.filter((post) => !post.deleted).length,
+    data: POSTS.filter((post) => !post.deleted),
+  });
+}
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (parsed.data.title.includes('금칙어')) {
+    return NextResponse.json({ error: 'blocked_word' }, { status: 422 });
+  }
+  return NextResponse.json(
+    { id: 9001, title: parsed.data.title, author: 'tester', deleted: false },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/reports/route.ts
+++ b/apps/qaground/app/api/practice/reports/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const ReportSchema = z
+  .object({
+    targetType: z.enum(['post', 'comment']),
+    targetId: z.number().int().positive(),
+    reason: z.string().trim().min(3).max(120),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+  const parsed = ReportSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (parsed.data.targetId === 701) {
+    return NextResponse.json({ error: 'duplicate_report' }, { status: 409 });
+  }
+  return NextResponse.json({ id: 'report-9001', status: 'received' }, { status: 201 });
+}

--- a/apps/qaground/app/api/practice/reservations/route.ts
+++ b/apps/qaground/app/api/practice/reservations/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const CreateSchema = z
+  .object({
+    slotId: z.string().min(1),
+    name: z.string().trim().min(1).max(50),
+    email: z.email(),
+  })
+  .strict();
+
+const FULL_SLOTS = new Set(['slot-1000']);
+const VALID_SLOTS = new Set(['slot-0900', 'slot-1000', 'slot-1100', 'slot-0900-2']);
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (!VALID_SLOTS.has(parsed.data.slotId)) {
+    return NextResponse.json({ error: 'slot_not_found' }, { status: 404 });
+  }
+  if (FULL_SLOTS.has(parsed.data.slotId)) {
+    return NextResponse.json({ error: 'slot_full' }, { status: 409 });
+  }
+
+  return NextResponse.json(
+    { id: 'resv-9001', status: 'confirmed', ...parsed.data },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/reservations/slots/route.ts
+++ b/apps/qaground/app/api/practice/reservations/slots/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const SLOTS = [
+  { id: 'slot-0900', date: '2026-07-01', time: '09:00', capacity: 2, booked: 0 },
+  { id: 'slot-1000', date: '2026-07-01', time: '10:00', capacity: 2, booked: 2 },
+  { id: 'slot-1100', date: '2026-07-01', time: '11:00', capacity: 2, booked: 1 },
+  { id: 'slot-0900-2', date: '2026-07-02', time: '09:00', capacity: 1, booked: 0 },
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const date = searchParams.get('date');
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'date는 YYYY-MM-DD 형식이어야 합니다.' }, { status: 400 });
+  }
+
+  const data = SLOTS.filter((slot) => slot.date === date).map((slot) => ({
+    ...slot,
+    available: slot.capacity - slot.booked,
+  }));
+  return NextResponse.json({ date, data });
+}

--- a/apps/qaground/app/api/practice/reservations/slots/route.ts
+++ b/apps/qaground/app/api/practice/reservations/slots/route.ts
@@ -9,11 +9,21 @@ const SLOTS = [
   { id: 'slot-0900-2', date: '2026-07-02', time: '09:00', capacity: 1, booked: 0 },
 ];
 
+function isValidIsoDate(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString().slice(0, 10) === date;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const date = searchParams.get('date');
-  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: 'date는 YYYY-MM-DD 형식이어야 합니다.' }, { status: 400 });
+  if (!date || !isValidIsoDate(date)) {
+    return NextResponse.json(
+      { error: 'date는 유효한 YYYY-MM-DD 형식이어야 합니다.' },
+      { status: 400 }
+    );
   }
 
   const data = SLOTS.filter((slot) => slot.date === date).map((slot) => ({

--- a/apps/qaground/app/api/practice/tickets/[id]/route.ts
+++ b/apps/qaground/app/api/practice/tickets/[id]/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+
+import { isAuthorized } from '@/shared/practice-api/auth';
+import { findTicket } from '@/shared/practice-api/data';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const UpdateSchema = z
+  .object({
+    status: z.enum(['open', 'pending', 'resolved']).optional(),
+    assignee: z.string().trim().min(1).max(50).nullable().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, { message: '수정할 필드가 없습니다.' });
+
+function parseId(id: string): number | null {
+  return /^\d+$/.test(id) ? Number(id) : null;
+}
+
+/**
+ * GET /api/practice/tickets/:id
+ * - 숫자가 아닌 id: 400 / 없음: 404 / 존재: 200 { ...ticket }.
+ */
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const ticketId = parseId(id);
+  if (ticketId === null) {
+    return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
+  }
+
+  const ticket = findTicket(ticketId);
+  if (!ticket) {
+    return NextResponse.json({ error: '티켓을 찾을 수 없습니다.' }, { status: 404 });
+  }
+
+  return NextResponse.json(ticket);
+}
+
+/**
+ * PATCH /api/practice/tickets/:id
+ * - 인증 필요: 토큰 없으면 401.
+ * - 상태·담당자 변경. 본문 검증 실패: 400 / 없음: 404 / 성공: 200.
+ */
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const ticketId = parseId(id);
+  if (ticketId === null) {
+    return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
+  }
+
+  const ticket = findTicket(ticketId);
+  if (!ticket) {
+    return NextResponse.json({ error: '티켓을 찾을 수 없습니다.' }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = UpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json({ ...ticket, ...parsed.data });
+}

--- a/apps/qaground/app/api/practice/tickets/route.ts
+++ b/apps/qaground/app/api/practice/tickets/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from 'next/server';
+
+import { TICKETS, type TicketPriority, type TicketStatus } from '@/shared/practice-api/data';
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const StatusSchema = z.enum(['open', 'pending', 'resolved']);
+const PrioritySchema = z.enum(['low', 'medium', 'high']);
+
+const CreateSchema = z
+  .object({
+    title: z.string().trim().min(1).max(120),
+    customerEmail: z.email(),
+    priority: PrioritySchema.default('medium'),
+    description: z.string().trim().max(1000).optional(),
+  })
+  .strict();
+
+/**
+ * GET /api/practice/tickets?page=1&limit=5&status=open&priority=high&assignee=support-a&q=로그인
+ * - 페이지네이션 + 상태·우선순위·담당자 필터 + 제목/이메일 검색.
+ */
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const page = Math.max(1, Number(searchParams.get('page') ?? '1') || 1);
+  const limit = Math.min(50, Math.max(1, Number(searchParams.get('limit') ?? '5') || 5));
+  const status = searchParams.get('status') as TicketStatus | null;
+  const priority = searchParams.get('priority') as TicketPriority | null;
+  const assignee = searchParams.get('assignee');
+  const q = (searchParams.get('q') ?? '').trim().toLowerCase();
+
+  let filtered = TICKETS.slice();
+  if (status && StatusSchema.safeParse(status).success) {
+    filtered = filtered.filter((ticket) => ticket.status === status);
+  }
+  if (priority && PrioritySchema.safeParse(priority).success) {
+    filtered = filtered.filter((ticket) => ticket.priority === priority);
+  }
+  if (assignee === 'unassigned') {
+    filtered = filtered.filter((ticket) => ticket.assignee === null);
+  } else if (assignee) {
+    filtered = filtered.filter((ticket) => ticket.assignee === assignee);
+  }
+  if (q) {
+    filtered = filtered.filter(
+      (ticket) =>
+        ticket.title.toLowerCase().includes(q) || ticket.customerEmail.toLowerCase().includes(q)
+    );
+  }
+
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const data = filtered.slice((page - 1) * limit, page * limit);
+
+  return NextResponse.json({ page, limit, total, totalPages, data });
+}
+
+/**
+ * POST /api/practice/tickets
+ * - 본문 검증 실패: 400 { error, issues }.
+ * - 성공: 201 { id, title, customerEmail, status, priority, assignee, createdAt }.
+ *   데모라 실제로 영속하지 않는다.
+ */
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = CreateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      id: 9001,
+      title: parsed.data.title,
+      customerEmail: parsed.data.customerEmail,
+      status: 'open',
+      priority: parsed.data.priority,
+      assignee: null,
+      createdAt: '2026-06-28T00:00:00.000Z',
+    },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/wallet/transactions/route.ts
+++ b/apps/qaground/app/api/practice/wallet/transactions/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+const TRANSACTIONS = [
+  { id: 'tx-1', type: 'deposit', amount: 50000, balanceAfter: 150000, memo: '충전' },
+  { id: 'tx-2', type: 'withdrawal', amount: 12000, balanceAfter: 138000, memo: '송금' },
+];
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get('type');
+  const data = type ? TRANSACTIONS.filter((tx) => tx.type === type) : TRANSACTIONS;
+  return NextResponse.json({ balance: 138000, total: data.length, data });
+}

--- a/apps/qaground/app/api/practice/wallet/transfer/route.ts
+++ b/apps/qaground/app/api/practice/wallet/transfer/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const BALANCE = 138000;
+const TransferSchema = z
+  .object({
+    to: z.string().trim().min(1),
+    amount: z.number().int().positive(),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = TransferSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (parsed.data.amount > BALANCE) {
+    return NextResponse.json({ error: 'insufficient_balance', balance: BALANCE }, { status: 409 });
+  }
+
+  return NextResponse.json(
+    { id: 'tx-9001', balanceAfter: BALANCE - parsed.data.amount },
+    { status: 201 }
+  );
+}

--- a/apps/qaground/app/api/practice/webhooks/payment/route.ts
+++ b/apps/qaground/app/api/practice/webhooks/payment/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+
+import { z } from 'zod';
+
+export const dynamic = 'force-dynamic';
+
+const PayloadSchema = z
+  .object({
+    eventId: z.string().trim().min(1),
+    type: z.enum(['payment.succeeded', 'payment.failed']),
+    amount: z.number().int().positive(),
+  })
+  .strict();
+
+export async function POST(request: Request) {
+  if (request.headers.get('x-qaground-signature') !== 'test-signature') {
+    return NextResponse.json({ error: 'invalid_signature' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  const parsed = PayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: '입력이 올바르지 않습니다.', issues: parsed.error.issues },
+      { status: 400 }
+    );
+  }
+  if (parsed.data.eventId === 'evt-duplicate') {
+    return NextResponse.json({ ok: true, duplicate: true });
+  }
+
+  return NextResponse.json({ ok: true, received: parsed.data.type });
+}

--- a/apps/qaground/app/api/submissions/route.ts
+++ b/apps/qaground/app/api/submissions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { gradeApiAttempts } from '@/shared/challenges/api-hidden-grader';
 import { getChallenge } from '@/shared/challenges/registry';
 import { getDatabase, qagroundSubmissions } from '@testea/db';
 import { z } from 'zod';
@@ -16,6 +17,34 @@ const BodySchema = z
     anonId: z.string().max(64).optional(),
   })
   .strict();
+
+const ApiAssertionSchema = z
+  .object({
+    kind: z.enum(['status', 'json']),
+    path: z.string(),
+    expected: z.string(),
+  })
+  .strict();
+
+const ApiCheckSchema = z.object({ pass: z.boolean() }).passthrough();
+
+const ApiAttemptSchema = z
+  .object({
+    method: z.string(),
+    path: z.string(),
+    status: z.number().int(),
+    assertions: z.array(ApiAssertionSchema),
+    script: z.string(),
+    checks: z.array(ApiCheckSchema),
+    scriptResults: z.array(ApiCheckSchema),
+  })
+  .strict();
+
+const ApiContentSchema = z
+  .object({
+    attempts: z.array(ApiAttemptSchema).max(100),
+  })
+  .passthrough();
 
 // 제출 내용 jsonb 크기 상한(직렬화 기준). 남용·과대 페이로드 차단.
 const MAX_CONTENT_BYTES = 50_000;
@@ -73,6 +102,18 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: 'content_too_large' }, { status: 413 });
   }
 
+  const apiContent =
+    parsed.data.kind === 'api' ? ApiContentSchema.safeParse(parsed.data.content) : null;
+  const serverResult =
+    apiContent?.success && challenge.endpoints
+      ? {
+          ...(parsed.data.result && typeof parsed.data.result === 'object'
+            ? parsed.data.result
+            : {}),
+          hiddenGrade: gradeApiAttempts(apiContent.data.attempts, { targets: challenge.endpoints }),
+        }
+      : (parsed.data.result ?? null);
+
   try {
     const db = getDatabase();
     await db.insert(qagroundSubmissions).values({
@@ -80,7 +121,7 @@ export async function POST(request: Request) {
       track: challenge.track,
       kind: parsed.data.kind,
       content: parsed.data.content ?? {},
-      result: parsed.data.result ?? null,
+      result: serverResult,
       anon_id: parsed.data.anonId ?? null,
     });
     return NextResponse.json({ ok: true });

--- a/apps/qaground/app/favicon.ico/route.ts
+++ b/apps/qaground/app/favicon.ico/route.ts
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-static';
+
+export function GET() {
+  redirect('/icon');
+}

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ApiAttemptForGrade, gradeApiAttempts } from './api-hidden-grader';
+
+const baseAttempt: ApiAttemptForGrade = {
+  method: 'GET',
+  path: '/status/200',
+  status: 200,
+  assertions: [{ kind: 'status', path: '', expected: '200' }],
+  script: '',
+  checks: [{ pass: true }],
+  scriptResults: [],
+};
+
+describe('gradeApiAttempts', () => {
+  it('부분 점수를 계산한다', () => {
+    const result = gradeApiAttempts([baseAttempt]);
+
+    expect(result.score).toBe(40);
+    expect(result.maxScore).toBe(100);
+    expect(result.passed).toBe(2);
+  });
+
+  it('성공/실패 경로와 본문 단언을 모두 커버하면 만점이다', () => {
+    const result = gradeApiAttempts(
+      [
+        baseAttempt,
+        {
+          ...baseAttempt,
+          method: 'GET',
+          path: '/status/404',
+          status: 404,
+          assertions: [
+            { kind: 'status', path: '', expected: '404' },
+            { kind: 'json', path: 'message', expected: 'Not Found' },
+          ],
+        },
+      ],
+      {
+        targets: [
+          { method: 'GET', path: '/status/200' },
+          { method: 'GET', path: '/status/404' },
+        ],
+      }
+    );
+
+    expect(result.score).toBe(100);
+    expect(result.passed).toBe(result.total);
+  });
+
+  it('실패한 사용자 단언은 성공/실패 경로 채점에 반영하지 않는다', () => {
+    const result = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        checks: [{ pass: false }],
+      },
+    ]);
+
+    expect(result.score).toBe(0);
+    expect(result.cases.find((item) => item.id === 'success-path')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
+  });
+
+  it('주석과 문자열 안의 pm.response 참조는 단언으로 세지 않는다', () => {
+    const result = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        assertions: [],
+        script: `
+          // pm.expect(pm.response.json().total).to.eql(12);
+          const note = "pm.response.code";
+          console.log(response.status);
+        `,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(false);
+  });
+
+  it('본문 단언은 pm.response.json 값을 실제 expect 대상으로 묶은 경우만 인정한다', () => {
+    const parseOnly = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        assertions: [],
+        script: `
+          const body = pm.response.json();
+          pm.response.to.have.status(200);
+        `,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+    const bodyAssert = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        assertions: [],
+        script: `pm.expect(pm.response.json().total).to.eql(12);`,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+
+    expect(parseOnly.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(false);
+    expect(bodyAssert.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(true);
+  });
+
+  it('쿼리 문자열이 다른 대상 엔드포인트를 서로 다른 coverage로 계산한다', () => {
+    const result = gradeApiAttempts(
+      [
+        {
+          ...baseAttempt,
+          path: '/health',
+          assertions: [{ kind: 'status', path: '', expected: '200' }],
+        },
+        {
+          ...baseAttempt,
+          path: '/health?mode=degraded',
+          status: 503,
+          assertions: [
+            { kind: 'status', path: '', expected: '503' },
+            { kind: 'json', path: 'status', expected: 'degraded' },
+          ],
+        },
+      ],
+      {
+        targets: [
+          { method: 'GET', path: '/health' },
+          { method: 'GET', path: '/health?mode=degraded' },
+        ],
+      }
+    );
+
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(true);
+  });
+
+  it('템플릿 엔드포인트는 실제 경로 세그먼트와 매칭한다', () => {
+    const result = gradeApiAttempts(
+      [
+        {
+          ...baseAttempt,
+          path: '/products/1',
+        },
+      ],
+      { targets: [{ method: 'GET', path: '/products/:id' }] }
+    );
+
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(true);
+  });
+
+  it('대상 챌린지 엔드포인트 밖의 요청은 숨김 점수로 인정하지 않는다', () => {
+    const result = gradeApiAttempts(
+      [
+        baseAttempt,
+        {
+          ...baseAttempt,
+          path: '/status/404',
+          status: 404,
+        },
+      ],
+      { targets: [{ method: 'GET', path: '/admin/reports' }] }
+    );
+
+    expect(result.cases.find((item) => item.id === 'success-path')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'failure-path')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
+  });
+});

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -1,0 +1,258 @@
+export interface ApiAssertionForGrade {
+  kind: 'status' | 'json';
+  path: string;
+  expected: string;
+}
+
+export interface ApiCheckForGrade {
+  pass: boolean;
+}
+
+export interface ApiScriptResultForGrade {
+  pass: boolean;
+}
+
+export interface ApiAttemptForGrade {
+  method: string;
+  path: string;
+  status: number;
+  assertions: ApiAssertionForGrade[];
+  script: string;
+  checks: ApiCheckForGrade[];
+  scriptResults: ApiScriptResultForGrade[];
+}
+
+export interface ApiTargetForGrade {
+  method: string;
+  path: string;
+}
+
+export interface ApiGradeOptions {
+  targets?: ApiTargetForGrade[];
+}
+
+export interface HiddenGradeCase {
+  id: string;
+  points: number;
+  pass: boolean;
+}
+
+export interface HiddenGradeResult {
+  score: number;
+  maxScore: number;
+  passed: number;
+  total: number;
+  cases: HiddenGradeCase[];
+}
+
+interface NormalizedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  segments: string[];
+}
+
+function hasPassingUserChecks(attempt: ApiAttemptForGrade): boolean {
+  const checks = [...attempt.checks, ...attempt.scriptResults];
+  return checks.length > 0 && checks.every((check) => check.pass);
+}
+
+function stripNonExecutableJavaScript(script: string): string {
+  let output = '';
+  let quote: 'single' | 'double' | 'template' | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < script.length; i += 1) {
+    const current = script[i];
+    const next = script[i + 1];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (current === '\\') {
+        escaped = true;
+      } else if (
+        (quote === 'single' && current === "'") ||
+        (quote === 'double' && current === '"') ||
+        (quote === 'template' && current === '`')
+      ) {
+        quote = null;
+      }
+      output += current === '\n' ? '\n' : ' ';
+      continue;
+    }
+
+    if (current === "'") {
+      quote = 'single';
+      output += ' ';
+      continue;
+    }
+    if (current === '"') {
+      quote = 'double';
+      output += ' ';
+      continue;
+    }
+    if (current === '`') {
+      quote = 'template';
+      output += ' ';
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      while (i < script.length && script[i] !== '\n') i += 1;
+      output += '\n';
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      i += 2;
+      while (i < script.length && !(script[i] === '*' && script[i + 1] === '/')) {
+        output += script[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
+      i += 1;
+      continue;
+    }
+
+    output += current;
+  }
+
+  return output;
+}
+
+function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
+  if (attempt.assertions.some((assertion) => assertion.kind === 'status')) return true;
+  const executable = stripNonExecutableJavaScript(attempt.script);
+  return (
+    /pm\.response\.to\.have\.status\s*\(/i.test(executable) ||
+    /pm\.expect\s*\(\s*(?:pm\.response\.code|response\.status)\s*\)\s*(?:\.to|\.be|\.that|\.have)*\s*\.(?:eql|equal|above|below)\s*\(/i.test(
+      executable
+    )
+  );
+}
+
+function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
+  if (attempt.assertions.some((assertion) => assertion.kind === 'json' && assertion.path.trim())) {
+    return true;
+  }
+  const executable = stripNonExecutableJavaScript(attempt.script);
+  return /pm\.expect\s*\(\s*pm\.response\.json\s*\(\s*\)\s*(?:\.[A-Za-z_$][\w$]*|\[[^\]]+\])*\s*\)\s*(?:\.to|\.be|\.that|\.have)*\s*\.(?:eql|equal|include|lengthOf|property|a|above|below)\s*\(/i.test(
+    executable
+  );
+}
+
+function normalizeRequest(input: ApiAttemptForGrade | ApiTargetForGrade): NormalizedRequest {
+  const rawPath = input.path.trim() || '/';
+  let pathname = '/';
+  let search = '';
+
+  try {
+    const url = new URL(rawPath, 'https://qaground.local');
+    pathname = url.pathname || '/';
+    search = url.search;
+  } catch {
+    const [withoutHash] = rawPath.split('#');
+    const [rawPathname, rawSearch] = withoutHash.split('?');
+    pathname = rawPathname.startsWith('/') ? rawPathname : `/${rawPathname}`;
+    search = rawSearch ? `?${rawSearch}` : '';
+  }
+
+  return {
+    method: input.method.toUpperCase(),
+    pathname,
+    search,
+    segments: pathname.split('/').filter(Boolean),
+  };
+}
+
+function matchesTarget(attempt: ApiAttemptForGrade, target: ApiTargetForGrade): boolean {
+  const actual = normalizeRequest(attempt);
+  const expected = normalizeRequest(target);
+  if (actual.method !== expected.method) return false;
+  if (actual.search !== expected.search) return false;
+  if (actual.segments.length !== expected.segments.length) return false;
+
+  return expected.segments.every((segment, index) => {
+    if (segment.startsWith(':')) return actual.segments[index].length > 0;
+    return segment === actual.segments[index];
+  });
+}
+
+function getTargetAttempts(
+  attempts: ApiAttemptForGrade[],
+  options?: ApiGradeOptions
+): ApiAttemptForGrade[] {
+  const targets = options?.targets ?? [];
+  if (targets.length === 0) return attempts;
+  return attempts.filter((attempt) => targets.some((target) => matchesTarget(attempt, target)));
+}
+
+function hasRequestCoverage(attempts: ApiAttemptForGrade[], options?: ApiGradeOptions): boolean {
+  const targets = options?.targets ?? [];
+  const passingAttempts = attempts.filter(hasPassingUserChecks);
+
+  if (targets.length > 0) {
+    return targets.every((target) =>
+      passingAttempts.some((attempt) => matchesTarget(attempt, target))
+    );
+  }
+
+  const attemptedKeys = new Set(
+    passingAttempts.map((attempt) => {
+      const normalized = normalizeRequest(attempt);
+      return `${normalized.method} ${normalized.pathname}${normalized.search}`;
+    })
+  );
+  return attemptedKeys.size >= 2;
+}
+
+export function gradeApiAttempts(
+  attempts: ApiAttemptForGrade[],
+  options?: ApiGradeOptions
+): HiddenGradeResult {
+  const targetAttempts = getTargetAttempts(attempts, options);
+  const cases: HiddenGradeCase[] = [
+    {
+      id: 'success-path',
+      points: 20,
+      pass: targetAttempts.some(
+        (attempt) => attempt.status >= 200 && attempt.status < 300 && hasPassingUserChecks(attempt)
+      ),
+    },
+    {
+      id: 'failure-path',
+      points: 20,
+      pass: targetAttempts.some(
+        (attempt) => attempt.status >= 400 && hasPassingUserChecks(attempt)
+      ),
+    },
+    {
+      id: 'request-coverage',
+      points: 20,
+      pass: hasRequestCoverage(attempts, options),
+    },
+    {
+      id: 'status-assertion',
+      points: 20,
+      pass: targetAttempts.some(
+        (attempt) => hasPassingUserChecks(attempt) && hasStatusAssertion(attempt)
+      ),
+    },
+    {
+      id: 'body-assertion',
+      points: 20,
+      pass: targetAttempts.some(
+        (attempt) => hasPassingUserChecks(attempt) && hasBodyAssertion(attempt)
+      ),
+    },
+  ];
+
+  const score = cases.filter((item) => item.pass).reduce((sum, item) => sum + item.points, 0);
+  const maxScore = cases.reduce((sum, item) => sum + item.points, 0);
+
+  return {
+    score,
+    maxScore,
+    passed: cases.filter((item) => item.pass).length,
+    total: cases.length,
+    cases,
+  };
+}

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -1437,6 +1437,283 @@ test('내 테스트', async ({ page }) => {
 `,
   },
   {
+    slug: 'rest-api-auth-session',
+    title: '인증·세션 API: 토큰 만료와 갱신',
+    track: 'api',
+    category: 'auth',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '로그인 후 보호된 /me API를 호출하고, 누락·만료·잘못된 토큰과 refresh token 갱신 경로를 검증하세요.',
+    requirement: [
+      '유효한 로그인은 token을 반환하고, 잘못된 자격증명은 401을 반환한다.',
+      'GET /auth/me 는 유효한 Bearer 토큰에서 200과 사용자 정보를 반환한다.',
+      '토큰이 없거나 expired-token 이면 각각 401과 에러 코드를 반환한다.',
+      'POST /auth/refresh 는 유효한 refreshToken 에서 새 token을 반환하고, 잘못된 refreshToken 은 401을 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'POST', path: '/auth/login', desc: '로그인' },
+      { method: 'GET', path: '/auth/me', auth: true, desc: '내 정보 조회' },
+      { method: 'POST', path: '/auth/refresh', desc: '토큰 갱신' },
+    ],
+    apiNote:
+      '데모 계정은 tester@qaground.dev / qaground123, refreshToken은 qaground-refresh-token 입니다. expired-token으로 만료 토큰 경로를 검증할 수 있습니다.',
+  },
+  {
+    slug: 'rest-api-reservations',
+    title: '예약 API: 슬롯 조회와 중복 방지',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '날짜별 예약 가능 슬롯을 조회하고, 만석 슬롯·잘못된 날짜·필수값 누락 같은 예약 API 경계 조건을 검증하세요.',
+    requirement: [
+      'GET /reservations/slots 는 YYYY-MM-DD 날짜에서 슬롯 목록과 available 값을 반환한다.',
+      '날짜 형식이 없거나 잘못되면 400을 반환한다.',
+      'POST /reservations 는 유효한 슬롯과 고객 정보에서 201 confirmed를 반환한다.',
+      '만석 슬롯은 409, 없는 슬롯은 404, 잘못된 이메일이나 이름 누락은 400을 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/reservations/slots?date=2026-07-01', desc: '날짜별 슬롯 조회' },
+      { method: 'POST', path: '/reservations', desc: '예약 생성 (400 / 404 / 409 / 201)' },
+    ],
+    apiNote:
+      '예약 생성 예: { "slotId": "slot-0900", "name": "김테스터", "email": "tester@example.com" }. slot-1000은 만석이라 409를 반환합니다.',
+  },
+  {
+    slug: 'rest-api-file-metadata',
+    title: '파일 메타데이터 API: 형식·용량 검증',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'easy',
+    tools: ['Postman'],
+    summary:
+      'JSON 기반 파일 메타데이터 업로드 API로 MIME type, 파일 크기, 단건 메타데이터 조회를 검증하세요.',
+    requirement: [
+      '허용 MIME(image/png, image/jpeg, application/pdf)과 5MB 이하 크기에서는 201 uploaded를 반환한다.',
+      '허용되지 않은 MIME type은 415를 반환한다.',
+      '5MB 초과 파일은 413과 maxSize를 반환한다.',
+      'GET /files/:id 는 존재하는 파일에서 200, 없는 파일에서 404를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'POST', path: '/files', desc: '파일 메타데이터 업로드 (400 / 413 / 415 / 201)' },
+      { method: 'GET', path: '/files/file-1001', desc: '파일 메타데이터 조회' },
+    ],
+    apiNote:
+      '요청 본문 예: { "fileName": "report.pdf", "mimeType": "application/pdf", "size": 204800 }. 브라우저 내 API 테스터 특성상 multipart 대신 메타데이터 API로 연습합니다.',
+  },
+  {
+    slug: 'rest-api-notifications',
+    title: '알림 API: 읽음 처리와 unread count',
+    track: 'api',
+    category: 'async',
+    difficulty: 'easy',
+    tools: ['Postman'],
+    summary:
+      '알림 목록과 읽음 처리 API에서 unreadOnly 필터, unreadCount, 없는 알림 처리와 멱등적 PATCH 응답을 검증하세요.',
+    requirement: [
+      'GET /notifications 는 unreadCount와 전체 알림 목록을 반환한다.',
+      'unreadOnly=true 는 읽지 않은 알림만 반환한다.',
+      'PATCH /notifications/:id/read 는 존재하는 알림에서 200과 read=true를 반환한다.',
+      '숫자가 아닌 ID는 400, 없는 ID는 404를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/notifications', desc: '알림 목록' },
+      { method: 'GET', path: '/notifications?unreadOnly=true', desc: '읽지 않은 알림만' },
+      { method: 'PATCH', path: '/notifications/301/read', desc: '읽음 처리' },
+    ],
+  },
+  {
+    slug: 'rest-api-rbac-admin',
+    title: '권한 API: 관리자 전용 리포트',
+    track: 'api',
+    category: 'auth',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '관리자 전용 API에서 미인증 401, 일반 사용자 403, 관리자 200 경계를 구분해 검증하세요.',
+    requirement: [
+      'Authorization 헤더가 없으면 401을 반환한다.',
+      '일반 토큰(qaground-demo-token)은 인증은 되었지만 관리자 권한이 없어 403을 반환한다.',
+      '관리자 토큰(qaground-admin-token)은 200과 운영 리포트 데이터를 반환한다.',
+      '401과 403을 같은 실패로 뭉개지 않고 각각 다른 의미로 단언한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [{ method: 'GET', path: '/admin/reports', auth: true, desc: '관리자 전용 리포트' }],
+    apiNote:
+      '일반 토큰은 qaground-demo-token, 관리자 토큰은 qaground-admin-token 입니다. 같은 엔드포인트를 토큰별로 반복 실행해 401/403/200을 비교하세요.',
+  },
+  {
+    slug: 'rest-api-articles-search',
+    title: '검색 API: 키워드·태그·정렬 조합',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary: '문서 검색 API에서 q, tag, sort, order 파라미터 조합과 total 메타데이터를 검증하세요.',
+    requirement: [
+      'q는 제목 부분검색으로 동작하고 total이 결과 수와 일치한다.',
+      'tag=api 는 API 태그 문서만 반환한다.',
+      'sort=views&order=desc 는 조회수 내림차순으로 정렬한다.',
+      '검색어와 태그를 조합해도 결과 집합과 total이 일관된다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/articles?q=API', desc: '키워드 검색' },
+      { method: 'GET', path: '/articles?tag=api&sort=views&order=desc', desc: '태그+정렬 조합' },
+    ],
+  },
+  {
+    slug: 'rest-api-webhook-signature',
+    title: '웹훅 API: 서명 검증과 중복 이벤트',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'hard',
+    tools: ['Postman'],
+    summary: '결제 웹훅 수신 API에서 서명 헤더, payload 검증, 중복 eventId 처리를 검증하세요.',
+    requirement: [
+      'x-qaground-signature 헤더가 없거나 틀리면 401을 반환한다.',
+      '유효 서명과 올바른 payload는 200과 ok=true를 반환한다.',
+      '필수 필드 누락, 허용되지 않은 type, 0 이하 amount는 400을 반환한다.',
+      'eventId=evt-duplicate 는 200과 duplicate=true를 반환해 멱등 처리 경로를 드러낸다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'POST', path: '/webhooks/payment', desc: '결제 웹훅 수신 (401 / 400 / 200)' },
+    ],
+    apiNote:
+      '헤더 x-qaground-signature: test-signature 를 넣어야 합니다. 본문 예: { "eventId": "evt-100", "type": "payment.succeeded", "amount": 39000 }.',
+  },
+  {
+    slug: 'rest-api-wallet-transfer',
+    title: '지갑 API: 잔액과 송금 검증',
+    track: 'api',
+    category: 'fintech',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '지갑 잔액·거래내역 조회와 송금 API에서 금액 검증, 잔액 부족, 거래내역 필터를 검증하세요.',
+    requirement: [
+      'GET /wallet/transactions 는 balance, total, 거래내역 배열을 반환한다.',
+      'type=deposit/withdrawal 필터가 적용되고 total이 결과 수와 일치한다.',
+      '송금 금액은 양의 정수여야 하며 0·음수·누락은 400을 반환한다.',
+      '잔액보다 큰 송금은 409 insufficient_balance를 반환하고, 정상 송금은 201과 balanceAfter를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/wallet/transactions?type=withdrawal', desc: '거래내역 필터' },
+      { method: 'POST', path: '/wallet/transfer', desc: '송금 (400 / 409 / 201)' },
+    ],
+    apiNote: '송금 예: { "to": "bank-001", "amount": 12000 }. 현재 데모 잔액은 138000입니다.',
+  },
+  {
+    slug: 'rest-api-content-moderation',
+    title: '콘텐츠 API: 댓글·신고·금칙어',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '게시글 생성, 댓글 작성, 신고 API에서 금칙어, 삭제된 글 댓글 금지, 중복 신고 같은 콘텐츠 정책을 검증하세요.',
+    requirement: [
+      '게시글 목록은 삭제되지 않은 글만 반환한다.',
+      '게시글 생성은 유효 제목에서 201, 짧은 제목은 400, 금칙어 포함은 422를 반환한다.',
+      '댓글 작성은 존재하는 글에서 201, 삭제된 글에서 409, 없는 글에서 404를 반환한다.',
+      '신고 생성은 정상 요청에서 201, 중복 신고 대상에서는 409를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/posts', desc: '게시글 목록' },
+      { method: 'POST', path: '/posts', desc: '게시글 생성 (400 / 422 / 201)' },
+      { method: 'POST', path: '/posts/701/comments', desc: '댓글 작성 (400 / 404 / 409 / 201)' },
+      { method: 'POST', path: '/reports', desc: '신고 생성 (400 / 409 / 201)' },
+    ],
+  },
+  {
+    slug: 'rest-api-health-monitoring',
+    title: '운영 API: 헬스체크와 장애 응답',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'easy',
+    tools: ['Postman'],
+    summary:
+      '헬스체크 API에서 정상 상태와 degraded 상태의 HTTP status, JSON checks 필드를 검증하세요.',
+    requirement: [
+      'GET /health 는 200과 status=ok, database=ok, queue=ok를 반환한다.',
+      'GET /health?mode=degraded 는 503과 status=degraded, queue=slow를 반환한다.',
+      '운영 API 테스트에서는 HTTP 상태와 body 상태 필드를 함께 단언한다.',
+      '503도 JSON body를 반환하므로 실패 응답 본문을 파싱해 검증한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/health', desc: '정상 헬스체크' },
+      { method: 'GET', path: '/health?mode=degraded', desc: '장애 상태 헬스체크' },
+    ],
+  },
+  {
+    slug: 'rest-api-support-tickets',
+    title: '고객지원 티켓 API: 필터·상태 변경',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '고객지원 티켓 API에서 상태·우선순위·담당자 필터, 티켓 생성 입력 검증, 보호된 상태 변경 API를 검증하세요. 실무 API 테스트에서 자주 만나는 목록 메타데이터와 권한 경계, 부분 수정(PATCH)을 함께 연습합니다.',
+    requirement: [
+      '티켓 목록은 page·limit 메타데이터를 포함하고, status·priority·assignee·q 필터가 조합되어 적용된다.',
+      '단건 조회는 존재하는 ID에서 200과 티켓 객체를 반환하고, 없는 ID는 404, 숫자가 아닌 ID는 400을 반환한다.',
+      '티켓 생성은 유효한 title·customerEmail·priority 에서 201과 open 상태 티켓을 반환하고, 잘못된 이메일·빈 제목은 400을 반환한다.',
+      '상태 변경(PATCH)은 Authorization 헤더가 없으면 401을 반환하고, 정상 토큰과 유효한 status/assignee 에서 200을 반환한다.',
+      'PATCH 본문이 비어 있거나 허용되지 않는 status 값이면 400을 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/tickets?status=open&priority=high', desc: '상태·우선순위 필터' },
+      { method: 'GET', path: '/tickets?assignee=unassigned&q=로그인', desc: '미배정 티켓 검색' },
+      { method: 'GET', path: '/tickets/501', desc: '티켓 단건 조회 (400 / 404 / 200)' },
+      { method: 'POST', path: '/tickets', desc: '티켓 생성 (400 / 201)' },
+      {
+        method: 'PATCH',
+        path: '/tickets/501',
+        auth: true,
+        desc: '상태·담당자 변경 (401 / 400 / 404 / 200)',
+      },
+    ],
+    apiNote:
+      'PATCH 는 Bearer qaground-demo-token 인증이 필요합니다. 생성 예: { "title": "비밀번호 재설정 문의", "customerEmail": "user@example.com", "priority": "high" }. 수정 예: { "status": "pending", "assignee": "support-a" }. assignee=unassigned 는 미배정 티켓만 반환합니다.',
+  },
+  {
+    slug: 'rest-api-product-crud-auth',
+    title: '상품 관리 API: 인증·CRUD 검증',
+    track: 'api',
+    category: 'commerce',
+    difficulty: 'medium',
+    tools: ['Postman'],
+    summary:
+      '로그인으로 토큰을 발급받고, 보호된 상품 생성·수정·삭제 API의 인증, 입력 검증, 상태 코드를 검증하세요. 성공 경로뿐 아니라 401·400·404·204 같은 API 경계 응답까지 함께 확인해야 합니다.',
+    requirement: [
+      'POST /auth/login 은 유효한 데모 계정으로 200과 token 을 반환하고, 잘못된 자격증명은 401 을 반환한다.',
+      '보호된 상품 생성·수정·삭제 요청은 Authorization 헤더가 없으면 401 을 반환한다.',
+      '정상 토큰으로 상품을 생성하면 201과 생성된 상품 객체를 반환하고, 필수값 누락·잘못된 price 는 400 을 반환한다.',
+      '상품 수정은 존재하는 ID와 유효한 본문에서 200을 반환하고, 빈 본문·없는 ID·숫자가 아닌 ID는 각각 에러 상태를 반환한다.',
+      '상품 삭제는 정상 토큰과 존재하는 ID에서 204 No Content 를 반환하고, 없는 ID는 404 를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'POST', path: '/auth/login', desc: '데모 계정 로그인 후 토큰 발급' },
+      { method: 'POST', path: '/products', auth: true, desc: '상품 생성 (401 / 400 / 201)' },
+      { method: 'PUT', path: '/products/1', auth: true, desc: '상품 수정 (401 / 400 / 404 / 200)' },
+      { method: 'DELETE', path: '/products/1', auth: true, desc: '상품 삭제 (401 / 404 / 204)' },
+    ],
+    apiNote:
+      '데모 계정은 tester@qaground.dev / qaground123 입니다. 로그인 응답의 token 또는 qaground-demo-token 을 Bearer 토큰으로 사용하세요. 상품 생성 예: { "name": "테스트 상품", "price": 12000, "category": "기타" }. 데모 API는 실제로 영속하지 않으므로 삭제·수정 후 목록 변경을 전제로 두지 마세요.',
+  },
+  {
     slug: 'rest-api-products-advanced',
     title: '상품 목록 API: 검색·정렬·필터',
     track: 'api',
@@ -1506,6 +1783,30 @@ test('내 테스트', async ({ page }) => {
     ],
     apiNote:
       '요청 본문 예: { "customer": "홍길동", "items": [{ "name": "키보드", "qty": 2, "price": 39000 }] }. total 은 서버가 계산합니다. 빈 items·음수 수량 등 실패 케이스도 검증하세요.',
+  },
+  {
+    slug: 'rest-api-status-basic',
+    title: '상태 코드 API 입문: 200·404 검증',
+    track: 'api',
+    category: 'fundamentals',
+    difficulty: 'easy',
+    tools: ['Postman'],
+    summary:
+      '상태 코드 시뮬레이터로 API 응답의 status code와 JSON 본문을 함께 검증하는 입문 챌린지입니다. 성공 응답과 실패 응답을 나란히 확인하며 기본 단언 흐름을 익히세요.',
+    requirement: [
+      'GET /status/200 은 HTTP 200과 본문 { status: 200, message: "OK" }를 반환한다.',
+      'GET /status/404 는 HTTP 404와 본문 { status: 404, message: "Not Found" }를 반환한다.',
+      'HTTP 상태 코드뿐 아니라 응답 JSON의 status·message 필드를 함께 단언한다.',
+      '숫자가 아닌 상태 코드 요청은 400과 error 필드를 반환한다.',
+    ],
+    apiBase: '/api/practice',
+    endpoints: [
+      { method: 'GET', path: '/status/200', desc: '성공 응답 기본 검증' },
+      { method: 'GET', path: '/status/404', desc: 'Not Found 응답 검증' },
+      { method: 'GET', path: '/status/abc', desc: '잘못된 코드 → 400' },
+    ],
+    apiNote:
+      '처음에는 구조화된 단언으로 상태 코드와 JSON 필드를 검증해 보세요. 예: status == 200, message == OK. 이후 pm.test 스크립트로 같은 검증을 옮겨 보면 좋습니다.',
   },
   {
     slug: 'rest-api-errors',

--- a/apps/qaground/src/shared/practice-api/data.ts
+++ b/apps/qaground/src/shared/practice-api/data.ts
@@ -87,3 +87,67 @@ export const ORDERS: Order[] = [
 export function findOrder(id: number): Order | undefined {
   return ORDERS.find((o) => o.id === id);
 }
+export type TicketStatus = 'open' | 'pending' | 'resolved';
+export type TicketPriority = 'low' | 'medium' | 'high';
+
+export interface Ticket {
+  id: number;
+  title: string;
+  customerEmail: string;
+  status: TicketStatus;
+  priority: TicketPriority;
+  assignee: string | null;
+  createdAt: string;
+}
+
+export const TICKETS: Ticket[] = [
+  {
+    id: 501,
+    title: '로그인 인증 메일이 오지 않아요',
+    customerEmail: 'minji@example.com',
+    status: 'open',
+    priority: 'high',
+    assignee: null,
+    createdAt: '2026-06-01T09:00:00.000Z',
+  },
+  {
+    id: 502,
+    title: '결제 영수증 재발급 요청',
+    customerEmail: 'billing@example.com',
+    status: 'pending',
+    priority: 'medium',
+    assignee: 'support-a',
+    createdAt: '2026-06-02T10:30:00.000Z',
+  },
+  {
+    id: 503,
+    title: '프로젝트 멤버 초대 오류',
+    customerEmail: 'lead@example.com',
+    status: 'open',
+    priority: 'medium',
+    assignee: 'support-b',
+    createdAt: '2026-06-03T14:20:00.000Z',
+  },
+  {
+    id: 504,
+    title: 'CSV 내보내기 파일이 깨져요',
+    customerEmail: 'qa@example.com',
+    status: 'resolved',
+    priority: 'low',
+    assignee: 'support-a',
+    createdAt: '2026-06-04T08:15:00.000Z',
+  },
+  {
+    id: 505,
+    title: '자동화 실행 결과가 지연됩니다',
+    customerEmail: 'runner@example.com',
+    status: 'pending',
+    priority: 'high',
+    assignee: null,
+    createdAt: '2026-06-05T16:45:00.000Z',
+  },
+];
+
+export function findTicket(id: number): Ticket | undefined {
+  return TICKETS.find((ticket) => ticket.id === id);
+}

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -16,7 +16,7 @@ const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ),
 });
 
-type Method = 'GET' | 'POST' | 'PUT' | 'DELETE';
+type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
 type AssertKind = 'status' | 'json';
 interface Assertion {
   id: number;
@@ -41,7 +41,7 @@ interface RunResult {
   scriptResults: PmResult[];
 }
 
-const METHODS: Method[] = ['GET', 'POST', 'PUT', 'DELETE'];
+const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
 
 /** 점(.) 경로로 JSON 값 탐색. eval 없이 구조적 접근만 한다. (`data.0.id` 등) */
 function getByPath(obj: unknown, path: string): unknown {

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -6,6 +6,12 @@ import dynamic from 'next/dynamic';
 
 import { recordSubmission } from '@/shared/analytics/record-submission';
 import { track } from '@/shared/analytics/track';
+import {
+  type ApiAttemptForGrade,
+  type ApiTargetForGrade,
+  type HiddenGradeResult,
+  gradeApiAttempts,
+} from '@/shared/challenges/api-hidden-grader';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
@@ -39,6 +45,7 @@ interface RunResult {
   bodyText: string;
   checks: Check[];
   scriptResults: PmResult[];
+  hiddenGrade: HiddenGradeResult;
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
@@ -180,6 +187,36 @@ pm.test('상태 코드는 200', () => {
 // });
 `;
 
+function parseHeaderInput(input: string): Record<string, string> {
+  const trimmed = input.trim();
+  if (!trimmed) return {};
+
+  if (trimmed.startsWith('{')) {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('추가 헤더 JSON은 객체여야 합니다.');
+    }
+    return Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value)]));
+  }
+
+  return Object.fromEntries(
+    trimmed.split('\n').map((line) => {
+      const separator = line.indexOf(':');
+      if (separator <= 0) throw new Error('추가 헤더는 "이름: 값" 형식이어야 합니다.');
+      return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+    })
+  );
+}
+const SENSITIVE_HEADER_NAME = /^(authorization|cookie|set-cookie|x-api-key|x-qaground-signature)$/i;
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [
+      key,
+      SENSITIVE_HEADER_NAME.test(key) ? '[REDACTED]' : value,
+    ])
+  );
+}
 let nextId = 2;
 
 /**
@@ -188,10 +225,19 @@ let nextId = 2;
  * 포스트맨처럼 요청을 구성하고, (1) 구조화된 단언 또는 (2) pm.test 스크립트로 응답을 검증한다.
  * 스크립트는 사용자 브라우저에서만 평가하므로 격리 러너·서버 코드 실행이 필요 없다.
  */
-export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: string }) => {
+export const ApiTesterExercise = ({
+  apiBase,
+  slug,
+  endpoints,
+}: {
+  apiBase: string;
+  slug: string;
+  endpoints: ApiTargetForGrade[];
+}) => {
   const [method, setMethod] = useState<Method>('GET');
   const [path, setPath] = useState('/products?page=1&limit=5');
   const [token, setToken] = useState('');
+  const [customHeaders, setCustomHeaders] = useState('');
   const [body, setBody] = useState('');
   const [assertions, setAssertions] = useState<Assertion[]>([
     { id: 1, kind: 'status', path: '', expected: '200' },
@@ -200,6 +246,7 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
   const [running, setRunning] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
+  const [attempts, setAttempts] = useState<ApiAttemptForGrade[]>([]);
 
   const updateAssertion = (id: number, patch: Partial<Assertion>) =>
     setAssertions((as) => as.map((a) => (a.id === id ? { ...a, ...patch } : a)));
@@ -212,7 +259,7 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
     setError('');
     setResult(null);
     try {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = parseHeaderInput(customHeaders);
       if (token.trim()) headers['Authorization'] = `Bearer ${token.trim()}`;
       const hasBody = method !== 'GET' && body.trim();
       if (hasBody) headers['Content-Type'] = 'application/json';
@@ -252,16 +299,36 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
         ? runPmScript(script, { status: res.status, json, bodyText })
         : [];
 
+      const attempt: ApiAttemptForGrade = {
+        method,
+        path,
+        status: res.status,
+        assertions,
+        script,
+        checks,
+        scriptResults,
+      };
+      const nextAttempts = [...attempts, attempt];
+      const hiddenGrade = gradeApiAttempts(nextAttempts, { targets: endpoints });
+      setAttempts(nextAttempts);
+
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
-      setResult({ status: res.status, bodyText: pretty, checks, scriptResults });
+      setResult({ status: res.status, bodyText: pretty, checks, scriptResults, hiddenGrade });
       const passed =
         checks.filter((c) => c.pass).length + scriptResults.filter((r) => r.pass).length;
       const totalChecks = checks.length + scriptResults.length;
-      track('api_run', { passed, total: totalChecks });
+      track('api_run', { passed, total: totalChecks, score: hiddenGrade.score });
       recordSubmission({
         slug,
         kind: 'api',
-        content: { method, path, assertions, script },
+        content: {
+          method,
+          path,
+          headers: redactHeaders(headers),
+          assertions,
+          script,
+          attempts: nextAttempts,
+        },
         result: { passed, total: totalChecks },
       });
     } catch (e) {
@@ -321,6 +388,15 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
           placeholder="Bearer 토큰 (보호된 요청에만, 예: qaground-demo-token)"
           className={`h-button-md ${fieldClass}`}
+        />
+
+        <textarea
+          data-testid="api-headers"
+          value={customHeaders}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCustomHeaders(e.target.value)}
+          rows={2}
+          placeholder={'추가 헤더 (선택)\nx-qaground-signature: test-signature'}
+          className={`py-2 font-mono ${fieldClass}`}
         />
 
         {method !== 'GET' && (
@@ -446,6 +522,36 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
             >
               {passCount}/{total} 통과
             </span>
+          </div>
+
+          <div className="border-line-2 bg-bg-3 mt-4 rounded-xl border p-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-text-1 text-sm font-semibold">숨김 채점</span>
+              <span
+                className={`font-mono text-sm font-semibold ${
+                  result.hiddenGrade.score === result.hiddenGrade.maxScore
+                    ? 'text-primary'
+                    : 'text-text-1'
+                }`}
+              >
+                {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}점
+              </span>
+            </div>
+            <p className="text-text-3 mt-1 text-xs">
+              숨김 케이스 {result.hiddenGrade.passed}/{result.hiddenGrade.total} 통과
+            </p>
+            <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
+              {result.hiddenGrade.cases.map((item, index) => (
+                <span
+                  key={item.id}
+                  className={`border-line-2 rounded-lg border px-2 py-1 text-center text-xs font-medium ${
+                    item.pass ? 'text-primary' : 'text-text-3'
+                  }`}
+                >
+                  #{index + 1} {item.pass ? '통과' : '실패'}
+                </span>
+              ))}
+            </div>
           </div>
 
           {result.checks.length > 0 && (

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -212,7 +212,11 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
                   starterSpec={challenge.starterSpec}
                 />
               ) : (
-                <ApiTesterExercise apiBase={challenge.apiBase!} slug={challenge.slug} />
+                <ApiTesterExercise
+                  apiBase={challenge.apiBase!}
+                  slug={challenge.slug}
+                  endpoints={challenge.endpoints!}
+                />
               )}
             </div>
           </div>

--- a/apps/qaground/src/view/challenges/challenges-view.tsx
+++ b/apps/qaground/src/view/challenges/challenges-view.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 
 import {
   CATEGORY_LABEL,
+  CHALLENGES,
   type Challenge,
   type ChallengeCategory,
   type ChallengeDifficulty,
@@ -59,7 +60,7 @@ function ChallengeCard({ challenge }: { challenge: Challenge }) {
   );
 }
 
-type Selected = ChallengeCategory | 'all';
+type Selected = ChallengeCategory | 'api' | 'all';
 
 /**
  * 선택 카테고리는 쿼리스트링(`?category=`)으로 받는다. 필터된 화면을 그대로
@@ -67,11 +68,25 @@ type Selected = ChallengeCategory | 'all';
  */
 export const ChallengesView = ({ selectedCategory }: { selectedCategory?: string }) => {
   const groups = challengesByCategory();
+  const visibleCategoryGroups = groups.filter((g) => g.category !== 'data');
   const total = groups.reduce((n, g) => n + g.items.length, 0);
+  const apiChallenges = CHALLENGES.filter((c) => c.track === 'api');
 
-  const isValid = groups.some((g) => g.category === selectedCategory);
-  const selected: Selected = isValid ? (selectedCategory as ChallengeCategory) : 'all';
-  const visible = selected === 'all' ? groups : groups.filter((g) => g.category === selected);
+  const isCategory = visibleCategoryGroups.some((g) => g.category === selectedCategory);
+  const selected: Selected =
+    selectedCategory === 'api'
+      ? 'api'
+      : isCategory
+        ? (selectedCategory as ChallengeCategory)
+        : 'all';
+  const visible =
+    selected === 'all'
+      ? groups.map((g) => ({ key: g.category, label: CATEGORY_LABEL[g.category], items: g.items }))
+      : selected === 'api'
+        ? [{ key: 'api', label: 'API', items: apiChallenges }]
+        : groups
+            .filter((g) => g.category === selected)
+            .map((g) => ({ key: g.category, label: CATEGORY_LABEL[g.category], items: g.items }));
 
   const navItem = (key: Selected, label: string, count: number) => {
     const active = selected === key;
@@ -107,15 +122,18 @@ export const ChallengesView = ({ selectedCategory }: { selectedCategory?: string
           <aside className="sm:w-44 sm:shrink-0">
             <nav className="flex gap-1 overflow-x-auto sm:sticky sm:top-24 sm:flex-col sm:overflow-visible">
               {navItem('all', '전체', total)}
-              {groups.map((g) => navItem(g.category, CATEGORY_LABEL[g.category], g.items.length))}
+              {navItem('api', 'API', apiChallenges.length)}
+              {visibleCategoryGroups.map((g) =>
+                navItem(g.category, CATEGORY_LABEL[g.category], g.items.length)
+              )}
             </nav>
           </aside>
 
           <div className="flex flex-1 flex-col gap-12">
             {visible.map((group) => (
-              <section key={group.category}>
+              <section key={group.key}>
                 <h2 className="mb-4 flex items-baseline gap-2 text-lg font-semibold">
-                  {CATEGORY_LABEL[group.category]}
+                  {group.label}
                   <span className="text-text-3 text-sm font-normal">{group.items.length}</span>
                 </h2>
                 <ul className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## 작업 유형

- [x] feat — 새 기능
- [ ] fix — 버그 수정
- [ ] hotfix — 긴급 수정 (프로덕션 장애 등)
- [ ] refactor — 리팩토링 (동작 변경 없음)
- [ ] perf — 성능 개선
- [ ] style — 코드 포맷 / 스타일 (동작 변경 없음)
- [ ] docs — 문서
- [ ] chore — 빌드·툴링·의존성 등 기타
- [ ] test — 테스트코드 작성·수정

## 요약

qaground에 API 연습 챌린지 세트를 추가합니다. API 카테고리 필터를 추가하고, 인증·예약·파일·알림·권한·검색·웹훅·지갑·콘텐츠·헬스체크 등 다양한 도메인의 연습용 API를 제공합니다.

## 배경 / 동기

기존 API 챌린지가 상품/커머스 주제에 치우쳐 있어 QA 관점에서 더 다양한 API 테스트 상황을 연습할 수 있도록 확장합니다.

- 관련 이슈: #
- 관련 FDD / 문서:

## 변경 사항

- qaground 챌린지 목록에 API 전용 좌측 필터를 추가하고 데이터 카테고리 필터 중복 노출을 정리했습니다.
- API 테스터에서 PATCH 메서드를 실행할 수 있도록 선택지를 추가했습니다.
- 상태 코드 입문, 인증/세션, 예약, 파일 메타데이터, 알림, RBAC, 검색, 웹훅, 지갑, 콘텐츠, 고객지원 티켓, 상품 CRUD API 챌린지를 추가했습니다.
- 각 챌린지에서 호출 가능한 `/api/practice/*` 연습용 API route와 샘플 데이터를 추가했습니다.

## 스크린샷 / 데모

| Before | After |
| ------ | ----- |
|        |       |

## 테스트 방법

1. `pnpm --filter qaground test`
2. `pnpm --filter qaground lint`
3. `http://localhost:3200/challenges?category=api`에서 API 챌린지 목록 노출 확인
4. 샘플 API 호출 확인: `/api/practice/reservations/slots?date=2026-07-01`, `/api/practice/wallet/transfer`

## 영향 범위 / 주의사항

- [ ] DB 스키마 / 마이그레이션 변경 있음
- [ ] 환경 변수 추가·변경 있음
- [ ] 외부 API / 의존성 변경 있음
- [ ] 인프라 / 배포 설정 변경 있음
- [x] 위 항목 모두 해당 없음

## 체크리스트

- [ ] 로컬에서 빌드 / 타입 체크 통과 확인
- [x] 관련 화면을 브라우저에서 직접 동작 확인 (UI 변경 시)
- [x] 골든 패스 외 엣지 케이스도 확인
- [x] 기존 기능에 회귀가 없는지 확인
- [x] 시크릿 / 키 / 개인정보가 코드·로그에 포함되지 않음