### PR TITLE
feat(qaground): API 숨김 채점 추가

### DIFF
--- a/apps/qaground/app/api/practice/admin/reports/route.ts
+++ b/apps/qaground/app/api/practice/admin/reports/route.ts
@@ -1,14 +1,21 @@
 import { NextResponse } from 'next/server';
 
+import { DEMO_TOKEN } from '@/shared/practice-api/auth';
+
 export const dynamic = 'force-dynamic';
+
+const ADMIN_TOKEN = 'qaground-admin-token';
 
 export async function GET(request: Request) {
   const auth = request.headers.get('authorization');
   if (!auth) {
     return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
   }
-  if (auth !== 'Bearer qaground-admin-token') {
+  if (auth === `Bearer ${DEMO_TOKEN}`) {
     return NextResponse.json({ error: '관리자 권한이 필요합니다.' }, { status: 403 });
+  }
+  if (auth !== `Bearer ${ADMIN_TOKEN}`) {
+    return NextResponse.json({ error: '인증이 필요합니다.' }, { status: 401 });
   }
   return NextResponse.json({ activeUsers: 128, failedJobs: 2, abuseReports: 3 });
 }

--- a/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
+++ b/apps/qaground/app/api/practice/posts/[id]/comments/route.ts
@@ -4,6 +4,11 @@ import { z } from 'zod';
 
 export const dynamic = 'force-dynamic';
 
+const POSTS = [
+  { id: 701, deleted: false },
+  { id: 702, deleted: true },
+];
+
 const CommentSchema = z.object({ body: z.string().trim().min(1).max(300) }).strict();
 
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -11,10 +16,12 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
   if (!/^\d+$/.test(id)) {
     return NextResponse.json({ error: 'id는 숫자여야 합니다.' }, { status: 400 });
   }
-  if (id === '999') {
+
+  const post = POSTS.find((item) => item.id === Number(id));
+  if (!post) {
     return NextResponse.json({ error: '게시글을 찾을 수 없습니다.' }, { status: 404 });
   }
-  if (id === '702') {
+  if (post.deleted) {
     return NextResponse.json({ error: 'deleted_post' }, { status: 409 });
   }
 

--- a/apps/qaground/app/api/practice/reservations/slots/route.ts
+++ b/apps/qaground/app/api/practice/reservations/slots/route.ts
@@ -9,11 +9,21 @@ const SLOTS = [
   { id: 'slot-0900-2', date: '2026-07-02', time: '09:00', capacity: 1, booked: 0 },
 ];
 
+function isValidIsoDate(date: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return false;
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString().slice(0, 10) === date;
+}
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const date = searchParams.get('date');
-  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: 'date는 YYYY-MM-DD 형식이어야 합니다.' }, { status: 400 });
+  if (!date || !isValidIsoDate(date)) {
+    return NextResponse.json(
+      { error: 'date는 유효한 YYYY-MM-DD 형식이어야 합니다.' },
+      { status: 400 }
+    );
   }
 
   const data = SLOTS.filter((slot) => slot.date === date).map((slot) => ({

--- a/apps/qaground/app/api/submissions/route.ts
+++ b/apps/qaground/app/api/submissions/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 
+import { gradeApiAttempts } from '@/shared/challenges/api-hidden-grader';
 import { getChallenge } from '@/shared/challenges/registry';
 import { getDatabase, qagroundSubmissions } from '@testea/db';
 import { z } from 'zod';
@@ -16,6 +17,34 @@ const BodySchema = z
     anonId: z.string().max(64).optional(),
   })
   .strict();
+
+const ApiAssertionSchema = z
+  .object({
+    kind: z.enum(['status', 'json']),
+    path: z.string(),
+    expected: z.string(),
+  })
+  .strict();
+
+const ApiCheckSchema = z.object({ pass: z.boolean() }).passthrough();
+
+const ApiAttemptSchema = z
+  .object({
+    method: z.string(),
+    path: z.string(),
+    status: z.number().int(),
+    assertions: z.array(ApiAssertionSchema),
+    script: z.string(),
+    checks: z.array(ApiCheckSchema),
+    scriptResults: z.array(ApiCheckSchema),
+  })
+  .strict();
+
+const ApiContentSchema = z
+  .object({
+    attempts: z.array(ApiAttemptSchema).max(100),
+  })
+  .passthrough();
 
 // 제출 내용 jsonb 크기 상한(직렬화 기준). 남용·과대 페이로드 차단.
 const MAX_CONTENT_BYTES = 50_000;
@@ -73,6 +102,18 @@ export async function POST(request: Request) {
     return NextResponse.json({ ok: false, error: 'content_too_large' }, { status: 413 });
   }
 
+  const apiContent =
+    parsed.data.kind === 'api' ? ApiContentSchema.safeParse(parsed.data.content) : null;
+  const serverResult =
+    apiContent?.success && challenge.endpoints
+      ? {
+          ...(parsed.data.result && typeof parsed.data.result === 'object'
+            ? parsed.data.result
+            : {}),
+          hiddenGrade: gradeApiAttempts(apiContent.data.attempts, { targets: challenge.endpoints }),
+        }
+      : (parsed.data.result ?? null);
+
   try {
     const db = getDatabase();
     await db.insert(qagroundSubmissions).values({
@@ -80,7 +121,7 @@ export async function POST(request: Request) {
       track: challenge.track,
       kind: parsed.data.kind,
       content: parsed.data.content ?? {},
-      result: parsed.data.result ?? null,
+      result: serverResult,
       anon_id: parsed.data.anonId ?? null,
     });
     return NextResponse.json({ ok: true });

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { type ApiAttemptForGrade, gradeApiAttempts } from './api-hidden-grader';
+
+const baseAttempt: ApiAttemptForGrade = {
+  method: 'GET',
+  path: '/status/200',
+  status: 200,
+  assertions: [{ kind: 'status', path: '', expected: '200' }],
+  script: '',
+  checks: [{ pass: true }],
+  scriptResults: [],
+};
+
+describe('gradeApiAttempts', () => {
+  it('부분 점수를 계산한다', () => {
+    const result = gradeApiAttempts([baseAttempt]);
+
+    expect(result.score).toBe(40);
+    expect(result.maxScore).toBe(100);
+    expect(result.passed).toBe(2);
+  });
+
+  it('성공/실패 경로와 본문 단언을 모두 커버하면 만점이다', () => {
+    const result = gradeApiAttempts([
+      baseAttempt,
+      {
+        ...baseAttempt,
+        method: 'GET',
+        path: '/status/404',
+        status: 404,
+        assertions: [
+          { kind: 'status', path: '', expected: '404' },
+          { kind: 'json', path: 'message', expected: 'Not Found' },
+        ],
+      },
+    ]);
+
+    expect(result.score).toBe(100);
+    expect(result.passed).toBe(result.total);
+  });
+
+  it('실패한 사용자 단언은 성공/실패 경로 채점에 반영하지 않는다', () => {
+    const result = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        checks: [{ pass: false }],
+      },
+    ]);
+
+    expect(result.score).toBe(0);
+    expect(result.cases.find((item) => item.id === 'success-path')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
+  });
+});

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
@@ -62,16 +62,47 @@ describe('gradeApiAttempts', () => {
     expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
   });
 
-  it('주석 처리된 pm.response.json 예시는 본문 단언으로 세지 않는다', () => {
+  it('주석과 문자열 안의 pm.response 참조는 단언으로 세지 않는다', () => {
     const result = gradeApiAttempts([
       {
         ...baseAttempt,
-        script: `// pm.expect(pm.response.json().total).to.eql(12);`,
+        assertions: [],
+        script: `
+          // pm.expect(pm.response.json().total).to.eql(12);
+          const note = "pm.response.code";
+          console.log(response.status);
+        `,
         scriptResults: [{ pass: true }],
       },
     ]);
 
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
     expect(result.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(false);
+  });
+
+  it('본문 단언은 pm.response.json 값을 실제 expect 대상으로 묶은 경우만 인정한다', () => {
+    const parseOnly = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        assertions: [],
+        script: `
+          const body = pm.response.json();
+          pm.response.to.have.status(200);
+        `,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+    const bodyAssert = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        assertions: [],
+        script: `pm.expect(pm.response.json().total).to.eql(12);`,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+
+    expect(parseOnly.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(false);
+    expect(bodyAssert.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(true);
   });
 
   it('쿼리 문자열이 다른 대상 엔드포인트를 서로 다른 coverage로 계산한다', () => {
@@ -103,7 +134,21 @@ describe('gradeApiAttempts', () => {
     expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(true);
   });
 
-  it('대상 챌린지 엔드포인트 밖의 요청은 coverage로 인정하지 않는다', () => {
+  it('템플릿 엔드포인트는 실제 경로 세그먼트와 매칭한다', () => {
+    const result = gradeApiAttempts(
+      [
+        {
+          ...baseAttempt,
+          path: '/products/1',
+        },
+      ],
+      { targets: [{ method: 'GET', path: '/products/:id' }] }
+    );
+
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(true);
+  });
+
+  it('대상 챌린지 엔드포인트 밖의 요청은 숨김 점수로 인정하지 않는다', () => {
     const result = gradeApiAttempts(
       [
         baseAttempt,
@@ -116,6 +161,9 @@ describe('gradeApiAttempts', () => {
       { targets: [{ method: 'GET', path: '/admin/reports' }] }
     );
 
+    expect(result.cases.find((item) => item.id === 'success-path')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'failure-path')?.pass).toBe(false);
     expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
+    expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
   });
 });

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.test.ts
@@ -22,19 +22,27 @@ describe('gradeApiAttempts', () => {
   });
 
   it('성공/실패 경로와 본문 단언을 모두 커버하면 만점이다', () => {
-    const result = gradeApiAttempts([
-      baseAttempt,
+    const result = gradeApiAttempts(
+      [
+        baseAttempt,
+        {
+          ...baseAttempt,
+          method: 'GET',
+          path: '/status/404',
+          status: 404,
+          assertions: [
+            { kind: 'status', path: '', expected: '404' },
+            { kind: 'json', path: 'message', expected: 'Not Found' },
+          ],
+        },
+      ],
       {
-        ...baseAttempt,
-        method: 'GET',
-        path: '/status/404',
-        status: 404,
-        assertions: [
-          { kind: 'status', path: '', expected: '404' },
-          { kind: 'json', path: 'message', expected: 'Not Found' },
+        targets: [
+          { method: 'GET', path: '/status/200' },
+          { method: 'GET', path: '/status/404' },
         ],
-      },
-    ]);
+      }
+    );
 
     expect(result.score).toBe(100);
     expect(result.passed).toBe(result.total);
@@ -52,5 +60,62 @@ describe('gradeApiAttempts', () => {
     expect(result.cases.find((item) => item.id === 'success-path')?.pass).toBe(false);
     expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
     expect(result.cases.find((item) => item.id === 'status-assertion')?.pass).toBe(false);
+  });
+
+  it('주석 처리된 pm.response.json 예시는 본문 단언으로 세지 않는다', () => {
+    const result = gradeApiAttempts([
+      {
+        ...baseAttempt,
+        script: `// pm.expect(pm.response.json().total).to.eql(12);`,
+        scriptResults: [{ pass: true }],
+      },
+    ]);
+
+    expect(result.cases.find((item) => item.id === 'body-assertion')?.pass).toBe(false);
+  });
+
+  it('쿼리 문자열이 다른 대상 엔드포인트를 서로 다른 coverage로 계산한다', () => {
+    const result = gradeApiAttempts(
+      [
+        {
+          ...baseAttempt,
+          path: '/health',
+          assertions: [{ kind: 'status', path: '', expected: '200' }],
+        },
+        {
+          ...baseAttempt,
+          path: '/health?mode=degraded',
+          status: 503,
+          assertions: [
+            { kind: 'status', path: '', expected: '503' },
+            { kind: 'json', path: 'status', expected: 'degraded' },
+          ],
+        },
+      ],
+      {
+        targets: [
+          { method: 'GET', path: '/health' },
+          { method: 'GET', path: '/health?mode=degraded' },
+        ],
+      }
+    );
+
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(true);
+  });
+
+  it('대상 챌린지 엔드포인트 밖의 요청은 coverage로 인정하지 않는다', () => {
+    const result = gradeApiAttempts(
+      [
+        baseAttempt,
+        {
+          ...baseAttempt,
+          path: '/status/404',
+          status: 404,
+        },
+      ],
+      { targets: [{ method: 'GET', path: '/admin/reports' }] }
+    );
+
+    expect(result.cases.find((item) => item.id === 'request-coverage')?.pass).toBe(false);
   });
 });

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -1,0 +1,109 @@
+export interface ApiAssertionForGrade {
+  kind: 'status' | 'json';
+  path: string;
+  expected: string;
+}
+
+export interface ApiCheckForGrade {
+  pass: boolean;
+}
+
+export interface ApiScriptResultForGrade {
+  pass: boolean;
+}
+
+export interface ApiAttemptForGrade {
+  method: string;
+  path: string;
+  status: number;
+  assertions: ApiAssertionForGrade[];
+  script: string;
+  checks: ApiCheckForGrade[];
+  scriptResults: ApiScriptResultForGrade[];
+}
+
+export interface HiddenGradeCase {
+  id: string;
+  points: number;
+  pass: boolean;
+}
+
+export interface HiddenGradeResult {
+  score: number;
+  maxScore: number;
+  passed: number;
+  total: number;
+  cases: HiddenGradeCase[];
+}
+
+function hasPassingUserChecks(attempt: ApiAttemptForGrade): boolean {
+  const checks = [...attempt.checks, ...attempt.scriptResults];
+  return checks.length > 0 && checks.every((check) => check.pass);
+}
+
+function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
+  if (attempt.assertions.some((assertion) => assertion.kind === 'status')) return true;
+  return /pm\.response\.to\.have\.status\s*\(|pm\.response\.code|response\.status/i.test(
+    attempt.script
+  );
+}
+
+function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
+  if (attempt.assertions.some((assertion) => assertion.kind === 'json' && assertion.path.trim())) {
+    return true;
+  }
+  return /pm\.response\.json\s*\(\)[\s\S]*(pm\.expect|\.to\.|\.have\.|\.eql\s*\(|\.equal\s*\()/i.test(
+    attempt.script
+  );
+}
+
+function normalizeRequestKey(attempt: ApiAttemptForGrade): string {
+  const rawPath = attempt.path.trim() || '/';
+  const [pathname] = rawPath.split('?');
+  return `${attempt.method.toUpperCase()} ${pathname}`;
+}
+
+export function gradeApiAttempts(attempts: ApiAttemptForGrade[]): HiddenGradeResult {
+  const cases: HiddenGradeCase[] = [
+    {
+      id: 'success-path',
+      points: 20,
+      pass: attempts.some(
+        (attempt) => attempt.status >= 200 && attempt.status < 300 && hasPassingUserChecks(attempt)
+      ),
+    },
+    {
+      id: 'failure-path',
+      points: 20,
+      pass: attempts.some((attempt) => attempt.status >= 400 && hasPassingUserChecks(attempt)),
+    },
+    {
+      id: 'request-coverage',
+      points: 20,
+      pass: new Set(attempts.map(normalizeRequestKey)).size >= 2,
+    },
+    {
+      id: 'status-assertion',
+      points: 20,
+      pass: attempts.some(
+        (attempt) => hasPassingUserChecks(attempt) && hasStatusAssertion(attempt)
+      ),
+    },
+    {
+      id: 'body-assertion',
+      points: 20,
+      pass: attempts.some((attempt) => hasPassingUserChecks(attempt) && hasBodyAssertion(attempt)),
+    },
+  ];
+
+  const score = cases.filter((item) => item.pass).reduce((sum, item) => sum + item.points, 0);
+  const maxScore = cases.reduce((sum, item) => sum + item.points, 0);
+
+  return {
+    score,
+    maxScore,
+    passed: cases.filter((item) => item.pass).length,
+    total: cases.length,
+    cases,
+  };
+}

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -22,6 +22,15 @@ export interface ApiAttemptForGrade {
   scriptResults: ApiScriptResultForGrade[];
 }
 
+export interface ApiTargetForGrade {
+  method: string;
+  path: string;
+}
+
+export interface ApiGradeOptions {
+  targets?: ApiTargetForGrade[];
+}
+
 export interface HiddenGradeCase {
   id: string;
   points: number;
@@ -41,10 +50,68 @@ function hasPassingUserChecks(attempt: ApiAttemptForGrade): boolean {
   return checks.length > 0 && checks.every((check) => check.pass);
 }
 
+function stripJavaScriptComments(script: string): string {
+  let output = '';
+  let quote: 'single' | 'double' | 'template' | null = null;
+  let escaped = false;
+
+  for (let i = 0; i < script.length; i += 1) {
+    const current = script[i];
+    const next = script[i + 1];
+
+    if (quote) {
+      output += current;
+      if (escaped) {
+        escaped = false;
+      } else if (current === '\\') {
+        escaped = true;
+      } else if (
+        (quote === 'single' && current === "'") ||
+        (quote === 'double' && current === '"') ||
+        (quote === 'template' && current === '`')
+      ) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (current === "'") {
+      quote = 'single';
+      output += current;
+      continue;
+    }
+    if (current === '"') {
+      quote = 'double';
+      output += current;
+      continue;
+    }
+    if (current === '`') {
+      quote = 'template';
+      output += current;
+      continue;
+    }
+    if (current === '/' && next === '/') {
+      while (i < script.length && script[i] !== '\n') i += 1;
+      output += '\n';
+      continue;
+    }
+    if (current === '/' && next === '*') {
+      i += 2;
+      while (i < script.length && !(script[i] === '*' && script[i + 1] === '/')) i += 1;
+      i += 1;
+      continue;
+    }
+
+    output += current;
+  }
+
+  return output;
+}
+
 function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
   if (attempt.assertions.some((assertion) => assertion.kind === 'status')) return true;
   return /pm\.response\.to\.have\.status\s*\(|pm\.response\.code|response\.status/i.test(
-    attempt.script
+    stripJavaScriptComments(attempt.script)
   );
 }
 
@@ -53,17 +120,42 @@ function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
     return true;
   }
   return /pm\.response\.json\s*\(\)[\s\S]*(pm\.expect|\.to\.|\.have\.|\.eql\s*\(|\.equal\s*\()/i.test(
-    attempt.script
+    stripJavaScriptComments(attempt.script)
   );
 }
 
-function normalizeRequestKey(attempt: ApiAttemptForGrade): string {
-  const rawPath = attempt.path.trim() || '/';
-  const [pathname] = rawPath.split('?');
-  return `${attempt.method.toUpperCase()} ${pathname}`;
+function normalizeRequestPath(path: string): string {
+  const rawPath = path.trim() || '/';
+  try {
+    const url = new URL(rawPath, 'https://qaground.local');
+    return `${url.pathname}${url.search}`;
+  } catch {
+    const [withoutHash] = rawPath.split('#');
+    return withoutHash.startsWith('/') ? withoutHash : `/${withoutHash}`;
+  }
 }
 
-export function gradeApiAttempts(attempts: ApiAttemptForGrade[]): HiddenGradeResult {
+function normalizeRequestKey(input: ApiAttemptForGrade | ApiTargetForGrade): string {
+  return `${input.method.toUpperCase()} ${normalizeRequestPath(input.path)}`;
+}
+
+function hasRequestCoverage(attempts: ApiAttemptForGrade[], options?: ApiGradeOptions): boolean {
+  const attemptedKeys = new Set(
+    attempts.filter(hasPassingUserChecks).map((attempt) => normalizeRequestKey(attempt))
+  );
+  const targetKeys = options?.targets?.map((target) => normalizeRequestKey(target)) ?? [];
+
+  if (targetKeys.length > 0) {
+    return targetKeys.every((targetKey) => attemptedKeys.has(targetKey));
+  }
+
+  return attemptedKeys.size >= 2;
+}
+
+export function gradeApiAttempts(
+  attempts: ApiAttemptForGrade[],
+  options?: ApiGradeOptions
+): HiddenGradeResult {
   const cases: HiddenGradeCase[] = [
     {
       id: 'success-path',
@@ -80,7 +172,7 @@ export function gradeApiAttempts(attempts: ApiAttemptForGrade[]): HiddenGradeRes
     {
       id: 'request-coverage',
       points: 20,
-      pass: new Set(attempts.map(normalizeRequestKey)).size >= 2,
+      pass: hasRequestCoverage(attempts, options),
     },
     {
       id: 'status-assertion',

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -45,12 +45,19 @@ export interface HiddenGradeResult {
   cases: HiddenGradeCase[];
 }
 
+interface NormalizedRequest {
+  method: string;
+  pathname: string;
+  search: string;
+  segments: string[];
+}
+
 function hasPassingUserChecks(attempt: ApiAttemptForGrade): boolean {
   const checks = [...attempt.checks, ...attempt.scriptResults];
   return checks.length > 0 && checks.every((check) => check.pass);
 }
 
-function stripJavaScriptComments(script: string): string {
+function stripNonExecutableJavaScript(script: string): string {
   let output = '';
   let quote: 'single' | 'double' | 'template' | null = null;
   let escaped = false;
@@ -60,7 +67,6 @@ function stripJavaScriptComments(script: string): string {
     const next = script[i + 1];
 
     if (quote) {
-      output += current;
       if (escaped) {
         escaped = false;
       } else if (current === '\\') {
@@ -72,22 +78,23 @@ function stripJavaScriptComments(script: string): string {
       ) {
         quote = null;
       }
+      output += current === '\n' ? '\n' : ' ';
       continue;
     }
 
     if (current === "'") {
       quote = 'single';
-      output += current;
+      output += ' ';
       continue;
     }
     if (current === '"') {
       quote = 'double';
-      output += current;
+      output += ' ';
       continue;
     }
     if (current === '`') {
       quote = 'template';
-      output += current;
+      output += ' ';
       continue;
     }
     if (current === '/' && next === '/') {
@@ -97,7 +104,10 @@ function stripJavaScriptComments(script: string): string {
     }
     if (current === '/' && next === '*') {
       i += 2;
-      while (i < script.length && !(script[i] === '*' && script[i + 1] === '/')) i += 1;
+      while (i < script.length && !(script[i] === '*' && script[i + 1] === '/')) {
+        output += script[i] === '\n' ? '\n' : ' ';
+        i += 1;
+      }
       i += 1;
       continue;
     }
@@ -110,8 +120,12 @@ function stripJavaScriptComments(script: string): string {
 
 function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
   if (attempt.assertions.some((assertion) => assertion.kind === 'status')) return true;
-  return /pm\.response\.to\.have\.status\s*\(|pm\.response\.code|response\.status/i.test(
-    stripJavaScriptComments(attempt.script)
+  const executable = stripNonExecutableJavaScript(attempt.script);
+  return (
+    /pm\.response\.to\.have\.status\s*\(/i.test(executable) ||
+    /pm\.expect\s*\(\s*(?:pm\.response\.code|response\.status)\s*\)\s*(?:\.to|\.be|\.that|\.have)*\s*\.(?:eql|equal|above|below)\s*\(/i.test(
+      executable
+    )
   );
 }
 
@@ -119,36 +133,74 @@ function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
   if (attempt.assertions.some((assertion) => assertion.kind === 'json' && assertion.path.trim())) {
     return true;
   }
-  return /pm\.response\.json\s*\(\)[\s\S]*(pm\.expect|\.to\.|\.have\.|\.eql\s*\(|\.equal\s*\()/i.test(
-    stripJavaScriptComments(attempt.script)
+  const executable = stripNonExecutableJavaScript(attempt.script);
+  return /pm\.expect\s*\(\s*pm\.response\.json\s*\(\s*\)\s*(?:\.[A-Za-z_$][\w$]*|\[[^\]]+\])*\s*\)\s*(?:\.to|\.be|\.that|\.have)*\s*\.(?:eql|equal|include|lengthOf|property|a|above|below)\s*\(/i.test(
+    executable
   );
 }
 
-function normalizeRequestPath(path: string): string {
-  const rawPath = path.trim() || '/';
+function normalizeRequest(input: ApiAttemptForGrade | ApiTargetForGrade): NormalizedRequest {
+  const rawPath = input.path.trim() || '/';
+  let pathname = '/';
+  let search = '';
+
   try {
     const url = new URL(rawPath, 'https://qaground.local');
-    return `${url.pathname}${url.search}`;
+    pathname = url.pathname || '/';
+    search = url.search;
   } catch {
     const [withoutHash] = rawPath.split('#');
-    return withoutHash.startsWith('/') ? withoutHash : `/${withoutHash}`;
+    const [rawPathname, rawSearch] = withoutHash.split('?');
+    pathname = rawPathname.startsWith('/') ? rawPathname : `/${rawPathname}`;
+    search = rawSearch ? `?${rawSearch}` : '';
   }
+
+  return {
+    method: input.method.toUpperCase(),
+    pathname,
+    search,
+    segments: pathname.split('/').filter(Boolean),
+  };
 }
 
-function normalizeRequestKey(input: ApiAttemptForGrade | ApiTargetForGrade): string {
-  return `${input.method.toUpperCase()} ${normalizeRequestPath(input.path)}`;
+function matchesTarget(attempt: ApiAttemptForGrade, target: ApiTargetForGrade): boolean {
+  const actual = normalizeRequest(attempt);
+  const expected = normalizeRequest(target);
+  if (actual.method !== expected.method) return false;
+  if (actual.search !== expected.search) return false;
+  if (actual.segments.length !== expected.segments.length) return false;
+
+  return expected.segments.every((segment, index) => {
+    if (segment.startsWith(':')) return actual.segments[index].length > 0;
+    return segment === actual.segments[index];
+  });
+}
+
+function getTargetAttempts(
+  attempts: ApiAttemptForGrade[],
+  options?: ApiGradeOptions
+): ApiAttemptForGrade[] {
+  const targets = options?.targets ?? [];
+  if (targets.length === 0) return attempts;
+  return attempts.filter((attempt) => targets.some((target) => matchesTarget(attempt, target)));
 }
 
 function hasRequestCoverage(attempts: ApiAttemptForGrade[], options?: ApiGradeOptions): boolean {
-  const attemptedKeys = new Set(
-    attempts.filter(hasPassingUserChecks).map((attempt) => normalizeRequestKey(attempt))
-  );
-  const targetKeys = options?.targets?.map((target) => normalizeRequestKey(target)) ?? [];
+  const targets = options?.targets ?? [];
+  const passingAttempts = attempts.filter(hasPassingUserChecks);
 
-  if (targetKeys.length > 0) {
-    return targetKeys.every((targetKey) => attemptedKeys.has(targetKey));
+  if (targets.length > 0) {
+    return targets.every((target) =>
+      passingAttempts.some((attempt) => matchesTarget(attempt, target))
+    );
   }
 
+  const attemptedKeys = new Set(
+    passingAttempts.map((attempt) => {
+      const normalized = normalizeRequest(attempt);
+      return `${normalized.method} ${normalized.pathname}${normalized.search}`;
+    })
+  );
   return attemptedKeys.size >= 2;
 }
 
@@ -156,18 +208,21 @@ export function gradeApiAttempts(
   attempts: ApiAttemptForGrade[],
   options?: ApiGradeOptions
 ): HiddenGradeResult {
+  const targetAttempts = getTargetAttempts(attempts, options);
   const cases: HiddenGradeCase[] = [
     {
       id: 'success-path',
       points: 20,
-      pass: attempts.some(
+      pass: targetAttempts.some(
         (attempt) => attempt.status >= 200 && attempt.status < 300 && hasPassingUserChecks(attempt)
       ),
     },
     {
       id: 'failure-path',
       points: 20,
-      pass: attempts.some((attempt) => attempt.status >= 400 && hasPassingUserChecks(attempt)),
+      pass: targetAttempts.some(
+        (attempt) => attempt.status >= 400 && hasPassingUserChecks(attempt)
+      ),
     },
     {
       id: 'request-coverage',
@@ -177,14 +232,16 @@ export function gradeApiAttempts(
     {
       id: 'status-assertion',
       points: 20,
-      pass: attempts.some(
+      pass: targetAttempts.some(
         (attempt) => hasPassingUserChecks(attempt) && hasStatusAssertion(attempt)
       ),
     },
     {
       id: 'body-assertion',
       points: 20,
-      pass: attempts.some((attempt) => hasPassingUserChecks(attempt) && hasBodyAssertion(attempt)),
+      pass: targetAttempts.some(
+        (attempt) => hasPassingUserChecks(attempt) && hasBodyAssertion(attempt)
+      ),
     },
   ];
 

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -6,6 +6,11 @@ import dynamic from 'next/dynamic';
 
 import { recordSubmission } from '@/shared/analytics/record-submission';
 import { track } from '@/shared/analytics/track';
+import {
+  type ApiAttemptForGrade,
+  type HiddenGradeResult,
+  gradeApiAttempts,
+} from '@/shared/challenges/api-hidden-grader';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
@@ -39,6 +44,7 @@ interface RunResult {
   bodyText: string;
   checks: Check[];
   scriptResults: PmResult[];
+  hiddenGrade: HiddenGradeResult;
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
@@ -200,6 +206,7 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
   const [running, setRunning] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
+  const [attempts, setAttempts] = useState<ApiAttemptForGrade[]>([]);
 
   const updateAssertion = (id: number, patch: Partial<Assertion>) =>
     setAssertions((as) => as.map((a) => (a.id === id ? { ...a, ...patch } : a)));
@@ -252,17 +259,30 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
         ? runPmScript(script, { status: res.status, json, bodyText })
         : [];
 
+      const attempt: ApiAttemptForGrade = {
+        method,
+        path,
+        status: res.status,
+        assertions,
+        script,
+        checks,
+        scriptResults,
+      };
+      const nextAttempts = [...attempts, attempt];
+      const hiddenGrade = gradeApiAttempts(nextAttempts);
+      setAttempts(nextAttempts);
+
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
-      setResult({ status: res.status, bodyText: pretty, checks, scriptResults });
+      setResult({ status: res.status, bodyText: pretty, checks, scriptResults, hiddenGrade });
       const passed =
         checks.filter((c) => c.pass).length + scriptResults.filter((r) => r.pass).length;
       const totalChecks = checks.length + scriptResults.length;
-      track('api_run', { passed, total: totalChecks });
+      track('api_run', { passed, total: totalChecks, score: hiddenGrade.score });
       recordSubmission({
         slug,
         kind: 'api',
         content: { method, path, assertions, script },
-        result: { passed, total: totalChecks },
+        result: { passed, total: totalChecks, hiddenGrade },
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : '요청 실패');
@@ -446,6 +466,36 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
             >
               {passCount}/{total} 통과
             </span>
+          </div>
+
+          <div className="border-line-2 bg-bg-3 mt-4 rounded-xl border p-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-text-1 text-sm font-semibold">숨김 채점</span>
+              <span
+                className={`font-mono text-sm font-semibold ${
+                  result.hiddenGrade.score === result.hiddenGrade.maxScore
+                    ? 'text-primary'
+                    : 'text-text-1'
+                }`}
+              >
+                {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}점
+              </span>
+            </div>
+            <p className="text-text-3 mt-1 text-xs">
+              숨김 케이스 {result.hiddenGrade.passed}/{result.hiddenGrade.total} 통과
+            </p>
+            <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
+              {result.hiddenGrade.cases.map((item, index) => (
+                <span
+                  key={item.id}
+                  className={`border-line-2 rounded-lg border px-2 py-1 text-center text-xs font-medium ${
+                    item.pass ? 'text-primary' : 'text-text-3'
+                  }`}
+                >
+                  #{index + 1} {item.pass ? '통과' : '실패'}
+                </span>
+              ))}
+            </div>
           </div>
 
           {result.checks.length > 0 && (

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -207,7 +207,16 @@ function parseHeaderInput(input: string): Record<string, string> {
     })
   );
 }
+const SENSITIVE_HEADER_NAME = /^(authorization|cookie|set-cookie|x-api-key|x-qaground-signature)$/i;
 
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [
+      key,
+      SENSITIVE_HEADER_NAME.test(key) ? '[REDACTED]' : value,
+    ])
+  );
+}
 let nextId = 2;
 
 /**
@@ -250,7 +259,7 @@ export const ApiTesterExercise = ({
     setError('');
     setResult(null);
     try {
-      const headers: Record<string, string> = {};
+      const headers: Record<string, string> = parseHeaderInput(customHeaders);
       if (token.trim()) headers['Authorization'] = `Bearer ${token.trim()}`;
       const hasBody = method !== 'GET' && body.trim();
       if (hasBody) headers['Content-Type'] = 'application/json';
@@ -312,8 +321,15 @@ export const ApiTesterExercise = ({
       recordSubmission({
         slug,
         kind: 'api',
-        content: { method, path, headers: customHeaders, assertions, script },
-        result: { passed, total: totalChecks, hiddenGrade },
+        content: {
+          method,
+          path,
+          headers: redactHeaders(headers),
+          assertions,
+          script,
+          attempts: nextAttempts,
+        },
+        result: { passed, total: totalChecks },
       });
     } catch (e) {
       setError(e instanceof Error ? e.message : '요청 실패');

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -8,6 +8,7 @@ import { recordSubmission } from '@/shared/analytics/record-submission';
 import { track } from '@/shared/analytics/track';
 import {
   type ApiAttemptForGrade,
+  type ApiTargetForGrade,
   type HiddenGradeResult,
   gradeApiAttempts,
 } from '@/shared/challenges/api-hidden-grader';
@@ -186,6 +187,27 @@ pm.test('상태 코드는 200', () => {
 // });
 `;
 
+function parseHeaderInput(input: string): Record<string, string> {
+  const trimmed = input.trim();
+  if (!trimmed) return {};
+
+  if (trimmed.startsWith('{')) {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('추가 헤더 JSON은 객체여야 합니다.');
+    }
+    return Object.fromEntries(Object.entries(parsed).map(([key, value]) => [key, String(value)]));
+  }
+
+  return Object.fromEntries(
+    trimmed.split('\n').map((line) => {
+      const separator = line.indexOf(':');
+      if (separator <= 0) throw new Error('추가 헤더는 "이름: 값" 형식이어야 합니다.');
+      return [line.slice(0, separator).trim(), line.slice(separator + 1).trim()];
+    })
+  );
+}
+
 let nextId = 2;
 
 /**
@@ -194,10 +216,19 @@ let nextId = 2;
  * 포스트맨처럼 요청을 구성하고, (1) 구조화된 단언 또는 (2) pm.test 스크립트로 응답을 검증한다.
  * 스크립트는 사용자 브라우저에서만 평가하므로 격리 러너·서버 코드 실행이 필요 없다.
  */
-export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: string }) => {
+export const ApiTesterExercise = ({
+  apiBase,
+  slug,
+  endpoints,
+}: {
+  apiBase: string;
+  slug: string;
+  endpoints: ApiTargetForGrade[];
+}) => {
   const [method, setMethod] = useState<Method>('GET');
   const [path, setPath] = useState('/products?page=1&limit=5');
   const [token, setToken] = useState('');
+  const [customHeaders, setCustomHeaders] = useState('');
   const [body, setBody] = useState('');
   const [assertions, setAssertions] = useState<Assertion[]>([
     { id: 1, kind: 'status', path: '', expected: '200' },
@@ -269,7 +300,7 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
         scriptResults,
       };
       const nextAttempts = [...attempts, attempt];
-      const hiddenGrade = gradeApiAttempts(nextAttempts);
+      const hiddenGrade = gradeApiAttempts(nextAttempts, { targets: endpoints });
       setAttempts(nextAttempts);
 
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
@@ -281,7 +312,7 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
       recordSubmission({
         slug,
         kind: 'api',
-        content: { method, path, assertions, script },
+        content: { method, path, headers: customHeaders, assertions, script },
         result: { passed, total: totalChecks, hiddenGrade },
       });
     } catch (e) {
@@ -341,6 +372,15 @@ export const ApiTesterExercise = ({ apiBase, slug }: { apiBase: string; slug: st
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
           placeholder="Bearer 토큰 (보호된 요청에만, 예: qaground-demo-token)"
           className={`h-button-md ${fieldClass}`}
+        />
+
+        <textarea
+          data-testid="api-headers"
+          value={customHeaders}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCustomHeaders(e.target.value)}
+          rows={2}
+          placeholder={'추가 헤더 (선택)\nx-qaground-signature: test-signature'}
+          className={`py-2 font-mono ${fieldClass}`}
         />
 
         {method !== 'GET' && (

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -212,7 +212,11 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
                   starterSpec={challenge.starterSpec}
                 />
               ) : (
-                <ApiTesterExercise apiBase={challenge.apiBase!} slug={challenge.slug} />
+                <ApiTesterExercise
+                  apiBase={challenge.apiBase!}
+                  slug={challenge.slug}
+                  endpoints={challenge.endpoints!}
+                />
               )}
             </div>
           </div>


### PR DESCRIPTION
## 작업 내용
- API 테스터 실행 이력을 기반으로 숨김 채점 결과를 계산하는 grader를 추가했습니다.
- 성공/실패 응답 경로, 요청 커버리지, 상태 코드 단언, 본문 단언을 부분 점수로 계산합니다.
- API 실행 결과 패널에 숨김 케이스 통과 개수와 점수를 표시합니다.

## 검증
- `pnpm --filter qaground test`
- `pnpm --filter qaground lint`