### PR TITLE
feat(#287): 성능 접근성 챌린지 추가

### DIFF
--- a/apps/qaground/app/api/grade/route.ts
+++ b/apps/qaground/app/api/grade/route.ts
@@ -78,7 +78,7 @@ interface GradeOk {
 /**
  * POST /api/grade
  *
- * 수동 트랙(테스트 케이스·결함 리포트) 제출을 LLM(OpenAI gpt-4o-mini)으로 내용 기반 채점한다.
+ * 수동·성능·접근성 트랙(테스트 케이스·결함 리포트) 제출을 LLM(OpenAI gpt-4o-mini)으로 내용 기반 채점한다.
  * 요구사항별 커버 여부 + 맞춤 피드백을 구조화 JSON 으로 돌려준다.
  *
  * - OPENAI_API_KEY 미설정: 503(llm_disabled) → 클라이언트는 기존 커버리지 채점으로 폴백한다.
@@ -107,7 +107,11 @@ export async function POST(request: Request) {
   }
 
   const challenge = getChallenge(parsed.data.slug);
-  if (!challenge || (challenge.track !== 'manual' && parsed.data.kind === 'testcase')) {
+  const acceptsTestcaseSubmission =
+    challenge?.track === 'manual' ||
+    challenge?.track === 'performance' ||
+    challenge?.track === 'accessibility';
+  if (!challenge || (!acceptsTestcaseSubmission && parsed.data.kind === 'testcase')) {
     return NextResponse.json({ error: 'not_found' }, { status: 404 });
   }
 

--- a/apps/qaground/app/challenges/page.tsx
+++ b/apps/qaground/app/challenges/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next';
 import { ChallengesView } from '@/view/challenges';
 
 const DESCRIPTION =
-  'QA 자동화·API·테스트 케이스 연습 챌린지. 로그인 없이 로그인 폼·결제·게시판 같은 실제형 연습 대상에 Playwright·Postman 테스트를 직접 작성해 실행하고 채점받으세요. QA 과제전형 준비에도 좋습니다.';
+  'QA 자동화·API·테스트 케이스·성능·접근성 연습 챌린지. 로그인 없이 로그인 폼·결제·게시판 같은 실제형 연습 대상에 Playwright·Postman 테스트를 작성하고 성능·접근성 점검 계획까지 연습하세요.';
 
 export const metadata: Metadata = {
   title: '연습 챌린지',
@@ -16,6 +16,10 @@ export const metadata: Metadata = {
     'Playwright 연습',
     'Postman 연습',
     '테스트 케이스 연습',
+    '성능 테스트 연습',
+    '접근성 테스트 연습',
+    'Core Web Vitals',
+    '웹 접근성',
     '테스티아',
   ],
   openGraph: {

--- a/apps/qaground/app/guide/page.tsx
+++ b/apps/qaground/app/guide/page.tsx
@@ -5,7 +5,7 @@ import { PlaygroundHeader } from '@/view/challenges/playground-header';
 import { GuideToc } from '@/view/guide/guide-toc';
 
 const DESCRIPTION =
-  'qaground 사용 가이드. 자동화(Playwright)·메뉴얼(테스트 케이스·결함 리포트)·API(Postman) 트랙이 무엇인지, 챌린지를 어떻게 풀고 채점받는지, 셀렉터·단언·좋은 테스트 케이스 작성법까지 한 번에 정리했습니다.';
+  'qaground 사용 가이드. 자동화(Playwright)·메뉴얼(테스트 케이스·결함 리포트)·API(Postman)·성능·접근성 트랙이 무엇인지, 챌린지를 어떻게 풀고 채점받는지, 셀렉터·단언·좋은 테스트 케이스 작성법까지 한 번에 정리했습니다.';
 
 export const metadata: Metadata = {
   title: '가이드',
@@ -59,6 +59,20 @@ const TRACKS = [
     title: 'API · Postman 스타일',
     desc: '요청을 구성하고 상태 코드·JSON·pm.test로 응답을 검증합니다. 브라우저 안에서 실제로 요청을 보내 바로 채점됩니다.',
   },
+  {
+    tag: 'PERF',
+    bar: 'bg-[#a371f7]',
+    text: 'text-[#a371f7]',
+    title: '성능 · Web Vitals',
+    desc: 'Core Web Vitals와 리소스 병목을 측정하고, 재현 가능한 성능 리포트와 개선 우선순위를 정리합니다.',
+  },
+  {
+    tag: 'A11Y',
+    bar: 'bg-[#f778ba]',
+    text: 'text-[#f778ba]',
+    title: '접근성 · Keyboard & Screen Reader',
+    desc: '키보드 탐색, 포커스 표시, 라벨·에러 전달, 색 대비처럼 실제 사용성에 영향을 주는 접근성 문제를 점검합니다.',
+  },
 ];
 
 const STEPS = [
@@ -85,7 +99,7 @@ const Terminal = ({ label, children }: { label: string; children: string }) => (
 );
 
 const TOC = [
-  ['01', '세 가지 트랙', 'tracks'],
+  ['01', '다섯 가지 트랙', 'tracks'],
   ['02', '푸는 흐름', 'flow'],
   ['03', '채점 방식', 'grading'],
   ['04', '셀렉터 전략', 'selector'],
@@ -129,7 +143,7 @@ export default function GuidePage() {
 
           <div className="mt-14 flex flex-col gap-16">
             {/* 트랙 */}
-            <Section id="tracks" n="01" title="세 가지 트랙">
+            <Section id="tracks" n="01" title="다섯 가지 트랙">
               <p className="text-text-3">
                 관심사와 도구로 고르세요. 한 챌린지는 한 트랙에 속합니다.
               </p>

--- a/apps/qaground/app/layout.tsx
+++ b/apps/qaground/app/layout.tsx
@@ -8,7 +8,7 @@ const SITE_URL = 'https://qaground.gettestea.com';
 const ADSENSE_ID = process.env.NEXT_PUBLIC_ADSENSE_ID;
 
 const DESCRIPTION =
-  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 로그인 폼·API·결제 같은 실제형 연습 대상에 Playwright·Postman 테스트를 직접 작성해 실행하고 채점받으세요. QA 과제전형·과제 연습·과제 테스트 준비에도 활용할 수 있습니다.';
+  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 로그인 폼·API·결제 같은 실제형 연습 대상에 Playwright·Postman 테스트를 직접 작성하고, 성능·접근성 테스트 계획까지 연습하세요. QA 과제전형·과제 연습·과제 테스트 준비에도 활용할 수 있습니다.';
 
 const TITLE = 'qaground — QA 자동화 연습 플레이그라운드 | 테스티아';
 
@@ -66,6 +66,15 @@ export const metadata: Metadata = {
     'Postman',
     'Postman 연습',
     'API 테스트',
+    '성능 테스트',
+    '성능 테스트 연습',
+    'Core Web Vitals',
+    'Lighthouse',
+    '접근성 테스트',
+    '웹 접근성',
+    'WCAG',
+    '스크린리더 테스트',
+    '키보드 접근성',
     'API 테스트 연습',
     'Selenium 대안',
     'Cypress 대안',
@@ -135,7 +144,8 @@ const jsonLd = {
       alternateName: '테스티아',
       url: 'https://gettestea.com',
       sameAs: ['https://gettestea.com'],
-      description: '테스티아(Testea)가 운영하는 QA 자동화 연습 플레이그라운드 qaground',
+      description:
+        '테스티아(Testea)가 운영하는 QA 자동화·API·성능·접근성 연습 플레이그라운드 qaground',
     },
   ],
 };
@@ -159,17 +169,17 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
         {children}
+        {gaEnabled && <GoogleAnalytics gaId={gaId} />}
+        {adsEnabled && (
+          <Script
+            id="adsbygoogle-loader"
+            async
+            strategy="afterInteractive"
+            crossOrigin="anonymous"
+            src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_ID}`}
+          />
+        )}
       </body>
-      {gaEnabled && <GoogleAnalytics gaId={gaId} />}
-      {adsEnabled && (
-        <Script
-          id="adsbygoogle-loader"
-          async
-          strategy="afterInteractive"
-          crossOrigin="anonymous"
-          src={`https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${ADSENSE_ID}`}
-        />
-      )}
     </html>
   );
 }

--- a/apps/qaground/app/learn/page.tsx
+++ b/apps/qaground/app/learn/page.tsx
@@ -10,7 +10,7 @@ import { PlaygroundHeader } from '@/view/challenges/playground-header';
 import { GuideToc } from '@/view/guide/guide-toc';
 
 const DESCRIPTION =
-  'qaground 학습 경로. 자동화(Playwright)·메뉴얼(테스트 설계)·API(Postman) 트랙을 난이도 순서로 따라가며 QA 실력을 단계별로 쌓는 커리큘럼입니다.';
+  'qaground 학습 경로. 자동화(Playwright)·메뉴얼(테스트 설계)·API(Postman)·성능·접근성 트랙을 난이도 순서로 따라가며 QA 실력을 단계별로 쌓는 커리큘럼입니다.';
 
 export const metadata: Metadata = {
   title: '학습 경로',
@@ -74,6 +74,24 @@ const TRACKS: {
     title: 'API · Postman',
     desc: '요청을 구성하고 상태 코드·응답을 단언하며 API 테스트를 연습합니다.',
   },
+  {
+    key: 'performance',
+    n: '04',
+    tag: 'PERF',
+    bar: 'bg-[#a371f7]',
+    text: 'text-[#a371f7]',
+    title: '성능 · Web Vitals',
+    desc: 'Core Web Vitals, 네트워크, 리소스 병목을 측정하고 재현 가능한 성능 리포트로 정리합니다.',
+  },
+  {
+    key: 'accessibility',
+    n: '05',
+    tag: 'A11Y',
+    bar: 'bg-[#f778ba]',
+    text: 'text-[#f778ba]',
+    title: '접근성 · Keyboard & Screen Reader',
+    desc: '키보드 탐색, 포커스, 라벨, 에러 전달, 색 대비를 점검하는 접근성 테스트를 연습합니다.',
+  },
 ];
 
 const TOC = TRACKS.map((t) => [t.n, t.title.split(' · ')[0], t.key]);
@@ -93,7 +111,7 @@ export default function LearnPage() {
           <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">학습 경로</h1>
           <p className="text-text-2 mt-4 text-base leading-relaxed">
             트랙을 골라 입문부터 심화까지 순서대로 풀어 보세요. 처음이라면 자동화 입문(입문
-            배지)부터 시작해 메뉴얼 설계, API로 넓혀 가는 흐름을 권장합니다.
+            배지)부터 시작해 메뉴얼 설계, API, 성능, 접근성으로 넓혀 가는 흐름을 권장합니다.
           </p>
 
           <div className="mt-14 flex flex-col gap-16">

--- a/apps/qaground/app/page.tsx
+++ b/apps/qaground/app/page.tsx
@@ -4,7 +4,7 @@ import { BetaLandingView } from '@/view/landing-beta';
 
 const TITLE = 'qaground — 로그인 없이 시작하는 QA 자동화 연습 | 테스티아';
 const DESCRIPTION =
-  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 바로 Playwright·Postman·테스트 케이스 연습을 시작하세요. QA 과제전형·과제 테스트 준비에도 좋습니다.';
+  'qaground(큐에이그라운드)는 테스티아(Testea)가 만든 QA 연습 플레이그라운드입니다. 로그인 없이 바로 Playwright·Postman·테스트 케이스·성능·접근성 연습을 시작하세요. QA 과제전형·과제 테스트 준비에도 좋습니다.';
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/apps/qaground/app/sitemap.ts
+++ b/apps/qaground/app/sitemap.ts
@@ -6,17 +6,19 @@ import { CHALLENGES } from '@/shared/challenges/registry';
 const SITE_URL = 'https://qaground.gettestea.com';
 
 export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
   const staticPages: MetadataRoute.Sitemap = [
-    { url: SITE_URL, changeFrequency: 'weekly', priority: 1 },
-    { url: `${SITE_URL}/preview`, changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${SITE_URL}/challenges`, changeFrequency: 'weekly', priority: 0.9 },
-    { url: `${SITE_URL}/learn`, changeFrequency: 'weekly', priority: 0.8 },
-    { url: `${SITE_URL}/guide`, changeFrequency: 'monthly', priority: 0.8 },
-    { url: `${SITE_URL}/privacy`, changeFrequency: 'yearly', priority: 0.3 },
+    { url: SITE_URL, lastModified: now, changeFrequency: 'weekly', priority: 1 },
+    { url: `${SITE_URL}/preview`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${SITE_URL}/challenges`, lastModified: now, changeFrequency: 'weekly', priority: 0.9 },
+    { url: `${SITE_URL}/learn`, lastModified: now, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${SITE_URL}/guide`, lastModified: now, changeFrequency: 'monthly', priority: 0.8 },
+    { url: `${SITE_URL}/privacy`, lastModified: now, changeFrequency: 'yearly', priority: 0.3 },
   ];
 
   const challengePages: MetadataRoute.Sitemap = CHALLENGES.map((c) => ({
     url: `${SITE_URL}/challenges/${c.slug}`,
+    lastModified: now,
     changeFrequency: 'monthly',
     priority: 0.7,
   }));

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -6,7 +6,7 @@
  * - sandboxSlug 가 가리키는 `/sandbox/[slug]` 가 실제 테스트 대상 페이지다.
  */
 
-export type ChallengeTrack = 'automation' | 'manual' | 'api';
+export type ChallengeTrack = 'automation' | 'manual' | 'api' | 'performance' | 'accessibility';
 export type ChallengeDifficulty = 'easy' | 'medium' | 'hard';
 /** 주제 카테고리. 트랙(테스트 방식)과 별개인 도메인 축. */
 export type ChallengeCategory =
@@ -17,6 +17,8 @@ export type ChallengeCategory =
   | 'async'
   | 'commerce'
   | 'fintech'
+  | 'performance'
+  | 'accessibility'
   | 'fundamentals';
 
 export interface ChallengeSelector {
@@ -67,6 +69,8 @@ export const TRACK_LABEL: Record<ChallengeTrack, string> = {
   automation: 'Automation',
   manual: 'Manual',
   api: 'API',
+  performance: 'Performance',
+  accessibility: 'Accessibility',
 };
 
 export const DIFFICULTY_LABEL: Record<ChallengeDifficulty, string> = {
@@ -83,6 +87,8 @@ export const CATEGORY_LABEL: Record<ChallengeCategory, string> = {
   async: '비동기',
   commerce: '커머스',
   fintech: '핀테크',
+  performance: '성능',
+  accessibility: '접근성',
   fundamentals: '테스팅 기초',
 };
 
@@ -95,6 +101,8 @@ export const CATEGORY_ORDER: ChallengeCategory[] = [
   'async',
   'commerce',
   'fintech',
+  'performance',
+  'accessibility',
   'fundamentals',
 ];
 
@@ -1531,6 +1539,792 @@ test('내 테스트', async ({ page }) => {
     ],
     apiNote:
       '/status/:code 는 200~599 범위의 코드로 응답합니다. 자동화에서 에러 응답의 상태와 본문을 어떻게 단언할지 연습하세요.',
+  },
+  {
+    slug: 'web-vitals-basic-audit',
+    title: 'Core Web Vitals 성능 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'easy',
+    tools: ['Lighthouse', 'DevTools'],
+    summary:
+      '랜딩 페이지를 기준으로 Core Web Vitals와 주요 리소스 병목을 점검하는 성능 테스트 계획을 작성하세요.',
+    requirement: [
+      'LCP, CLS, INP를 어떤 도구와 기준으로 측정할지 정의한다.',
+      '모바일과 데스크톱을 분리해 측정하고, 네트워크/CPU 조건을 명시한다.',
+      '이미지, 폰트, JavaScript 번들 등 주요 병목 후보를 확인하는 절차를 포함한다.',
+      '성능 저하를 재현 가능한 리포트로 남기기 위한 증거(스크린샷, trace, 측정값)를 정의한다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'Core Web Vitals 기준 측정',
+        detail:
+          'Lighthouse 또는 DevTools Performance로 모바일/데스크톱 각각 LCP·CLS·INP를 측정하고, 기준값과 실제값을 함께 기록한다.',
+      },
+      {
+        title: '리소스 병목 분석',
+        detail:
+          'Network/Performance 탭에서 큰 이미지, render-blocking CSS, 과도한 JS 실행 시간을 확인하고 영향도를 정리한다.',
+      },
+      {
+        title: '재현 가능한 증거 수집',
+        detail:
+          '측정 환경, URL, throttling 조건, trace 또는 Lighthouse 결과 파일, 개선 전후 비교 기준을 리포트에 포함한다.',
+      },
+    ],
+  },
+  {
+    slug: 'api-response-time-slo',
+    title: 'API 응답 시간 SLO 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'easy',
+    tools: ['DevTools', 'k6'],
+    summary:
+      '상품 목록과 주문 생성 API를 기준으로 응답 시간 목표와 측정 방법을 정의하는 성능 테스트 케이스를 작성하세요.',
+    requirement: [
+      '목록 조회, 단건 조회, 생성 요청처럼 성격이 다른 엔드포인트를 구분해 측정 대상을 정의한다.',
+      'p50, p95, p99 중 어떤 지표를 기준으로 볼지와 목표 응답 시간을 명시한다.',
+      '콜드 스타트, 인증, 네트워크 변동처럼 측정값을 흔드는 조건을 통제하는 방법을 포함한다.',
+      'SLO 초과 시 재현 절차와 서버/클라이언트 로그 확인 항목을 함께 정의한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '엔드포인트별 응답 시간 기준',
+        detail:
+          'GET 목록, GET 단건, POST 생성 요청을 나누고 각 요청의 p95 목표값과 허용 오차를 명시한다.',
+      },
+      {
+        title: '측정 조건 통제',
+        detail:
+          '동일한 환경, 반복 횟수, 인증 토큰, payload 크기, 워밍업 여부를 고정하고 결과를 비교한다.',
+      },
+      {
+        title: '초과 시 분석 절차',
+        detail:
+          'SLO 초과 요청의 trace, 서버 로그, DB 쿼리 시간, 응답 payload 크기를 확인하는 후속 절차를 포함한다.',
+      },
+    ],
+  },
+  {
+    slug: 'image-loading-performance',
+    title: '이미지 로딩 성능 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Lighthouse', 'Network'],
+    summary:
+      '상품 카드와 상세 화면의 이미지가 LCP와 네트워크 비용에 미치는 영향을 검증하는 성능 테스트 계획을 작성하세요.',
+    requirement: [
+      'LCP 후보 이미지가 무엇인지 식별하고 로딩 우선순위가 적절한지 확인한다.',
+      '이미지 포맷, 크기, DPR, lazy loading 적용 여부를 검증하는 절차를 포함한다.',
+      '느린 네트워크에서 placeholder, layout shift, 이미지 실패 상태를 함께 확인한다.',
+      '개선 전후를 비교할 수 있도록 bytes, request 수, LCP 값을 증거로 남긴다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'LCP 이미지 식별',
+        detail:
+          'Performance 또는 Lighthouse 결과에서 LCP element를 확인하고 preload/fetchpriority 적용 여부를 점검한다.',
+      },
+      {
+        title: '이미지 최적화 검증',
+        detail:
+          '원본 크기 대비 렌더링 크기, WebP/AVIF 등 적절한 포맷, lazy loading 대상 분리를 확인한다.',
+      },
+      {
+        title: '저속 네트워크 경험',
+        detail:
+          'Slow 4G 조건에서 레이아웃 밀림, 빈 이미지 영역, 로딩 실패 fallback이 사용성을 해치지 않는지 검증한다.',
+      },
+    ],
+  },
+  {
+    slug: 'bundle-regression-budget',
+    title: '번들 크기 회귀 예산 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Bundle Analyzer', 'Lighthouse CI'],
+    summary:
+      '새 기능 추가 후 JavaScript 번들 크기와 초기 로딩 지표가 회귀하지 않았는지 확인하는 성능 게이트를 설계하세요.',
+    requirement: [
+      '초기 로딩에 포함되는 JS/CSS 번들 크기와 chunk 증가량 기준을 정의한다.',
+      '동적 import, tree shaking, 중복 의존성 여부를 확인하는 분석 절차를 포함한다.',
+      'PR 또는 배포 전 자동 확인할 수 있는 budget 기준과 실패 조건을 제안한다.',
+      '회귀가 발생했을 때 어느 화면/기능이 원인인지 추적하는 방법을 포함한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '번들 예산 기준',
+        detail:
+          'route별 initial JS와 total JS 예산을 정하고 기준 초과 시 실패하도록 Lighthouse CI 또는 analyzer 결과를 활용한다.',
+      },
+      {
+        title: '의존성 증가 원인 분석',
+        detail:
+          '새 라이브러리 추가 시 중복 패키지, client boundary 확장, 불필요한 전역 import를 확인한다.',
+      },
+      {
+        title: '회귀 추적 리포트',
+        detail:
+          '이전 main 빌드와 현재 빌드의 chunk diff, 영향 route, 사용자 지표 영향도를 함께 기록한다.',
+      },
+    ],
+  },
+  {
+    slug: 'checkout-load-test-plan',
+    title: '체크아웃 부하 테스트 설계',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'hard',
+    tools: ['k6', 'Grafana'],
+    summary:
+      '동시 주문 상황에서 체크아웃 API가 지연·실패·중복 주문 없이 동작하는지 검증하는 부하 테스트 계획을 작성하세요.',
+    requirement: [
+      '정상 주문, 재시도, 결제 실패 등 현실적인 사용자 시나리오와 비율을 정의한다.',
+      '동시 사용자 수, ramp-up, duration, think time 같은 부하 모델을 명시한다.',
+      '응답 시간, 오류율, 중복 주문, 재고 차감 정확성 등 관찰 지표를 정의한다.',
+      '테스트 데이터 격리, 결제 모킹, 운영 영향 방지 전략을 포함한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '현실적인 부하 모델',
+        detail:
+          '브라우징→장바구니→체크아웃 흐름과 실패/재시도 비율을 포함해 ramp-up과 peak 구간을 설계한다.',
+      },
+      {
+        title: '성능과 정합성 지표',
+        detail: 'p95 응답 시간, 5xx 비율, timeout, 중복 주문 수, 재고 음수 여부를 함께 관찰한다.',
+      },
+      {
+        title: '안전한 실행 조건',
+        detail:
+          '스테이징 환경, 결제 모킹, 테스트 계정/상품 분리, 실행 시간 제한과 중단 조건을 명시한다.',
+      },
+    ],
+  },
+  {
+    slug: 'screen-reader-form-audit',
+    title: '스크린리더 폼 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'easy',
+    tools: ['NVDA', 'VoiceOver', 'Accessibility Tree'],
+    summary:
+      '회원가입 폼에서 스크린리더 사용자가 입력 목적과 오류를 이해할 수 있는지 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      '각 입력 필드의 accessible name이 화면 라벨과 일치하는지 확인한다.',
+      '필수 여부, 도움말, 형식 안내가 보조기술에 전달되는지 검증한다.',
+      '유효성 오류 발생 시 오류 메시지와 필드가 연결되어 읽히는지 확인한다.',
+      '오류 수정 후 상태가 갱신되고 성공 메시지가 적절히 전달되는지 검증한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '입력 필드 이름과 설명',
+        detail:
+          '이메일, 비밀번호, 확인 입력의 accessible name과 description을 접근성 트리 또는 스크린리더로 확인한다.',
+      },
+      {
+        title: '오류 메시지 연결',
+        detail:
+          '잘못된 입력 후 aria-describedby 또는 동등한 방식으로 해당 필드의 오류가 읽히는지 확인한다.',
+      },
+      {
+        title: '상태 변화 전달',
+        detail:
+          '오류가 사라지거나 제출 성공 시 사용자가 상태 변화를 인지할 수 있는 live region 또는 포커스 전략을 점검한다.',
+      },
+    ],
+  },
+  {
+    slug: 'modal-focus-accessibility',
+    title: '모달 포커스 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['Keyboard', 'Screen Reader'],
+    summary:
+      '삭제 확인 모달이 키보드와 보조기술 사용자에게 안전하게 동작하는지 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      '모달이 열리면 포커스가 모달 내부의 적절한 요소로 이동하는지 확인한다.',
+      'Tab 순환이 모달 내부에 갇히고 배경 요소로 빠져나가지 않는지 검증한다.',
+      'Escape, 취소, 확인 동작 후 포커스가 호출 버튼으로 복귀하는지 확인한다.',
+      'dialog 역할, 제목, 설명이 보조기술에 전달되는지 검증한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '초기 포커스와 포커스 트랩',
+        detail:
+          '모달 오픈 시 취소 또는 제목으로 포커스가 이동하고 Tab/Shift+Tab이 모달 내부에서 순환하는지 확인한다.',
+      },
+      {
+        title: '닫힘 후 포커스 복귀',
+        detail:
+          'Escape, 취소, 확인 각각에서 모달이 닫히고 포커스가 모달을 연 버튼으로 돌아오는지 검증한다.',
+      },
+      {
+        title: '보조기술 정보',
+        detail:
+          'role=dialog, aria-modal, accessible name/description이 모달 목적과 위험성을 설명하는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'color-contrast-audit',
+    title: '색 대비와 상태 표현 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['axe', 'Contrast Checker'],
+    summary:
+      '상태 배지, 버튼, 에러 메시지가 색에만 의존하지 않고 충분한 대비로 전달되는지 검증하는 접근성 테스트 계획을 작성하세요.',
+    requirement: [
+      '본문, 보조 텍스트, 버튼, 배지의 색 대비가 WCAG 기준을 만족하는지 확인한다.',
+      '성공/실패/경고 상태가 색상 외 텍스트나 아이콘 등으로도 구분되는지 검증한다.',
+      'hover, focus, disabled 상태에서도 의미와 대비가 유지되는지 확인한다.',
+      '다크 모드 또는 고대비 설정에서 정보 손실이 없는지 점검한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '텍스트와 UI 대비 측정',
+        detail:
+          '일반 텍스트 4.5:1, 큰 텍스트 3:1, UI 컴포넌트 3:1 기준으로 주요 색 조합을 측정한다.',
+      },
+      {
+        title: '색상 단독 전달 방지',
+        detail:
+          '완료/실패/경고가 색상만이 아니라 텍스트, 아이콘, aria-label 등으로 구분되는지 확인한다.',
+      },
+      {
+        title: '상태별 대비 유지',
+        detail:
+          'hover, focus, disabled, selected 상태에서 대비와 의미 전달이 유지되는지 스냅샷과 측정값으로 기록한다.',
+      },
+    ],
+  },
+  {
+    slug: 'accessible-data-table-audit',
+    title: '데이터 테이블 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'hard',
+    tools: ['Screen Reader', 'Keyboard', 'axe'],
+    summary:
+      '검색·정렬·페이지네이션이 있는 데이터 테이블을 스크린리더와 키보드로 탐색 가능한지 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      '테이블 헤더와 셀이 의미적으로 연결되어 행·열 맥락을 이해할 수 있는지 확인한다.',
+      '정렬 가능한 컬럼의 현재 정렬 상태가 보조기술에 전달되는지 검증한다.',
+      '검색과 페이지 이동 후 결과 수와 현재 페이지 상태가 사용자가 인지 가능하게 갱신되는지 확인한다.',
+      '키보드만으로 검색, 정렬, 페이지 이동을 완료할 수 있는지 검증한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '테이블 구조와 헤더 연결',
+        detail:
+          'th, scope, caption 또는 accessible name으로 테이블 목적과 각 셀의 열 맥락이 전달되는지 확인한다.',
+      },
+      {
+        title: '정렬 상태 전달',
+        detail:
+          '정렬 버튼의 이름과 aria-sort 또는 동등한 상태 정보가 오름차순/내림차순 변화를 정확히 알리는지 검증한다.',
+      },
+      {
+        title: '동적 결과 갱신',
+        detail:
+          '검색·페이지네이션 후 결과 수와 현재 페이지가 화면과 보조기술 모두에서 인지 가능하게 갱신되는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'third-party-script-performance',
+    title: '서드파티 스크립트 성능 영향 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Performance', 'Network', 'Lighthouse'],
+    summary:
+      '분석, 채팅, 광고 같은 서드파티 스크립트가 초기 로딩과 상호작용 지연에 미치는 영향을 검증하는 성능 테스트 계획을 작성하세요.',
+    requirement: [
+      '서드파티 스크립트별 요청 수, 전송량, main thread 점유 시간을 측정한다.',
+      '스크립트 로딩 전략(async, defer, lazy load)이 초기 렌더링에 미치는 영향을 확인한다.',
+      '서드파티 장애나 지연 상황에서도 핵심 기능이 사용 가능한지 검증한다.',
+      '제거 또는 지연 로딩 전후의 LCP, INP, TBT 변화를 비교할 증거를 정의한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '스크립트별 비용 분리',
+        detail:
+          'Network와 Performance 결과에서 서드파티 도메인별 요청 수, bytes, long task 기여도를 분리해 기록한다.',
+      },
+      {
+        title: '로딩 전략 검증',
+        detail:
+          'async/defer/lazy load 적용 전후로 초기 렌더링과 상호작용 가능 시점이 개선되는지 비교한다.',
+      },
+      {
+        title: '장애 내성 확인',
+        detail:
+          '서드파티 요청 실패 또는 지연을 시뮬레이션해 로그인, 탐색, 제출 같은 핵심 흐름이 막히지 않는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'cache-revalidation-performance',
+    title: '캐시와 재검증 성능 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Network', 'Headers', 'Lighthouse'],
+    summary:
+      '정적 자산과 API 응답의 캐시 정책이 반복 방문 성능과 데이터 신선도에 미치는 영향을 검증하는 테스트 케이스를 작성하세요.',
+    requirement: [
+      '정적 자산의 Cache-Control, ETag, immutable 정책이 의도와 맞는지 확인한다.',
+      'API 응답 캐시가 stale 데이터와 과도한 재요청을 만들지 않는지 검증한다.',
+      '첫 방문과 재방문에서 요청 수, 전송량, 로딩 시간을 비교한다.',
+      '배포 후 자산 해시 변경과 오래된 캐시 무효화가 정상 동작하는지 확인한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '정적 자산 캐시 정책',
+        detail:
+          'JS/CSS/이미지의 Cache-Control과 파일 해시를 확인해 장기 캐시와 배포 후 갱신이 양립하는지 검증한다.',
+      },
+      {
+        title: 'API 재검증 동작',
+        detail:
+          '목록/상세 API가 필요한 순간에만 재검증되고 stale 데이터가 사용자에게 오래 노출되지 않는지 확인한다.',
+      },
+      {
+        title: '첫 방문과 재방문 비교',
+        detail:
+          'Disable cache와 일반 캐시 상태를 비교해 request 수, transferred bytes, load event 시간을 기록한다.',
+      },
+    ],
+  },
+  {
+    slug: 'mobile-interaction-latency',
+    title: '모바일 상호작용 지연 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'hard',
+    tools: ['Performance', 'CPU Throttling'],
+    summary:
+      '저사양 모바일 환경에서 검색, 필터, 입력 같은 상호작용이 지연 없이 반응하는지 검증하는 성능 테스트 계획을 작성하세요.',
+    requirement: [
+      'CPU throttling과 모바일 viewport 조건을 명시하고 반복 가능한 측정 환경을 정의한다.',
+      '검색 입력, 필터 변경, 모달 열기처럼 사용자가 자주 하는 상호작용을 측정 대상으로 정한다.',
+      'long task, scripting time, input delay를 관찰해 지연 원인을 분리한다.',
+      'debounce, virtualization, memoization 등 개선 전후를 비교할 기준을 포함한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '모바일 측정 조건',
+        detail:
+          '모바일 viewport, Slow 4G 또는 Fast 3G, 4x CPU throttling 등 재현 가능한 조건을 고정한다.',
+      },
+      {
+        title: '상호작용별 지연 측정',
+        detail:
+          '검색 타이핑, 필터 변경, 모달 오픈에서 input delay와 long task 발생 여부를 trace로 확인한다.',
+      },
+      {
+        title: '개선 전후 비교',
+        detail:
+          'debounce나 리스트 최적화 적용 전후의 scripting time, dropped frame, INP 추정값을 비교한다.',
+      },
+    ],
+  },
+  {
+    slug: 'search-result-rendering-performance',
+    title: '검색 결과 렌더링 성능 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Performance', 'React Profiler'],
+    summary:
+      '검색 결과가 많아질 때 렌더링 비용과 스크롤 성능이 악화되지 않는지 검증하는 성능 테스트 케이스를 작성하세요.',
+    requirement: [
+      '결과 수가 적을 때와 많을 때 렌더링 시간과 프레임 드랍을 비교한다.',
+      '검색어 변경 시 불필요한 전체 재렌더링이 발생하는지 확인한다.',
+      '페이지네이션 또는 가상화가 필요한 임계점을 정의한다.',
+      '빈 결과, 빠른 연속 입력, 긴 제목 같은 경계 조건을 포함한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '결과 규모별 렌더링 비교',
+        detail: '10개, 100개, 1000개 결과에서 commit time, scripting time, scroll FPS를 비교한다.',
+      },
+      {
+        title: '불필요한 재렌더링 확인',
+        detail: 'React Profiler로 검색 입력 시 변경되지 않은 카드/행까지 재렌더링되는지 확인한다.',
+      },
+      {
+        title: '경계 조건 검증',
+        detail:
+          '빈 결과, 매우 긴 문자열, 빠른 연속 입력에서 UI 멈춤이나 레이아웃 흔들림이 없는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'landmark-skiplink-accessibility',
+    title: '랜드마크와 본문 건너뛰기 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'easy',
+    tools: ['Keyboard', 'Screen Reader'],
+    summary:
+      '반복되는 네비게이션을 건너뛰고 페이지 구조를 빠르게 파악할 수 있는지 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      '키보드 사용자가 본문으로 바로 이동할 수 있는 skip link가 있는지 확인한다.',
+      'header, nav, main, footer 같은 landmark가 의미 있게 구성되어 있는지 검증한다.',
+      '페이지 제목과 h1이 현재 페이지 목적을 명확히 설명하는지 확인한다.',
+      '스크린리더 landmark 목록에서 주요 영역이 중복이나 누락 없이 탐색되는지 확인한다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'skip link 동작',
+        detail:
+          '첫 Tab에서 본문 건너뛰기 링크가 노출되고 Enter 후 main 영역으로 포커스가 이동하는지 확인한다.',
+      },
+      {
+        title: '랜드마크 구조',
+        detail:
+          'nav, main, footer가 역할에 맞게 구성되고 중첩/중복 landmark가 혼란을 만들지 않는지 점검한다.',
+      },
+      {
+        title: '제목 구조',
+        detail:
+          'document title, h1, 섹션 heading이 페이지 목적과 구조를 일관되게 전달하는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'live-region-notification-accessibility',
+    title: '동적 알림 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['Screen Reader', 'Keyboard'],
+    summary:
+      '토스트, 저장 완료, 오류 배너처럼 동적으로 나타나는 메시지가 보조기술 사용자에게 적절히 전달되는지 검증하세요.',
+    requirement: [
+      '저장 완료, 오류, 로딩 완료 메시지가 스크린리더에 자동으로 전달되는지 확인한다.',
+      '중요도에 따라 polite/assertive live region 사용이 적절한지 검증한다.',
+      '알림이 너무 빨리 사라져 읽을 수 없는 문제가 없는지 확인한다.',
+      '포커스를 강제로 빼앗지 않으면서도 사용자가 상태 변화를 인지할 수 있는지 확인한다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'live region 발표',
+        detail:
+          '저장 성공과 실패 메시지가 aria-live 또는 role=status/alert로 스크린리더에 발표되는지 확인한다.',
+      },
+      {
+        title: '알림 지속 시간',
+        detail:
+          '토스트가 사용자가 읽기에 충분한 시간 유지되고 hover/focus 시 사라지지 않는지 확인한다.',
+      },
+      {
+        title: '포커스 유지',
+        detail:
+          '비치명적 알림은 현재 작업 포커스를 유지하고, 치명적 오류는 적절한 요약 영역으로 안내하는지 점검한다.',
+      },
+    ],
+  },
+  {
+    slug: 'touch-target-accessibility',
+    title: '모바일 터치 타깃 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['Mobile Viewport', 'axe'],
+    summary:
+      '모바일 화면에서 버튼, 링크, 체크박스 같은 조작 대상이 충분한 크기와 간격을 갖는지 검증하는 접근성 테스트 계획을 작성하세요.',
+    requirement: [
+      '주요 터치 타깃의 크기와 간격이 WCAG 권장 기준을 만족하는지 확인한다.',
+      '작은 아이콘 버튼도 accessible name과 충분한 클릭 영역을 갖는지 검증한다.',
+      '한 손 사용 또는 확대 상태에서 오작동 위험이 없는지 확인한다.',
+      '가로/세로 화면과 작은 viewport에서 텍스트 겹침이나 타깃 중첩이 없는지 점검한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '터치 타깃 크기 측정',
+        detail:
+          '버튼, 링크, 체크박스, 아이콘 버튼의 실제 hit area가 최소 권장 크기와 간격을 만족하는지 측정한다.',
+      },
+      {
+        title: '아이콘 버튼 접근성',
+        detail:
+          '아이콘만 있는 버튼에 accessible name이 있고, 시각적 아이콘과 동작이 일치하는지 확인한다.',
+      },
+      {
+        title: '작은 화면 회귀 확인',
+        detail:
+          '320px 폭과 확대 상태에서 텍스트/타깃 겹침, 인접 버튼 오탭 위험, 가로 스크롤 발생 여부를 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'reduced-motion-accessibility',
+    title: '모션 민감 사용자 설정 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'hard',
+    tools: ['prefers-reduced-motion', 'DevTools'],
+    summary:
+      '애니메이션과 전환 효과가 모션 민감 사용자에게 부담을 주지 않도록 reduced motion 설정을 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      'prefers-reduced-motion 설정에서 큰 이동, 확대, 반복 애니메이션이 줄어드는지 확인한다.',
+      '모션이 줄어도 상태 변화와 화면 전환 의미가 사라지지 않는지 검증한다.',
+      '자동 재생, 깜박임, 반복 효과가 사용자의 제어 없이 지속되지 않는지 확인한다.',
+      '기본 모션과 reduced motion 각각에서 핵심 작업 흐름이 동일하게 가능한지 확인한다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'reduced motion 적용',
+        detail:
+          'OS 또는 DevTools에서 prefers-reduced-motion을 켠 뒤 페이지 전환, 모달, 리스트 등장 효과가 축소되는지 확인한다.',
+      },
+      {
+        title: '의미 보존 확인',
+        detail:
+          '모션이 제거되어도 선택됨, 완료, 오류 같은 상태 변화가 텍스트나 스타일로 명확히 전달되는지 검증한다.',
+      },
+      {
+        title: '반복/깜박임 제어',
+        detail:
+          '자동 재생 애니메이션, 깜박임, skeleton 효과가 과도하지 않고 멈춤 또는 축소 전략을 갖는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'font-loading-performance',
+    title: '웹폰트 로딩 성능 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'easy',
+    tools: ['Network', 'Lighthouse'],
+    summary:
+      '웹폰트가 렌더링 지연, 레이아웃 변화, 텍스트 표시 경험에 미치는 영향을 검증하는 성능 테스트 케이스를 작성하세요.',
+    requirement: [
+      '폰트 파일 크기, 요청 수, preload 적용 여부를 확인한다.',
+      'font-display 전략이 FOIT/FOUT와 사용자 경험에 미치는 영향을 검증한다.',
+      '폰트 로딩 전후 레이아웃 변화와 CLS 영향을 확인한다.',
+      '서브셋, 가변 폰트, 시스템 폰트 fallback 개선 여부를 비교한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '폰트 요청 비용 확인',
+        detail:
+          'Network 탭에서 폰트 파일 수, 크기, 캐시 여부, preload 적용 여부를 확인하고 초기 렌더링 영향도를 기록한다.',
+      },
+      {
+        title: '텍스트 표시 전략 검증',
+        detail:
+          'font-display 설정에 따라 텍스트가 보이지 않는 시간이 발생하는지, fallback 전환이 과도하게 튀지 않는지 확인한다.',
+      },
+      {
+        title: '레이아웃 변화 측정',
+        detail:
+          '웹폰트 적용 전후 텍스트 폭 변화로 CLS가 증가하는지 확인하고 fallback metric 조정 필요성을 정리한다.',
+      },
+    ],
+  },
+  {
+    slug: 'memory-leak-performance',
+    title: '장시간 사용 메모리 누수 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'hard',
+    tools: ['Memory', 'Performance Monitor'],
+    summary:
+      '대시보드나 리스트 화면을 장시간 사용할 때 메모리 사용량이 계속 증가하지 않는지 검증하는 성능 테스트 계획을 작성하세요.',
+    requirement: [
+      '반복 탐색, 검색, 모달 열기/닫기 같은 장시간 사용 시나리오를 정의한다.',
+      'heap snapshot, detached node, event listener 증가 여부를 확인한다.',
+      '동일 작업 반복 후 메모리가 안정화되는지 또는 지속 증가하는지 측정한다.',
+      '누수 의심 지점을 재현 가능한 최소 절차와 증거로 정리한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '반복 사용 시나리오',
+        detail:
+          '목록 검색, 상세 진입, 모달 열기/닫기, 페이지 전환을 20회 이상 반복하는 측정 절차를 정의한다.',
+      },
+      {
+        title: '메모리 증가 관찰',
+        detail:
+          'Performance Monitor와 heap snapshot으로 JS heap, DOM node, event listener 수가 반복 후 안정화되는지 확인한다.',
+      },
+      {
+        title: '누수 증거 수집',
+        detail:
+          'detached DOM tree 또는 해제되지 않은 listener를 snapshot diff로 확인하고 재현 URL과 단계로 리포트한다.',
+      },
+    ],
+  },
+  {
+    slug: 'server-rendering-ttfb-performance',
+    title: '서버 렌더링 TTFB 점검',
+    track: 'performance',
+    category: 'performance',
+    difficulty: 'medium',
+    tools: ['Network', 'WebPageTest'],
+    summary:
+      'SSR/동적 페이지에서 서버 응답 지연이 초기 표시 성능에 미치는 영향을 검증하는 성능 테스트 케이스를 작성하세요.',
+    requirement: [
+      'TTFB, server timing, HTML 응답 크기와 초기 렌더링 관계를 측정한다.',
+      '캐시 hit/miss, 로그인 여부, 지역 차이에 따른 응답 시간을 비교한다.',
+      '느린 DB/API 의존성이 TTFB에 미치는 영향을 추적하는 절차를 포함한다.',
+      'TTFB 회귀를 배포 전 감지할 기준과 알림 조건을 정의한다.',
+    ],
+    modelTestCases: [
+      {
+        title: 'TTFB 측정 기준',
+        detail:
+          '동일 URL에서 cache hit/miss, 로그인/비로그인, 지역 조건을 나누어 TTFB와 server timing을 기록한다.',
+      },
+      {
+        title: '서버 병목 추적',
+        detail:
+          '느린 API 호출, DB 쿼리, 동기 작업이 HTML 응답 시작을 지연시키는지 로그와 trace로 확인한다.',
+      },
+      {
+        title: '회귀 감지 기준',
+        detail: '주요 동적 route의 p95 TTFB 예산과 이전 배포 대비 증가율 기준을 정의한다.',
+      },
+    ],
+  },
+  {
+    slug: 'accessible-error-summary',
+    title: '폼 오류 요약 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['Keyboard', 'Screen Reader'],
+    summary:
+      '여러 필드 오류가 동시에 발생했을 때 사용자가 오류 위치와 수정 방법을 빠르게 이해할 수 있는지 검증하세요.',
+    requirement: [
+      '제출 실패 시 오류 요약이 제공되고 각 오류가 해당 필드로 이동 가능한지 확인한다.',
+      '오류 요약과 개별 필드 오류가 중복되더라도 혼란스럽지 않게 전달되는지 검증한다.',
+      '키보드와 스크린리더 사용자가 첫 오류 또는 요약으로 안내되는지 확인한다.',
+      '오류 수정 후 요약과 필드 상태가 정확히 갱신되는지 검증한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '오류 요약 제공',
+        detail:
+          '필수값 누락 제출 후 페이지 상단 또는 폼 상단에 오류 요약이 표시되고 스크린리더가 인지 가능한지 확인한다.',
+      },
+      {
+        title: '필드 이동 연결',
+        detail:
+          '요약의 각 오류 링크가 해당 입력 필드로 포커스를 이동시키고 필드 오류 메시지가 함께 읽히는지 검증한다.',
+      },
+      {
+        title: '수정 후 상태 갱신',
+        detail: '오류를 수정하면 요약 항목과 aria-invalid 상태가 제거되거나 갱신되는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'language-and-i18n-accessibility',
+    title: '언어와 다국어 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'medium',
+    tools: ['Screen Reader', 'HTML Validator'],
+    summary:
+      '한국어/영문이 섞인 화면에서 문서 언어와 부분 언어 표시가 올바르게 전달되는지 검증하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      'html lang 값이 페이지 기본 언어와 일치하는지 확인한다.',
+      '다른 언어 문구, 코드, 약어가 필요한 경우 적절히 구분되는지 검증한다.',
+      '날짜, 숫자, 통화, 단위가 지역화 규칙에 맞게 읽히는지 확인한다.',
+      '언어 전환 또는 번역 누락이 스크린리더 이해를 방해하지 않는지 점검한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '문서 기본 언어',
+        detail:
+          'html lang이 ko 또는 페이지 실제 기본 언어와 일치하고 스크린리더 발음이 과도하게 어긋나지 않는지 확인한다.',
+      },
+      {
+        title: '부분 언어와 약어 처리',
+        detail:
+          '영문 제품명, 코드, 약어, 외국어 문구가 필요한 경우 lang 또는 설명으로 의미가 전달되는지 점검한다.',
+      },
+      {
+        title: '지역화 포맷 확인',
+        detail: '날짜, 시간, 가격, 단위가 사용자 지역과 문맥에 맞게 표시되고 읽히는지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'accessible-empty-loading-states',
+    title: '빈 상태와 로딩 상태 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'easy',
+    tools: ['Screen Reader', 'Keyboard'],
+    summary:
+      '목록의 빈 상태, 로딩, 오류 상태가 시각 사용자와 보조기술 사용자 모두에게 명확히 전달되는지 검증하세요.',
+    requirement: [
+      '로딩 중 상태가 텍스트와 보조기술 모두에 전달되는지 확인한다.',
+      '빈 상태에서 다음 행동이 무엇인지 명확히 안내되는지 검증한다.',
+      '오류 상태가 재시도 방법과 함께 전달되는지 확인한다.',
+      '로딩 완료 후 포커스와 읽기 순서가 예상치 못하게 이동하지 않는지 점검한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '로딩 상태 전달',
+        detail:
+          '스피너만 보이는 상태를 피하고 role=status 또는 텍스트로 현재 로딩 중임이 전달되는지 확인한다.',
+      },
+      {
+        title: '빈 상태 행동 안내',
+        detail:
+          '검색 결과 없음 또는 작성 글 없음 상태에서 원인과 다음 행동이 텍스트로 명확히 제공되는지 검증한다.',
+      },
+      {
+        title: '오류와 재시도',
+        detail:
+          '데이터 로딩 실패 시 오류 원인, 재시도 버튼, 포커스 유지가 키보드/스크린리더 사용자에게 적절한지 확인한다.',
+      },
+    ],
+  },
+  {
+    slug: 'keyboard-accessibility-audit',
+    title: '키보드 접근성 점검',
+    track: 'accessibility',
+    category: 'accessibility',
+    difficulty: 'easy',
+    tools: ['Keyboard', 'Screen Reader', 'axe'],
+    summary:
+      '로그인/폼 화면을 기준으로 키보드 탐색, 포커스 표시, 라벨·에러 전달을 점검하는 접근성 테스트 케이스를 작성하세요.',
+    requirement: [
+      'Tab/Shift+Tab만으로 주요 입력, 버튼, 링크에 순서대로 접근 가능한지 검증한다.',
+      '현재 포커스 위치가 시각적으로 명확히 보이는지 확인한다.',
+      '입력 필드의 이름, 설명, 에러 메시지가 보조기술에 전달되는지 검증한다.',
+      '색 대비와 아이콘 단독 정보 전달처럼 시각 의존 문제가 없는지 확인한다.',
+    ],
+    modelTestCases: [
+      {
+        title: '키보드 탐색 순서',
+        detail:
+          '마우스 없이 Tab/Shift+Tab으로 전체 컨트롤을 이동하며 포커스 순서가 화면 흐름과 일치하고 키보드 함정이 없는지 확인한다.',
+      },
+      {
+        title: '폼 라벨과 에러 접근성',
+        detail:
+          '각 입력의 접근 가능한 이름과 에러 메시지 연결을 스크린리더 또는 브라우저 접근성 트리로 확인한다.',
+      },
+      {
+        title: '시각 의존성 점검',
+        detail:
+          '포커스 링, 색 대비, 아이콘 버튼의 accessible name을 확인해 색상이나 아이콘만으로 의미가 전달되지 않게 검증한다.',
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## 작업 내용

- qaground 학습 경로에 성능·접근성 트랙을 추가했습니다.
- 성능 챌린지 12개와 접근성 챌린지 12개를 추가했습니다.
- 챌린지 목록/가이드/학습 경로에서 신규 트랙이 자연스럽게 노출되도록 메타데이터를 정리했습니다.
- qaground SEO 메타데이터와 사이트맵을 성능·접근성 트랙 기준으로 보강했습니다.
- GA/AdSense 스크립트를 `<body>` 내부로 정리하고 production gating을 유지했습니다.

## 추가된 챌린지

### 성능

- Core Web Vitals 성능 점검
- API 응답 시간 SLO 점검
- 이미지 로딩 성능 점검
- 번들 크기 회귀 예산 점검
- 체크아웃 부하 테스트 설계
- 서드파티 스크립트 성능 영향 점검
- 캐시와 재검증 성능 점검
- 모바일 상호작용 지연 점검
- 검색 결과 렌더링 성능 점검
- 웹폰트 로딩 성능 점검
- 장시간 사용 메모리 누수 점검
- 서버 렌더링 TTFB 점검

### 접근성

- 키보드 접근성 점검
- 스크린리더 폼 접근성 점검
- 모달 포커스 접근성 점검
- 색 대비와 상태 표현 점검
- 데이터 테이블 접근성 점검
- 랜드마크와 본문 건너뛰기 점검
- 동적 알림 접근성 점검
- 모바일 터치 타깃 접근성 점검
- 모션 민감 사용자 설정 점검
- 폼 오류 요약 접근성 점검
- 언어와 다국어 접근성 점검
- 빈 상태와 로딩 상태 접근성 점검

## 확인

- `pnpm --filter qaground build`

Closes #287