### PR TITLE
refactor: 운영 호스트에서만 GA 기록

### DIFF
--- a/apps/qaground/app/api/submissions/route.ts
+++ b/apps/qaground/app/api/submissions/route.ts
@@ -19,11 +19,22 @@ const BodySchema = z
 
 // 제출 내용 jsonb 크기 상한(직렬화 기준). 남용·과대 페이로드 차단.
 const MAX_CONTENT_BYTES = 50_000;
+const SUBMISSION_HOSTS = new Set(['qaground.gettestea.com']);
 
 // 간단 인메모리 레이트리밋(서버 인스턴스별). 제출은 빈번하므로 이슈보다 넉넉히.
 const WINDOW_MS = 60 * 60 * 1000;
 const MAX_PER_WINDOW = 60;
 const hits = new Map<string, number[]>();
+function getHostname(request: Request): string {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  const host = forwardedHost ?? request.headers.get('host') ?? '';
+  return host.split(',')[0].trim().split(':')[0].toLowerCase();
+}
+
+function shouldRecordSubmission(request: Request): boolean {
+  return SUBMISSION_HOSTS.has(getHostname(request));
+}
+
 function rateLimited(ip: string): boolean {
   const now = Date.now();
   const recent = (hits.get(ip) ?? []).filter((t) => now - t < WINDOW_MS);
@@ -47,6 +58,10 @@ function rateLimited(ip: string): boolean {
  * - DB 접근은 서버(연결) 경유. 테이블은 RLS deny-anon.
  */
 export async function POST(request: Request) {
+  if (!shouldRecordSubmission(request)) {
+    return NextResponse.json({ ok: true, skipped: true });
+  }
+
   const ip = (request.headers.get('x-forwarded-for') ?? '').split(',')[0].trim() || 'unknown';
   if (rateLimited(ip)) {
     return NextResponse.json({ ok: false, error: 'rate_limited' }, { status: 429 });

--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from 'next';
-import Script from 'next/script';
 
 import '@/app-shell/globals.css';
-import { GoogleAnalytics } from '@next/third-parties/google';
+import { ProductionScripts } from '@/shared/analytics/production-scripts';
 
 const SITE_URL = 'https://qaground.gettestea.com';
 const ADSENSE_ID = process.env.NEXT_PUBLIC_ADSENSE_ID;
@@ -145,10 +144,9 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // GA는 production 배포에서만 로드. preview(dev 브랜치)·로컬은 GA_ID가 주입돼도 차단.
+  // GA/AdSense는 production 배포 + 운영 호스트에서만 로드. dev 서브도메인은 production 배포여도 차단.
   const gaId = process.env.NEXT_PUBLIC_GA_ID;
   const gaEnabled = !!gaId && process.env.VERCEL_ENV === 'production';
-  // AdSense도 동일하게 production + ID 주입 시에만 로더 주입.
   const adsEnabled = !!ADSENSE_ID && process.env.VERCEL_ENV === 'production';
 
   return (
@@ -160,14 +158,10 @@ export default function RootLayout({
         />
         {children}
       </body>
-      {gaEnabled && <GoogleAnalytics gaId={gaId} />}
-      {adsEnabled && (
-        <Script
-          id="adsbygoogle-loader"
-          async
-          strategy="afterInteractive"
-          crossOrigin="anonymous"
-          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_ID}`}
+      {(gaEnabled || adsEnabled) && (
+        <ProductionScripts
+          gaId={gaEnabled ? gaId : undefined}
+          adsenseId={adsEnabled ? ADSENSE_ID : undefined}
         />
       )}
     </html>

--- a/apps/qaground/src/shared/analytics/host.ts
+++ b/apps/qaground/src/shared/analytics/host.ts
@@ -1,0 +1,7 @@
+const ANALYTICS_HOSTS = new Set(['qaground.gettestea.com']);
+
+export function isAllowedAnalyticsHost(
+  hostname: string | undefined = globalThis.location?.hostname
+): boolean {
+  return !!hostname && ANALYTICS_HOSTS.has(hostname.toLowerCase());
+}

--- a/apps/qaground/src/shared/analytics/production-scripts.tsx
+++ b/apps/qaground/src/shared/analytics/production-scripts.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import Script from 'next/script';
+
+import { isAllowedAnalyticsHost } from '@/shared/analytics/host';
+import { GoogleAnalytics } from '@next/third-parties/google';
+
+type ProductionScriptsProps = {
+  adsenseId?: string;
+  gaId?: string;
+};
+
+export function ProductionScripts({ adsenseId, gaId }: ProductionScriptsProps) {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(isAllowedAnalyticsHost());
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      {gaId && <GoogleAnalytics gaId={gaId} />}
+      {adsenseId && (
+        <Script
+          id="adsbygoogle-loader"
+          async
+          strategy="afterInteractive"
+          crossOrigin="anonymous"
+          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseId}`}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/qaground/src/shared/analytics/record-submission.ts
+++ b/apps/qaground/src/shared/analytics/record-submission.ts
@@ -1,3 +1,5 @@
+import { isAllowedAnalyticsHost } from '@/shared/analytics/host';
+
 type SubmissionKind = 'code' | 'api' | 'defect' | 'testcase';
 
 /** 같은 브라우저의 제출을 느슨히 묶는 익명 ID(localStorage). 개인정보 아님. */
@@ -17,6 +19,7 @@ function getAnonId(): string {
 
 /**
  * 사용자 제출(코드·답안)과 결과를 익명으로 서버에 기록한다(베스트 에포트).
+ * 운영 호스트(qaground.gettestea.com) 밖에서는 개발 데이터 오염을 막기 위해 기록하지 않는다.
  *
  * 응답을 기다리지 않고 fire-and-forget 하므로 제출 UX 를 막지 않는다.
  * GA 의 집계 이벤트와 달리 실제 작성 내용을 저장해 분석·통계에 쓴다.
@@ -27,7 +30,7 @@ export function recordSubmission(payload: {
   content: unknown;
   result?: unknown;
 }): void {
-  if (typeof window === 'undefined') return;
+  if (typeof window === 'undefined' || !isAllowedAnalyticsHost()) return;
   try {
     void fetch('/api/submissions', {
       method: 'POST',

--- a/apps/qaground/src/shared/analytics/track.ts
+++ b/apps/qaground/src/shared/analytics/track.ts
@@ -1,13 +1,12 @@
+import { isAllowedAnalyticsHost } from '@/shared/analytics/host';
 import { sendGAEvent } from '@next/third-parties/google';
 
 type EventParams = Record<string, string | number | boolean | undefined | null>;
 
 /**
  * GA4 커스텀 이벤트 전송.
- *
- * production 외(로컬·preview)에서는 GoogleAnalytics 스크립트가 로드되지 않으므로
- * dataLayer 로 push 돼도 실제 전송되지 않는다(무해). 개인정보는 보내지 않고,
- * 어떤 챌린지에서 무엇을 제출했는지 같은 비식별 사용 데이터만 수집한다.
+ * 운영 호스트(qaground.gettestea.com) 밖에서는 이벤트를 전송하지 않는다.
+ * 개인정보는 보내지 않고, 어떤 챌린지에서 무엇을 제출했는지 같은 비식별 사용 데이터만 수집한다.
  *
  * @example track('issue_submit', { type: 'bug' });
  */
@@ -16,8 +15,12 @@ export function track(event: string, params?: EventParams): void {
   const clean = params
     ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null))
     : {};
-  sendGAEvent('event', event, clean);
+
   if (process.env.NODE_ENV === 'development') {
     console.log(`[GA] ${event}`, clean);
   }
+
+  if (!isAllowedAnalyticsHost()) return;
+
+  sendGAEvent('event', event, clean);
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,6 +8,7 @@ import Script from 'next/script';
 import { LazyToaster } from '@/app-shell/providers/lazy-toaster';
 import { QueryProvider } from '@/app-shell/providers/query-provider';
 import '@/app-shell/styles/globals.css';
+import { ProductionAnalytics } from '@/shared/lib/analytics/production-analytics';
 import { CriticalBanner } from '@/widgets/announcement-banner';
 import { AnnouncementPopup } from '@/widgets/announcement-popup';
 import { MvpBottomNavbarLazy } from '@testea/ui';
@@ -248,22 +249,9 @@ export default async function RootLayout({
             __html: `var f=document.querySelector('[data-font-css]');if(f){if(f.sheet){f.media='all'}else{f.addEventListener('load',function(){this.media='all'})}}`,
           }}
         />
-        {/* GTM은 production 배포에서만 로드. preview(dev 브랜치)·로컬은 GTM_ID가 주입돼도 차단 */}
-        {process.env.NEXT_PUBLIC_GTM_ID && process.env.VERCEL_ENV === 'production' && (
-          <>
-            <Script
-              id="gtm-init"
-              strategy="lazyOnload"
-              dangerouslySetInnerHTML={{
-                __html: `window.dataLayer=window.dataLayer||[];window.dataLayer.push({'gtm.start':new Date().getTime(),event:'gtm.js'});`,
-              }}
-            />
-            <Script
-              id="gtm-script"
-              src={`https://www.googletagmanager.com/gtm.js?id=${process.env.NEXT_PUBLIC_GTM_ID}`}
-              strategy="lazyOnload"
-            />
-          </>
+        {/* GA는 production 배포 + 운영 호스트에서만 로드. dev 서브도메인은 production 배포여도 차단. */}
+        {process.env.NEXT_PUBLIC_GA_ID && process.env.VERCEL_ENV === 'production' && (
+          <ProductionAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
         )}
       </body>
     </html>

--- a/apps/web/src/shared/lib/analytics/host.ts
+++ b/apps/web/src/shared/lib/analytics/host.ts
@@ -1,0 +1,7 @@
+const ANALYTICS_HOSTS = new Set(['gettestea.com', 'www.gettestea.com']);
+
+export function isAllowedAnalyticsHost(
+  hostname: string | undefined = globalThis.location?.hostname
+): boolean {
+  return !!hostname && ANALYTICS_HOSTS.has(hostname.toLowerCase());
+}

--- a/apps/web/src/shared/lib/analytics/production-analytics.tsx
+++ b/apps/web/src/shared/lib/analytics/production-analytics.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { isAllowedAnalyticsHost } from '@/shared/lib/analytics/host';
+import { GoogleAnalytics } from '@next/third-parties/google';
+
+type ProductionAnalyticsProps = {
+  gaId?: string;
+};
+
+export function ProductionAnalytics({ gaId }: ProductionAnalyticsProps) {
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    setEnabled(!!gaId && isAllowedAnalyticsHost());
+  }, [gaId]);
+
+  if (!enabled || !gaId) return null;
+
+  return <GoogleAnalytics gaId={gaId} />;
+}

--- a/apps/web/src/shared/lib/analytics/track.ts
+++ b/apps/web/src/shared/lib/analytics/track.ts
@@ -1,9 +1,11 @@
-import { sendGTMEvent } from '@next/third-parties/google';
+import { isAllowedAnalyticsHost } from '@/shared/lib/analytics/host';
+import { sendGAEvent } from '@next/third-parties/google';
 
 type EventParams = Record<string, string | number | boolean | null | undefined>;
 
 /**
- * GTM dataLayer로 이벤트 전송
+ * GA4 이벤트 전송.
+ * 운영 호스트(gettestea.com) 밖에서는 이벤트를 전송하지 않는다.
  *
  * @example
  * track(GA_EVENTS.LANDING.PROJECT_CREATE_START, { trigger_location: 'landing_hero' });
@@ -17,12 +19,14 @@ export function track(eventName: string, params?: EventParams): void {
     ? Object.fromEntries(Object.entries(params).filter(([, v]) => v !== undefined && v !== null))
     : {};
 
-  sendGTMEvent({ event: eventName, ...cleanParams });
-
   // 개발 환경에서 디버깅
   if (process.env.NODE_ENV === 'development') {
     console.log(`[GA] ${eventName}`, cleanParams);
   }
+
+  if (!isAllowedAnalyticsHost()) return;
+
+  sendGAEvent('event', eventName, cleanParams);
 }
 
 /**


### PR DESCRIPTION
## 변경 내용
- `apps/web`의 GTM 연동을 제거하고 GA4 직접 연동으로 정리했습니다.
- `gettestea.com`, `www.gettestea.com`, `qaground.gettestea.com` 운영 호스트에서만 GA/AdSense 스크립트가 로드되도록 호스트 가드를 추가했습니다.
- GA 커스텀 이벤트 전송도 운영 호스트 밖에서는 실행하지 않도록 막았습니다.
- qaground의 자체 제출 분석 저장(`/api/submissions`)도 개발 호스트에서는 저장하지 않고 `skipped`로 응답하도록 정리했습니다.

## 배경
`localhost`, `dev.gettestea.com`, `dev.qaground...` 같은 개발 서버에서 GA와 분석 DB에 테스트 데이터가 쌓이는 문제가 있어 운영 도메인 allowlist 방식으로 차단했습니다.

## 검증
- `pnpm exec prettier --check apps/qaground/app/api/submissions/route.ts apps/qaground/app/layout.tsx apps/qaground/src/shared/analytics/host.ts apps/qaground/src/shared/analytics/production-scripts.tsx apps/qaground/src/shared/analytics/record-submission.ts apps/qaground/src/shared/analytics/track.ts apps/web/app/layout.tsx apps/web/src/shared/lib/analytics/host.ts apps/web/src/shared/lib/analytics/production-analytics.tsx apps/web/src/shared/lib/analytics/track.ts`
- `git diff --check`
- `pnpm --filter qaground build`
- `pnpm --filter web build`