### PR TITLE
feat(qaground): 챌린지 상세 UX 개선

### DIFF
--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -131,7 +131,11 @@ function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
 
 function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
   if (
-    attempt.assertions.some((assertion) => assertion.kind !== 'status' && assertion.path.trim())
+    attempt.assertions.some(
+      (assertion) =>
+        assertion.kind !== 'status' &&
+        (assertion.path.trim() || assertion.kind === 'type' || assertion.kind === 'arrayLength')
+    )
   ) {
     return true;
   }

--- a/apps/qaground/src/shared/challenges/api-hidden-grader.ts
+++ b/apps/qaground/src/shared/challenges/api-hidden-grader.ts
@@ -1,5 +1,5 @@
 export interface ApiAssertionForGrade {
-  kind: 'status' | 'json';
+  kind: 'status' | 'json' | 'exists' | 'type' | 'arrayLength';
   path: string;
   expected: string;
 }
@@ -130,7 +130,9 @@ function hasStatusAssertion(attempt: ApiAttemptForGrade): boolean {
 }
 
 function hasBodyAssertion(attempt: ApiAttemptForGrade): boolean {
-  if (attempt.assertions.some((assertion) => assertion.kind === 'json' && assertion.path.trim())) {
+  if (
+    attempt.assertions.some((assertion) => assertion.kind !== 'status' && assertion.path.trim())
+  ) {
     return true;
   }
   const executable = stripNonExecutableJavaScript(attempt.script);

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -28,6 +28,14 @@ export interface ChallengeSelector {
 }
 
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+export type ApiSchemaType = 'string' | 'number' | 'boolean' | 'array' | 'object' | 'null';
+
+export interface ApiSchemaField {
+  path: string;
+  type: ApiSchemaType;
+  required?: boolean;
+  desc?: string;
+}
 
 export interface ApiEndpoint {
   method: HttpMethod;
@@ -35,6 +43,10 @@ export interface ApiEndpoint {
   /** 인증(토큰) 필요 여부. */
   auth?: boolean;
   desc: string;
+  query?: ApiSchemaField[];
+  body?: ApiSchemaField[];
+  response?: ApiSchemaField[];
+  responseExample?: unknown;
 }
 
 export interface Challenge {
@@ -554,10 +566,81 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
         method: 'GET',
         path: '/products?page=1&limit=5',
         desc: '상품 목록 (페이지네이션·category 필터)',
+        query: [
+          { path: 'page', type: 'number', desc: '1부터 시작하는 페이지 번호' },
+          { path: 'limit', type: 'number', desc: '페이지 크기' },
+          { path: 'category', type: 'string', desc: '카테고리 필터' },
+        ],
+        response: [
+          { path: 'data', type: 'array', required: true, desc: '상품 배열' },
+          { path: 'data.0.id', type: 'number', required: true },
+          { path: 'data.0.name', type: 'string', required: true },
+          { path: 'total', type: 'number', required: true },
+          { path: 'totalPages', type: 'number', required: true },
+        ],
+        responseExample: {
+          data: [{ id: 1, name: '무선 키보드', category: '주변기기', price: 39000, inStock: true }],
+          page: 1,
+          limit: 5,
+          total: 12,
+          totalPages: 3,
+        },
       },
-      { method: 'GET', path: '/products/:id', desc: '상품 단건 (없으면 404)' },
-      { method: 'POST', path: '/auth/login', desc: '로그인 → 토큰 (무효 시 401)' },
-      { method: 'POST', path: '/products', auth: true, desc: '상품 생성 (검증 400 / 성공 201)' },
+      {
+        method: 'GET',
+        path: '/products/:id',
+        desc: '상품 단건 (없으면 404)',
+        response: [
+          { path: 'id', type: 'number', required: true },
+          { path: 'name', type: 'string', required: true },
+          { path: 'price', type: 'number', required: true },
+          { path: 'inStock', type: 'boolean', required: true },
+        ],
+        responseExample: {
+          id: 1,
+          name: '무선 키보드',
+          category: '주변기기',
+          price: 39000,
+          inStock: true,
+        },
+      },
+      {
+        method: 'POST',
+        path: '/auth/login',
+        desc: '로그인 → 토큰 (무효 시 401)',
+        body: [
+          { path: 'email', type: 'string', required: true },
+          { path: 'password', type: 'string', required: true },
+        ],
+        response: [
+          { path: 'token', type: 'string', required: true },
+          { path: 'user.email', type: 'string', required: true },
+        ],
+        responseExample: { token: 'qaground-demo-token', user: { email: 'tester@qaground.dev' } },
+      },
+      {
+        method: 'POST',
+        path: '/products',
+        auth: true,
+        desc: '상품 생성 (검증 400 / 성공 201)',
+        body: [
+          { path: 'name', type: 'string', required: true },
+          { path: 'price', type: 'number', required: true },
+          { path: 'category', type: 'string' },
+        ],
+        response: [
+          { path: 'id', type: 'number', required: true },
+          { path: 'name', type: 'string', required: true },
+          { path: 'price', type: 'number', required: true },
+        ],
+        responseExample: {
+          id: 13,
+          name: '테스트 상품',
+          category: '기타',
+          price: 12000,
+          inStock: true,
+        },
+      },
       { method: 'DELETE', path: '/products/:id', auth: true, desc: '상품 삭제 (204 / 404)' },
     ],
     apiNote:

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -597,6 +597,11 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
           { path: 'data', type: 'array', required: true, desc: '상품 배열' },
           { path: 'data.0.id', type: 'number', required: true },
           { path: 'data.0.name', type: 'string', required: true },
+          { path: 'data.0.category', type: 'string', required: true },
+          { path: 'data.0.price', type: 'number', required: true },
+          { path: 'data.0.inStock', type: 'boolean', required: true },
+          { path: 'page', type: 'number', required: true },
+          { path: 'limit', type: 'number', required: true },
           { path: 'total', type: 'number', required: true },
           { path: 'totalPages', type: 'number', required: true },
         ],
@@ -615,6 +620,7 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
         response: [
           { path: 'id', type: 'number', required: true },
           { path: 'name', type: 'string', required: true },
+          { path: 'category', type: 'string', required: true },
           { path: 'price', type: 'number', required: true },
           { path: 'inStock', type: 'boolean', required: true },
         ],
@@ -653,7 +659,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
         response: [
           { path: 'id', type: 'number', required: true },
           { path: 'name', type: 'string', required: true },
+          { path: 'category', type: 'string', required: true },
           { path: 'price', type: 'number', required: true },
+          { path: 'inStock', type: 'boolean', required: true },
         ],
         responseExample: {
           id: 13,

--- a/apps/qaground/src/shared/challenges/registry.ts
+++ b/apps/qaground/src/shared/challenges/registry.ts
@@ -75,6 +75,12 @@ export interface Challenge {
   modelTestCases?: { title: string; detail: string }[];
   /** 코드 채점: 코드 에디터 초기 Playwright 스펙 템플릿. */
   starterSpec?: string;
+  /** 학습 UX: 예상 풀이 시간(분). */
+  estimatedMinutes?: number;
+  /** 학습 UX: 먼저 풀면 좋은 챌린지 slug 목록. */
+  prerequisites?: string[];
+  /** 학습 UX: 완료 후 추천할 챌린지 slug 목록. */
+  recommendedNext?: string[];
 }
 
 export const TRACK_LABEL: Record<ChallengeTrack, string> = {
@@ -125,6 +131,8 @@ export const CHALLENGES: Challenge[] = [
     track: 'automation',
     category: 'auth',
     difficulty: 'easy',
+    estimatedMinutes: 20,
+    recommendedNext: ['signup-validation', 'test-design-password-reset'],
     tools: ['Playwright'],
     summary: '유효·무효 자격증명에 따른 로그인 동작을 검증하는 자동화 테스트를 작성하세요.',
     requirement: [
@@ -156,6 +164,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'automation',
     category: 'forms',
     difficulty: 'easy',
+    estimatedMinutes: 25,
+    prerequisites: ['login-basic'],
+    recommendedNext: ['profile-form', 'realtime-validation'],
     tools: ['Playwright'],
     summary: '이메일 형식, 비밀번호 규칙, 비밀번호 확인 일치를 검증하는 테스트를 작성하세요.',
     requirement: [
@@ -212,6 +223,8 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'automation',
     category: 'data',
     difficulty: 'medium',
+    estimatedMinutes: 30,
+    recommendedNext: ['wizard-form', 'cart-checkout'],
     tools: ['Playwright'],
     summary: '검색 필터, 컬럼 정렬, 페이지 이동이 있는 테이블을 검증하는 테스트를 작성하세요.',
     requirement: [
@@ -366,6 +379,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'automation',
     category: 'forms',
     difficulty: 'medium',
+    estimatedMinutes: 35,
+    prerequisites: ['signup-validation'],
+    recommendedNext: ['cart-checkout'],
     tools: ['Playwright'],
     summary: '단계별 검증·이동·이전 복귀가 있는 3단계 위저드 폼을 검증하는 테스트를 작성하세요.',
     requirement: [
@@ -482,6 +498,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'automation',
     category: 'commerce',
     difficulty: 'hard',
+    estimatedMinutes: 45,
+    prerequisites: ['data-table', 'wizard-form'],
+    recommendedNext: ['test-case-coupon', 'rest-api-products'],
     tools: ['Playwright'],
     summary:
       '수량 변경에 따라 소계·배송비·쿠폰 할인이 연쇄로 합계에 반영되는 장바구니를 검증하세요. 재고 한도와 쿠폰 최소 금액 규칙이 얽혀 있습니다.',
@@ -550,6 +569,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'api',
     category: 'data',
     difficulty: 'medium',
+    estimatedMinutes: 35,
+    prerequisites: ['login-basic'],
+    recommendedNext: ['rest-api-auth-session', 'rest-api-product-crud-auth'],
     tools: ['Postman'],
     summary:
       '상품 REST API의 목록·조회·생성·삭제와 인증을 검증하는 API 테스트를 작성하세요. 브라우저가 아니라 HTTP 요청으로 검증합니다.',
@@ -652,6 +674,8 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'manual',
     category: 'fundamentals',
     difficulty: 'medium',
+    estimatedMinutes: 25,
+    recommendedNext: ['test-design-password-reset'],
     tools: ['Testea'],
     summary:
       '주문 폼에 의도적으로 심은 결함을 탐색적 테스트로 찾고, 결함 리포트를 작성해 제출하세요. 제출하면 정답과 피드백을 보여줍니다.',
@@ -684,6 +708,9 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'manual',
     category: 'fundamentals',
     difficulty: 'medium',
+    estimatedMinutes: 30,
+    prerequisites: ['login-basic'],
+    recommendedNext: ['test-design-login-lockout', 'test-case-coupon'],
     tools: ['Testea'],
     summary:
       '비밀번호 재설정 기능의 테스트 케이스를 설계하세요. 정상·예외·경계 시나리오를 빠짐없이 도출하는 메뉴얼 테스트 연습입니다.',
@@ -725,6 +752,8 @@ test('유효한 자격증명으로 로그인하면 환영 메시지가 보인다
     track: 'manual',
     category: 'fundamentals',
     difficulty: 'easy',
+    estimatedMinutes: 35,
+    prerequisites: ['cart-checkout', 'test-design-password-reset'],
     tools: ['Testea'],
     summary:
       '할인 쿠폰 적용 기능의 테스트 케이스를 작성하세요. 정상·예외·경계 시나리오를 표로 정리하는 연습입니다.',
@@ -1162,6 +1191,8 @@ test('내 테스트', async ({ page }) => {
     track: 'manual',
     category: 'fundamentals',
     difficulty: 'medium',
+    estimatedMinutes: 35,
+    prerequisites: ['test-design-password-reset'],
     tools: ['Testea'],
     summary:
       '로그인 실패 잠금 정책의 테스트 케이스를 설계하세요. 실패 누적·잠금·해제·카운터 리셋을 경계값과 함께 빠짐없이 도출하는 연습입니다.',
@@ -1533,6 +1564,9 @@ test('내 테스트', async ({ page }) => {
     track: 'api',
     category: 'auth',
     difficulty: 'medium',
+    estimatedMinutes: 40,
+    prerequisites: ['rest-api-products'],
+    recommendedNext: ['rest-api-product-crud-auth'],
     tools: ['Postman'],
     summary:
       '로그인 후 보호된 /me API를 호출하고, 누락·만료·잘못된 토큰과 refresh token 갱신 경로를 검증하세요.',
@@ -1784,6 +1818,8 @@ test('내 테스트', async ({ page }) => {
     track: 'api',
     category: 'commerce',
     difficulty: 'medium',
+    estimatedMinutes: 50,
+    prerequisites: ['rest-api-products', 'rest-api-auth-session'],
     tools: ['Postman'],
     summary:
       '로그인으로 토큰을 발급받고, 보호된 상품 생성·수정·삭제 API의 인증, 입력 검증, 상태 코드를 검증하세요. 성공 경로뿐 아니라 401·400·404·204 같은 API 경계 응답까지 함께 확인해야 합니다.',

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -43,10 +43,22 @@ interface PmResult {
 }
 interface RunResult {
   status: number;
+  durationMs: number;
+  responseHeaders: Record<string, string>;
   bodyText: string;
   checks: Check[];
   scriptResults: PmResult[];
   hiddenGrade: HiddenGradeResult;
+}
+interface RequestHistoryItem {
+  id: string;
+  method: Method;
+  path: string;
+  status: number;
+  durationMs: number;
+  passed: number;
+  total: number;
+  createdAt: string;
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
@@ -454,6 +466,7 @@ export const ApiTesterExercise = ({
   const [running, setRunning] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
+  const [history, setHistory] = useState<RequestHistoryItem[]>([]);
   const [attempts, setAttempts] = useState<ApiAttemptForGrade[]>([]);
   const [activePanel, setActivePanel] = useState<'test' | 'docs' | 'script'>('test');
   const [resultH, setResultH] = useState(288);
@@ -500,11 +513,14 @@ export const ApiTesterExercise = ({
       const hasBody = method !== 'GET' && body.trim();
       if (hasBody) headers['Content-Type'] = 'application/json';
 
+      const startedAt = performance.now();
       const res = await fetch(apiBase + path, {
         method,
         headers,
         body: hasBody ? body : undefined,
       });
+      const durationMs = Math.round(performance.now() - startedAt);
+      const responseHeaders = Object.fromEntries(res.headers.entries());
 
       const bodyText = await res.text();
       let json: unknown = undefined;
@@ -576,10 +592,37 @@ export const ApiTesterExercise = ({
       setAttempts(nextAttempts);
 
       const pretty = json !== undefined ? JSON.stringify(json, null, 2) : bodyText;
-      setResult({ status: res.status, bodyText: pretty, checks, scriptResults, hiddenGrade });
       const passed =
         checks.filter((c) => c.pass).length + scriptResults.filter((r) => r.pass).length;
       const totalChecks = checks.length + scriptResults.length;
+      setResult({
+        status: res.status,
+        durationMs,
+        responseHeaders,
+        bodyText: pretty,
+        checks,
+        scriptResults,
+        hiddenGrade,
+      });
+      setHistory((prev) =>
+        [
+          {
+            id: `${Date.now()}-${nextAttempts.length}`,
+            method,
+            path,
+            status: res.status,
+            durationMs,
+            passed,
+            total: totalChecks,
+            createdAt: new Date().toLocaleTimeString('ko-KR', {
+              hour: '2-digit',
+              minute: '2-digit',
+              second: '2-digit',
+            }),
+          },
+          ...prev,
+        ].slice(0, 6)
+      );
       track('api_run', { passed, total: totalChecks, score: hiddenGrade.score });
       recordSubmission({
         slug,
@@ -745,6 +788,51 @@ export const ApiTesterExercise = ({
               <p className="text-system-red mt-3 text-sm" role="alert">
                 {error}
               </p>
+            )}
+
+            {history.length > 0 && (
+              <div className="border-line-2 bg-bg-3 mt-4 border">
+                <div className="border-line-2 flex items-center justify-between border-b px-3 py-2">
+                  <span className="text-text-2 text-xs font-semibold">최근 요청</span>
+                  <span className="text-text-3 text-xs">최근 {history.length}개</span>
+                </div>
+                <div className="divide-line-2 divide-y">
+                  {history.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => {
+                        setMethod(item.method);
+                        setPath(item.path);
+                      }}
+                      className="hover:bg-bg-1 grid w-full grid-cols-[4rem_minmax(0,1fr)_auto] items-center gap-2 px-3 py-2 text-left transition-colors"
+                    >
+                      <span
+                        className={`w-fit border px-1.5 py-0.5 font-mono text-[11px] font-semibold ${METHOD_TONE[item.method]}`}
+                      >
+                        {item.method}
+                      </span>
+                      <span className="min-w-0">
+                        <code className="text-text-1 block truncate font-mono text-xs">
+                          {item.path}
+                        </code>
+                        <span className="text-text-3 text-[11px]">
+                          {item.createdAt} · HTTP {item.status} · {item.durationMs}ms
+                        </span>
+                      </span>
+                      <span
+                        className={
+                          item.passed === item.total
+                            ? 'text-xs text-[#3fb950]'
+                            : 'text-xs text-[#f85149]'
+                        }
+                      >
+                        {item.passed}/{item.total}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
             )}
 
             <div className="mt-5 grid gap-4 lg:grid-cols-2">
@@ -951,7 +1039,11 @@ export const ApiTesterExercise = ({
       >
         <div className="flex shrink-0 items-center gap-2 border-b border-white/10 px-4 py-2">
           <span className="font-mono text-xs text-[#8b949e]">api result</span>
-          {result && <span className="font-mono text-xs text-[#c9d1d9]">HTTP {result.status}</span>}
+          {result && (
+            <span className="font-mono text-xs text-[#c9d1d9]">
+              HTTP {result.status} · {result.durationMs}ms
+            </span>
+          )}
           {result && (
             <span
               className={`ml-auto font-mono text-xs ${passCount === total ? 'text-[#3fb950]' : 'text-[#f85149]'}`}
@@ -975,6 +1067,19 @@ export const ApiTesterExercise = ({
                   </span>
                 ))}
               </div>
+              <details className="mt-3 border border-white/10">
+                <summary className="cursor-pointer px-3 py-2 text-[#8b949e] hover:text-[#c9d1d9]">
+                  response headers · {Object.keys(result.responseHeaders).length}
+                </summary>
+                <div className="border-t border-white/10 px-3 py-2">
+                  {Object.entries(result.responseHeaders).map(([key, value]) => (
+                    <div key={key} className="grid gap-2 sm:grid-cols-[11rem_minmax(0,1fr)]">
+                      <span className="text-[#8b949e]">{key}</span>
+                      <span className="break-all text-[#c9d1d9]">{value}</span>
+                    </div>
+                  ))}
+                </div>
+              </details>
               {(result.checks.length > 0 || result.scriptResults.length > 0) && (
                 <div className="mt-3 space-y-1">
                   {result.checks.map((c, i) => (

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -260,6 +260,21 @@ function endpointKey(endpoint: ApiEndpoint): string {
   return `${endpoint.method} ${endpoint.path}`;
 }
 
+function defaultExpectedForKind(kind: AssertKind) {
+  if (kind === 'status') return '200';
+  if (kind === 'type') return 'string';
+  if (kind === 'arrayLength') return '0';
+  return '';
+}
+
+function executablePathForEndpoint(path: string) {
+  return path.replace(/:([A-Za-z_$][\w$]*)/g, (_, name: string) => {
+    const lower = name.toLowerCase();
+    if (lower.endsWith('id') || lower.includes('id')) return '1';
+    return 'demo';
+  });
+}
+
 function SchemaFieldList({ title, fields }: { title: string; fields?: ApiSchemaField[] }) {
   if (!fields?.length) return null;
 
@@ -481,7 +496,7 @@ export const ApiTesterExercise = ({
         id: nextId++,
         kind,
         path: '',
-        expected: kind === 'type' ? 'string' : kind === 'arrayLength' ? '0' : '',
+        expected: defaultExpectedForKind(kind),
       },
     ]);
   const removeAssertion = (id: number) => setAssertions((as) => as.filter((a) => a.id !== id));
@@ -489,18 +504,18 @@ export const ApiTesterExercise = ({
   const applyEndpoint = (endpoint: ApiEndpoint) => {
     setSelectedEndpointKey(endpointKey(endpoint));
     setMethod(endpoint.method);
-    setPath(endpoint.path);
-    if (endpoint.body?.length) {
-      setBody(
-        JSON.stringify(
-          Object.fromEntries(
-            endpoint.body.map((field) => [field.path, defaultValueForSchemaType(field.type)])
-          ),
-          null,
-          2
-        )
-      );
-    }
+    setPath(executablePathForEndpoint(endpoint.path));
+    setBody(
+      endpoint.body?.length
+        ? JSON.stringify(
+            Object.fromEntries(
+              endpoint.body.map((field) => [field.path, defaultValueForSchemaType(field.type)])
+            ),
+            null,
+            2
+          )
+        : ''
+    );
   };
 
   const run = async () => {
@@ -574,8 +589,9 @@ export const ApiTesterExercise = ({
         };
       });
 
-      const scriptResults = script.trim()
-        ? runPmScript(script, { status: res.status, json, bodyText })
+      const userScript = script.trim() === DEFAULT_SCRIPT.trim() ? '' : script;
+      const scriptResults = userScript.trim()
+        ? runPmScript(userScript, { status: res.status, json, bodyText })
         : [];
 
       const attempt: ApiAttemptForGrade = {
@@ -583,7 +599,7 @@ export const ApiTesterExercise = ({
         path,
         status: res.status,
         assertions,
-        script,
+        script: userScript,
         checks,
         scriptResults,
       };
@@ -632,7 +648,7 @@ export const ApiTesterExercise = ({
           path,
           headers: redactHeaders(headers),
           assertions,
-          script,
+          script: userScript,
           attempts: nextAttempts,
         },
         result: { passed, total: totalChecks },
@@ -918,7 +934,11 @@ export const ApiTesterExercise = ({
                     <select
                       value={a.kind}
                       onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                        updateAssertion(a.id, { kind: e.target.value as AssertKind })
+                        updateAssertion(a.id, {
+                          kind: e.target.value as AssertKind,
+                          path: e.target.value === 'status' ? '' : a.path,
+                          expected: defaultExpectedForKind(e.target.value as AssertKind),
+                        })
                       }
                       className={`h-9 ${fieldClass}`}
                     >
@@ -1022,10 +1042,18 @@ export const ApiTesterExercise = ({
         role="separator"
         aria-orientation="horizontal"
         aria-label="API 결과 높이 조절"
+        aria-valuemin={120}
+        aria-valuemax={520}
+        aria-valuenow={resultH}
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowUp') setResultH((h) => Math.min(h + 16, 520));
+          if (e.key === 'ArrowDown') setResultH((h) => Math.max(h - 16, 120));
+        }}
         onPointerDown={onResizeDown}
         onPointerMove={onResizeMove}
         onPointerUp={onResizeUp}
-        className="border-line-2 bg-bg-2 hover:bg-primary/20 group flex h-2 shrink-0 cursor-row-resize touch-none items-center justify-center border-t transition-colors"
+        className="border-line-2 bg-bg-2 hover:bg-primary/20 focus:bg-primary/20 group flex h-2 shrink-0 cursor-row-resize touch-none items-center justify-center border-t transition-colors outline-none"
       >
         <span
           aria-hidden

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 
 import dynamic from 'next/dynamic';
 
@@ -12,11 +12,12 @@ import {
   gradeApiAttempts,
 } from '@/shared/challenges/api-hidden-grader';
 import type { ApiEndpoint, ApiSchemaField, ApiSchemaType } from '@/shared/challenges/registry';
+import { Play, Plus, Send, Trash2 } from 'lucide-react';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
   loading: () => (
-    <div className="border-line-2 bg-bg-1 text-text-3 flex h-[180px] items-center justify-center rounded-xl border text-sm">
+    <div className="border-line-2 bg-bg-1 text-text-3 flex h-[180px] items-center justify-center border text-sm">
       에디터를 불러오는 중...
     </div>
   ),
@@ -49,6 +50,13 @@ interface RunResult {
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const METHOD_TONE: Record<Method, string> = {
+  GET: 'text-primary bg-primary/10 border-primary/20',
+  POST: 'text-amber-500 bg-amber-500/10 border-amber-500/20',
+  PUT: 'text-blue-500 bg-blue-500/10 border-blue-500/20',
+  PATCH: 'text-blue-500 bg-blue-500/10 border-blue-500/20',
+  DELETE: 'text-system-red bg-system-red/10 border-system-red/20',
+};
 const SCHEMA_TYPES: ApiSchemaType[] = ['string', 'number', 'boolean', 'array', 'object', 'null'];
 
 /** 점(.) 경로로 JSON 값 탐색. eval 없이 구조적 접근만 한다. (`data.0.id` 등) */
@@ -236,13 +244,17 @@ function defaultValueForSchemaType(type: ApiSchemaType): unknown {
   return '';
 }
 
+function endpointKey(endpoint: ApiEndpoint): string {
+  return `${endpoint.method} ${endpoint.path}`;
+}
+
 function SchemaFieldList({ title, fields }: { title: string; fields?: ApiSchemaField[] }) {
   if (!fields?.length) return null;
 
   return (
     <div className="mt-3">
       <span className="text-text-3 text-xs font-medium">{title}</span>
-      <div className="border-line-2 mt-1 overflow-hidden rounded-lg border">
+      <div className="border-line-2 mt-1 overflow-hidden border">
         <div className="border-line-2 bg-bg-2 text-text-3 hidden grid-cols-[minmax(7rem,1.2fr)_5rem_4rem_minmax(0,1.5fr)] gap-2 border-b px-3 py-2 text-[11px] font-medium sm:grid">
           <span>필드</span>
           <span>타입</span>
@@ -267,6 +279,53 @@ function SchemaFieldList({ title, fields }: { title: string; fields?: ApiSchemaF
   );
 }
 
+function DocsSection({
+  title,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  children: ReactNode;
+  defaultOpen?: boolean;
+}) {
+  return (
+    <details className="border-line-2 bg-bg-2 border" open={defaultOpen}>
+      <summary className="text-text-2 hover:bg-bg-1 cursor-pointer px-3 py-2 text-xs font-medium transition-colors">
+        {title}
+      </summary>
+      <div className="border-line-2 border-t p-3">{children}</div>
+    </details>
+  );
+}
+
+function HeaderDoc({ endpoint }: { endpoint: ApiEndpoint }) {
+  return (
+    <div className="border-line-2 overflow-hidden border text-xs">
+      <div className="border-line-2 bg-bg-2 text-text-3 grid grid-cols-[minmax(8rem,1fr)_minmax(9rem,1fr)_minmax(0,1.5fr)] gap-2 border-b px-3 py-2 font-medium">
+        <span>헤더</span>
+        <span>값</span>
+        <span>설명</span>
+      </div>
+      <div className="border-line-2 grid grid-cols-[minmax(8rem,1fr)_minmax(9rem,1fr)_minmax(0,1.5fr)] gap-2 border-b px-3 py-2 last:border-b-0">
+        <code className="text-text-1 font-mono">Content-Type</code>
+        <code className="text-text-2 font-mono">application/json</code>
+        <span className="text-text-3">본문이 있는 요청에서 사용합니다.</span>
+      </div>
+      {endpoint.auth && (
+        <div className="grid grid-cols-[minmax(8rem,1fr)_minmax(9rem,1fr)_minmax(0,1.5fr)] gap-2 px-3 py-2">
+          <code className="text-text-1 font-mono">Authorization</code>
+          <code className="text-text-2 font-mono">Bearer &lt;token&gt;</code>
+          <span className="text-text-3">보호된 API 요청에 필요합니다.</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyDoc({ label }: { label: string }) {
+  return <p className="text-text-3 text-xs">{label}이 없습니다.</p>;
+}
+
 function ApiDocsPanel({
   apiBase,
   endpoints,
@@ -277,57 +336,89 @@ function ApiDocsPanel({
   onSelectEndpoint: (endpoint: ApiEndpoint) => void;
 }) {
   return (
-    <div className="mt-5 flex flex-col gap-4">
-      <div>
+    <div className="flex flex-col gap-3">
+      <div className="border-line-2 bg-bg-3 border px-4 py-3">
         <span className="text-text-2 text-sm font-medium">API 문서</span>
         <p className="text-text-3 mt-1 text-xs leading-relaxed">
-          엔드포인트, 인증 조건, 요청 스키마, 응답 예시를 확인하고 테스터에 바로 적용합니다.
+          엔드포인트별 요청 헤더, 쿼리, 본문, 응답 스키마와 예시를 펼쳐서 확인합니다.
         </p>
       </div>
 
-      {endpoints.map((endpoint) => (
-        <div
-          key={`${endpoint.method} ${endpoint.path}`}
-          className="border-line-2 bg-bg-3 rounded-xl border p-4"
-        >
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-primary font-mono text-xs font-semibold">
+      <div className="flex flex-col gap-2">
+        {endpoints.map((endpoint, index) => (
+          <details
+            key={`${endpoint.method} ${endpoint.path}`}
+            className="border-line-2 bg-bg-3 border"
+            open={index === 0}
+          >
+            <summary className="hover:bg-bg-2 cursor-pointer px-4 py-3 transition-colors">
+              <div className="inline-flex min-w-0 flex-wrap items-center gap-2 align-middle">
+                <span
+                  className={`border px-1.5 py-0.5 font-mono text-[11px] font-semibold ${METHOD_TONE[endpoint.method]}`}
+                >
                   {endpoint.method}
                 </span>
                 <code className="text-text-1 font-mono text-xs break-all">
                   {apiBase}
                   {endpoint.path}
                 </code>
+                {endpoint.auth && <span className="text-text-3 text-xs">인증 필요</span>}
               </div>
               <p className="text-text-3 mt-1 text-xs">{endpoint.desc}</p>
+            </summary>
+
+            <div className="border-line-2 flex flex-col gap-3 border-t p-4">
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => onSelectEndpoint(endpoint)}
+                  className="border-line-2 hover:bg-bg-2 border px-3 py-1.5 text-xs transition-colors"
+                >
+                  요청에 적용
+                </button>
+              </div>
+
+              <DocsSection title="요청 헤더" defaultOpen>
+                <HeaderDoc endpoint={endpoint} />
+              </DocsSection>
+
+              <DocsSection title="쿼리 파라미터" defaultOpen={!!endpoint.query?.length}>
+                {endpoint.query?.length ? (
+                  <SchemaFieldList title="쿼리 파라미터" fields={endpoint.query} />
+                ) : (
+                  <EmptyDoc label="쿼리 파라미터" />
+                )}
+              </DocsSection>
+
+              <DocsSection title="요청 본문" defaultOpen={!!endpoint.body?.length}>
+                {endpoint.body?.length ? (
+                  <SchemaFieldList title="요청 본문" fields={endpoint.body} />
+                ) : (
+                  <EmptyDoc label="요청 본문" />
+                )}
+              </DocsSection>
+
+              <DocsSection title="응답 스키마" defaultOpen={!!endpoint.response?.length}>
+                {endpoint.response?.length ? (
+                  <SchemaFieldList title="응답 스키마" fields={endpoint.response} />
+                ) : (
+                  <EmptyDoc label="응답 스키마" />
+                )}
+              </DocsSection>
+
+              <DocsSection title="응답 예시" defaultOpen={endpoint.responseExample !== undefined}>
+                {endpoint.responseExample !== undefined ? (
+                  <pre className="border-line-2 bg-bg-1 text-text-2 max-h-72 overflow-auto border p-3 font-mono text-xs">
+                    {JSON.stringify(endpoint.responseExample, null, 2)}
+                  </pre>
+                ) : (
+                  <EmptyDoc label="응답 예시" />
+                )}
+              </DocsSection>
             </div>
-            <button
-              type="button"
-              onClick={() => onSelectEndpoint(endpoint)}
-              className="border-line-2 hover:bg-bg-2 rounded-button border px-3 py-1.5 text-xs transition-colors"
-            >
-              요청에 적용
-            </button>
-          </div>
-
-          <div className="mt-3 text-xs">
-            <span className="text-text-3 font-medium">인증</span>
-            <p className="text-text-2 mt-1">{endpoint.auth ? 'Bearer 토큰 필요' : '불필요'}</p>
-          </div>
-
-          <SchemaFieldList title="쿼리 파라미터" fields={endpoint.query} />
-          <SchemaFieldList title="요청 본문" fields={endpoint.body} />
-          <SchemaFieldList title="응답 스키마" fields={endpoint.response} />
-
-          {endpoint.responseExample !== undefined && (
-            <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-48 overflow-auto rounded-lg border p-3 font-mono text-xs">
-              {JSON.stringify(endpoint.responseExample, null, 2)}
-            </pre>
-          )}
-        </div>
-      ))}
+          </details>
+        ))}
+      </div>
     </div>
   );
 }
@@ -348,8 +439,11 @@ export const ApiTesterExercise = ({
   slug: string;
   endpoints: ApiEndpoint[];
 }) => {
-  const [method, setMethod] = useState<Method>('GET');
-  const [path, setPath] = useState('/products?page=1&limit=5');
+  const [method, setMethod] = useState<Method>(endpoints[0]?.method ?? 'GET');
+  const [path, setPath] = useState(endpoints[0]?.path ?? '/products?page=1&limit=5');
+  const [selectedEndpointKey, setSelectedEndpointKey] = useState(
+    endpoints[0] ? endpointKey(endpoints[0]) : ''
+  );
   const [token, setToken] = useState('');
   const [customHeaders, setCustomHeaders] = useState('');
   const [body, setBody] = useState('');
@@ -361,7 +455,9 @@ export const ApiTesterExercise = ({
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
   const [attempts, setAttempts] = useState<ApiAttemptForGrade[]>([]);
-  const [activeTab, setActiveTab] = useState<'tester' | 'docs'>('tester');
+  const [activePanel, setActivePanel] = useState<'test' | 'docs' | 'script'>('test');
+  const [resultH, setResultH] = useState(288);
+  const dragRef = useRef<{ startY: number; startH: number } | null>(null);
 
   const updateAssertion = (id: number, patch: Partial<Assertion>) =>
     setAssertions((as) => as.map((a) => (a.id === id ? { ...a, ...patch } : a)));
@@ -378,6 +474,7 @@ export const ApiTesterExercise = ({
   const removeAssertion = (id: number) => setAssertions((as) => as.filter((a) => a.id !== id));
 
   const applyEndpoint = (endpoint: ApiEndpoint) => {
+    setSelectedEndpointKey(endpointKey(endpoint));
     setMethod(endpoint.method);
     setPath(endpoint.path);
     if (endpoint.body?.length) {
@@ -391,7 +488,6 @@ export const ApiTesterExercise = ({
         )
       );
     }
-    setActiveTab('tester');
   };
 
   const run = async () => {
@@ -505,54 +601,117 @@ export const ApiTesterExercise = ({
     }
   };
 
+  const onResizeDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    dragRef.current = { startY: e.clientY, startH: resultH };
+    e.currentTarget.setPointerCapture(e.pointerId);
+  };
+  const onResizeMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!dragRef.current) return;
+    const next = dragRef.current.startH + (dragRef.current.startY - e.clientY);
+    setResultH(Math.min(Math.max(next, 120), 520));
+  };
+  const onResizeUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragRef.current = null;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      // 포인터 캡처가 없으면 무시
+    }
+  };
   const fieldClass =
-    'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary border px-3 text-sm transition-colors outline-none';
+    'border-line-3 bg-bg-3 text-text-1 placeholder:text-text-3 focus:border-primary border px-3 text-sm transition-colors outline-none';
   const passCount =
     (result?.checks.filter((c) => c.pass).length ?? 0) +
     (result?.scriptResults.filter((r) => r.pass).length ?? 0);
   const total = (result?.checks.length ?? 0) + (result?.scriptResults.length ?? 0);
 
   return (
-    <section className="border-line-2 bg-bg-2 rounded-2xl border p-6">
-      <h2 className="text-base font-semibold">API 테스터 자동 채점</h2>
-      <p className="text-text-2 mt-2 text-sm leading-relaxed">
-        요청을 구성하고, 구조화된 단언이나 포스트맨 스타일{' '}
-        <code className="font-mono">pm.test</code> 스크립트로 응답을 검증해 채점합니다.
-      </p>
-
-      {!!endpoints.length && (
-        <div className="border-line-2 bg-bg-3 mt-5 inline-flex rounded-lg border p-1">
-          {(['tester', 'docs'] as const).map((tab) => (
+    <section className="border-line-2 bg-bg-2 flex h-full min-h-0 flex-col overflow-hidden border-0 lg:border-l">
+      <div className="border-line-2 flex shrink-0 flex-wrap items-center gap-3 border-b px-4 py-2">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div className="bg-bg-3 border-line-2 flex size-8 shrink-0 items-center justify-center border">
+            <Send className="text-primary size-4" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="text-text-1 text-sm font-semibold">API 테스트 워크벤치</h2>
+            <div className="text-text-3 mt-0.5 flex flex-wrap items-center gap-2 text-xs">
+              <span>{endpoints.length}개 엔드포인트</span>
+              <span>·</span>
+              <span>{attempts.length}회 실행</span>
+            </div>
+          </div>
+        </div>
+        <div className="border-line-2 bg-bg-3 flex border text-sm">
+          {(
+            [
+              ['test', 'API 테스트'],
+              ['docs', '문서'],
+              ['script', '스크립트 작성'],
+            ] as const
+          ).map(([key, label]) => (
             <button
-              key={tab}
+              key={key}
               type="button"
-              onClick={() => setActiveTab(tab)}
-              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
-                activeTab === tab ? 'bg-primary text-white' : 'text-text-2 hover:text-text-1'
+              onClick={() => setActivePanel(key)}
+              className={`border-line-2 border-r px-3 py-1.5 text-xs transition-colors last:border-r-0 ${
+                activePanel === key ? 'bg-bg-1 text-text-1' : 'text-text-3 hover:text-text-1'
               }`}
             >
-              {tab === 'tester' ? '테스터' : 'API 문서'}
+              {label}
             </button>
           ))}
         </div>
-      )}
+        <button
+          data-testid="api-run"
+          type="button"
+          onClick={run}
+          disabled={running}
+          className="bg-primary hover:bg-primary/90 active:bg-primary/80 inline-flex h-9 items-center justify-center gap-2 px-4 text-sm font-medium text-white transition-colors disabled:opacity-60"
+        >
+          <Play className="size-4" aria-hidden="true" />
+          {running ? '실행 중' : '실행'}
+        </button>
+      </div>
 
-      {activeTab === 'docs' && !!endpoints.length && (
-        <ApiDocsPanel apiBase={apiBase} endpoints={endpoints} onSelectEndpoint={applyEndpoint} />
-      )}
+      <div className="min-h-0 flex-1 overflow-auto">
+        {activePanel === 'test' && (
+          <div className="p-4 sm:p-5">
+            {!!endpoints.length && (
+              <div className="border-line-2 mb-4 flex gap-2 overflow-x-auto border-b pb-3">
+                {endpoints.map((endpoint) => {
+                  const isActive = endpointKey(endpoint) === selectedEndpointKey;
+                  return (
+                    <button
+                      key={endpointKey(endpoint)}
+                      type="button"
+                      onClick={() => applyEndpoint(endpoint)}
+                      className={`border-line-2 shrink-0 border px-3 py-2 text-left transition-colors ${
+                        isActive ? 'bg-bg-1' : 'bg-bg-3 hover:bg-bg-1'
+                      }`}
+                    >
+                      <span
+                        className={`inline-flex border px-1.5 py-0.5 font-mono text-[11px] font-semibold ${METHOD_TONE[endpoint.method]}`}
+                      >
+                        {endpoint.method}
+                      </span>
+                      <code className="text-text-1 mt-1 block max-w-52 truncate font-mono text-xs">
+                        {endpoint.path}
+                      </code>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
 
-      {activeTab === 'tester' && (
-        <>
-          {/* 요청 */}
-          <div className="mt-5 flex flex-col gap-3">
-            <div className="flex gap-2">
+            <div className="grid gap-2 sm:grid-cols-[7rem_minmax(0,1fr)_auto]">
               <select
                 data-testid="api-method"
                 value={method}
                 onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                   setMethod(e.target.value as Method)
                 }
-                className={`h-button-md w-28 ${fieldClass}`}
+                className={`h-button-md ${fieldClass}`}
               >
                 {METHODS.map((m) => (
                   <option key={m} value={m}>
@@ -560,86 +719,147 @@ export const ApiTesterExercise = ({
                   </option>
                 ))}
               </select>
-              <span className="text-text-3 h-button-md flex items-center font-mono text-xs">
-                {apiBase}
-              </span>
-              <input
-                data-testid="api-path"
-                value={path}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPath(e.target.value)}
-                placeholder="/products?page=1&limit=5"
-                className={`h-button-md flex-1 font-mono ${fieldClass}`}
-              />
+              <div className="border-line-3 bg-bg-3 focus-within:border-primary grid min-w-0 grid-cols-[auto_minmax(0,1fr)] items-center border transition-colors">
+                <span className="text-text-3 border-line-2 h-full border-r px-3 py-2.5 font-mono text-xs">
+                  {apiBase}
+                </span>
+                <input
+                  data-testid="api-path"
+                  value={path}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPath(e.target.value)}
+                  placeholder="/products?page=1&limit=5"
+                  className="text-text-1 placeholder:text-text-3 min-w-0 bg-transparent px-3 py-2.5 font-mono text-sm outline-none"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={run}
+                disabled={running}
+                className="border-line-2 bg-bg-3 hover:bg-bg-1 border px-4 text-sm font-medium transition-colors disabled:opacity-60"
+              >
+                Send
+              </button>
             </div>
 
-            <input
-              data-testid="api-token"
-              value={token}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
-              placeholder="Bearer 토큰 (보호된 요청에만, 예: qaground-demo-token)"
-              className={`h-button-md ${fieldClass}`}
-            />
-            <textarea
-              data-testid="api-headers"
-              value={customHeaders}
-              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
-                setCustomHeaders(e.target.value)
-              }
-              rows={2}
-              placeholder={'추가 헤더 (선택)\nx-qaground-signature: test-signature'}
-              className={`py-2 font-mono ${fieldClass}`}
-            />
-            {method !== 'GET' && (
-              <textarea
-                data-testid="api-body"
-                value={body}
-                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
-                rows={3}
-                placeholder={'요청 본문(JSON)\n{ "name": "테스트 상품", "price": 1000 }'}
-                className={`py-2 font-mono ${fieldClass}`}
-              />
+            {error && (
+              <p className="text-system-red mt-3 text-sm" role="alert">
+                {error}
+              </p>
             )}
-          </div>
 
-          {/* 단언 */}
-          <div className="mt-5">
-            <span className="text-text-2 text-sm font-medium">검증(단언)</span>
-            <div className="mt-2 flex flex-col gap-2">
-              {assertions.map((a) => (
-                <div key={a.id} className="flex items-center gap-2">
-                  <select
-                    value={a.kind}
-                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                      updateAssertion(a.id, { kind: e.target.value as AssertKind })
-                    }
-                    className={`h-9 w-28 ${fieldClass}`}
+            <div className="mt-5 grid gap-4 lg:grid-cols-2">
+              <label className="flex min-w-0 flex-col gap-2">
+                <span className="text-text-2 text-sm font-medium">토큰</span>
+                <input
+                  data-testid="api-token"
+                  value={token}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
+                  placeholder="qaground-demo-token"
+                  className={`h-button-md ${fieldClass}`}
+                />
+              </label>
+              <label className="flex min-w-0 flex-col gap-2">
+                <span className="text-text-2 text-sm font-medium">추가 헤더</span>
+                <input
+                  data-testid="api-headers"
+                  value={customHeaders}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setCustomHeaders(e.target.value)
+                  }
+                  placeholder="x-qaground-signature: test-signature"
+                  className={`h-button-md font-mono ${fieldClass}`}
+                />
+              </label>
+            </div>
+
+            {method !== 'GET' && (
+              <label className="mt-4 flex min-w-0 flex-col gap-2">
+                <span className="text-text-2 text-sm font-medium">본문</span>
+                <textarea
+                  data-testid="api-body"
+                  value={body}
+                  onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
+                  rows={5}
+                  placeholder={'{ "name": "테스트 상품", "price": 1000 }'}
+                  className={`resize-none py-2 font-mono ${fieldClass}`}
+                />
+              </label>
+            )}
+
+            <div className="border-line-2 mt-6 border-t pt-5">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <span className="text-text-1 text-sm font-semibold">검증 조건</span>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => addAssertion()}
+                    className="border-line-2 bg-bg-3 hover:bg-bg-1 inline-flex items-center gap-1 border px-2.5 py-1.5 text-xs transition-colors"
                   >
-                    <option value="status">상태 코드</option>
-                    <option value="json">JSON 값</option>
-                    <option value="exists">필드 존재</option>
-                    <option value="type">타입</option>
-                    <option value="arrayLength">배열 길이</option>
-                  </select>
-                  {a.kind !== 'status' && (
-                    <input
-                      value={a.path}
-                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                        updateAssertion(a.id, { path: e.target.value })
+                    <Plus className="size-3.5" aria-hidden="true" /> JSON
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => addAssertion('exists')}
+                    className="border-line-2 bg-bg-3 hover:bg-bg-1 inline-flex items-center gap-1 border px-2.5 py-1.5 text-xs transition-colors"
+                  >
+                    <Plus className="size-3.5" aria-hidden="true" /> 존재
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => addAssertion('type')}
+                    className="border-line-2 bg-bg-3 hover:bg-bg-1 inline-flex items-center gap-1 border px-2.5 py-1.5 text-xs transition-colors"
+                  >
+                    <Plus className="size-3.5" aria-hidden="true" /> 타입
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => addAssertion('arrayLength')}
+                    className="border-line-2 bg-bg-3 hover:bg-bg-1 inline-flex items-center gap-1 border px-2.5 py-1.5 text-xs transition-colors"
+                  >
+                    <Plus className="size-3.5" aria-hidden="true" /> 길이
+                  </button>
+                </div>
+              </div>
+
+              <div className="mt-3 flex flex-col gap-2">
+                {assertions.map((a) => (
+                  <div
+                    key={a.id}
+                    className="border-line-2 bg-bg-3 grid gap-2 border p-2 sm:grid-cols-[8rem_minmax(0,1fr)_auto_auto] sm:items-center"
+                  >
+                    <select
+                      value={a.kind}
+                      onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                        updateAssertion(a.id, { kind: e.target.value as AssertKind })
                       }
-                      placeholder="경로 (예: total, data.0.name)"
-                      className={`h-9 flex-1 font-mono ${fieldClass}`}
-                    />
-                  )}
-                  {a.kind !== 'exists' && (
-                    <>
-                      <span className="text-text-3 text-sm">==</span>
-                      {a.kind === 'type' ? (
+                      className={`h-9 ${fieldClass}`}
+                    >
+                      <option value="status">상태 코드</option>
+                      <option value="json">JSON 값</option>
+                      <option value="exists">필드 존재</option>
+                      <option value="type">타입</option>
+                      <option value="arrayLength">배열 길이</option>
+                    </select>
+                    {a.kind !== 'status' ? (
+                      <input
+                        value={a.path}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          updateAssertion(a.id, { path: e.target.value })
+                        }
+                        placeholder="total, data.0.name"
+                        className={`h-9 min-w-0 font-mono ${fieldClass}`}
+                      />
+                    ) : (
+                      <div className="hidden sm:block" />
+                    )}
+                    {a.kind !== 'exists' &&
+                      (a.kind === 'type' ? (
                         <select
                           value={a.expected}
                           onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
                             updateAssertion(a.id, { expected: e.target.value })
                           }
-                          className={`h-9 w-28 font-mono ${fieldClass}`}
+                          className={`h-9 w-full font-mono sm:w-28 ${fieldClass}`}
                         >
                           {SCHEMA_TYPES.map((type) => (
                             <option key={type} value={type}>
@@ -654,66 +874,43 @@ export const ApiTesterExercise = ({
                             updateAssertion(a.id, { expected: e.target.value })
                           }
                           placeholder={a.kind === 'arrayLength' ? '길이' : '기대값'}
-                          className={`h-9 w-28 font-mono ${fieldClass}`}
+                          className={`h-9 w-full font-mono sm:w-28 ${fieldClass}`}
                         />
-                      )}
-                    </>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => removeAssertion(a.id)}
-                    className="text-text-3 hover:text-system-red px-1 text-sm transition-colors"
-                    aria-label="단언 삭제"
-                  >
-                    ×
-                  </button>
-                </div>
-              ))}
+                      ))}
+                    <button
+                      type="button"
+                      onClick={() => removeAssertion(a.id)}
+                      className="text-text-3 hover:text-system-red flex size-9 items-center justify-center transition-colors"
+                      aria-label="단언 삭제"
+                      title="단언 삭제"
+                    >
+                      <Trash2 className="size-4" aria-hidden="true" />
+                    </button>
+                  </div>
+                ))}
+              </div>
             </div>
-            <button
-              type="button"
-              onClick={() => addAssertion()}
-              className="text-text-2 hover:text-text-1 mt-2 text-sm transition-colors"
-            >
-              + JSON 값 검증 추가
-            </button>
-            <button
-              type="button"
-              onClick={() => addAssertion('exists')}
-              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
-            >
-              + 필드 존재
-            </button>
-            <button
-              type="button"
-              onClick={() => addAssertion('type')}
-              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
-            >
-              + 타입
-            </button>
-            <button
-              type="button"
-              onClick={() => addAssertion('arrayLength')}
-              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
-            >
-              + 배열 길이
-            </button>
           </div>
+        )}
 
-          {/* 테스트 스크립트 (Postman 스타일) */}
-          <div className="mt-6">
-            <span className="text-text-2 text-sm font-medium">
-              테스트 스크립트 (Postman 스타일, 선택)
-            </span>
-            <p className="text-text-3 mt-1 text-xs leading-relaxed">
-              <code className="font-mono">pm.response</code>,{' '}
-              <code className="font-mono">pm.expect</code>,{' '}
-              <code className="font-mono">pm.test</code> 로 응답을 검증합니다. 비워 두면 단언만
-              채점합니다.
-            </p>
-            <div className="border-line-2 mt-2 overflow-hidden rounded-xl border">
+        {activePanel === 'docs' && (
+          <div className="p-4 sm:p-5">
+            <ApiDocsPanel
+              apiBase={apiBase}
+              endpoints={endpoints}
+              onSelectEndpoint={applyEndpoint}
+            />
+          </div>
+        )}
+
+        {activePanel === 'script' && (
+          <div className="flex h-full min-h-[420px] flex-col">
+            <div className="border-line-2 bg-bg-3 border-b px-4 py-2 text-sm font-semibold">
+              테스트 스크립트
+            </div>
+            <div className="min-h-0 flex-1">
               <MonacoEditor
-                height="180px"
+                height="100%"
                 defaultLanguage="javascript"
                 theme="vs-dark"
                 value={script}
@@ -724,119 +921,83 @@ export const ApiTesterExercise = ({
                   tabSize: 2,
                   scrollBeyondLastLine: false,
                   automaticLayout: true,
-                  lineNumbers: 'off',
                   padding: { top: 10, bottom: 10 },
+                  fixedOverflowWidgets: true,
                 }}
               />
             </div>
           </div>
+        )}
+      </div>
 
-          <button
-            data-testid="api-run"
-            type="button"
-            onClick={run}
-            disabled={running}
-            className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:opacity-60"
-          >
-            {running ? '실행 중...' : '실행하고 채점'}
-          </button>
-
-          {error && (
-            <p className="text-system-red mt-4 text-sm" role="alert">
-              {error}
-            </p>
-          )}
-
+      <div
+        role="separator"
+        aria-orientation="horizontal"
+        aria-label="API 결과 높이 조절"
+        onPointerDown={onResizeDown}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeUp}
+        className="border-line-2 bg-bg-2 hover:bg-primary/20 group flex h-2 shrink-0 cursor-row-resize touch-none items-center justify-center border-t transition-colors"
+      >
+        <span
+          aria-hidden
+          className="bg-line-3 group-hover:bg-primary h-0.5 w-8 transition-colors"
+        />
+      </div>
+      <div
+        data-testid="api-result"
+        style={{ height: resultH }}
+        className="flex shrink-0 flex-col overflow-hidden bg-[#0d1117]"
+      >
+        <div className="flex shrink-0 items-center gap-2 border-b border-white/10 px-4 py-2">
+          <span className="font-mono text-xs text-[#8b949e]">api result</span>
+          {result && <span className="font-mono text-xs text-[#c9d1d9]">HTTP {result.status}</span>}
           {result && (
-            <div data-testid="api-result" className="border-line-2 mt-6 border-t pt-6">
-              <div className="flex items-center gap-2">
-                <span className="text-text-2 text-sm">응답 상태</span>
-                <span className="text-text-1 font-mono text-sm font-semibold">{result.status}</span>
-                <span
-                  className={`ml-auto text-sm font-semibold ${passCount === total ? 'text-primary' : 'text-system-red'}`}
-                >
-                  {passCount}/{total} 통과
-                </span>
-              </div>
-
-              <div className="border-line-2 bg-bg-3 mt-4 rounded-xl border p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <span className="text-text-1 text-sm font-semibold">숨김 채점</span>
-                  <span
-                    className={`font-mono text-sm font-semibold ${
-                      result.hiddenGrade.score === result.hiddenGrade.maxScore
-                        ? 'text-primary'
-                        : 'text-text-1'
-                    }`}
-                  >
-                    {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}점
-                  </span>
-                </div>
-                <p className="text-text-3 mt-1 text-xs">
-                  숨김 케이스 {result.hiddenGrade.passed}/{result.hiddenGrade.total} 통과
-                </p>
-                <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
-                  {result.hiddenGrade.cases.map((item, index) => (
-                    <span
-                      key={item.id}
-                      className={`border-line-2 rounded-lg border px-2 py-1 text-center text-xs font-medium ${
-                        item.pass ? 'text-primary' : 'text-text-3'
-                      }`}
-                    >
-                      #{index + 1} {item.pass ? '통과' : '실패'}
-                    </span>
-                  ))}
-                </div>
-              </div>
-
-              {result.checks.length > 0 && (
-                <ul className="mt-3 flex flex-col gap-2">
-                  {result.checks.map((c, i) => (
-                    <li
-                      key={i}
-                      className="border-line-2 bg-bg-3 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
-                    >
-                      <span className={c.pass ? 'text-primary' : 'text-system-red'}>
-                        {c.pass ? '통과' : '실패'}
-                      </span>
-                      <span className="text-text-1 font-mono text-xs">{c.label}</span>
-                      <span className="text-text-3 ml-auto font-mono text-xs">
-                        실제: {c.actual}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              {result.scriptResults.length > 0 && (
-                <ul className="mt-3 flex flex-col gap-2">
-                  {result.scriptResults.map((r, i) => (
-                    <li
-                      key={i}
-                      className="border-line-2 bg-bg-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-sm"
-                    >
-                      <span className={r.pass ? 'text-primary' : 'text-system-red'}>
-                        {r.pass ? '통과' : '실패'}
-                      </span>
-                      <span className="flex flex-col gap-0.5">
-                        <span className="text-text-1 text-xs">{r.name}</span>
-                        {r.error && (
-                          <span className="text-system-red font-mono text-xs">{r.error}</span>
-                        )}
-                      </span>
-                      <span className="text-text-3 ml-auto font-mono text-xs">pm.test</span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-
-              <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-72 overflow-auto rounded-xl border p-4 font-mono text-xs">
-                {result.bodyText}
-              </pre>
-            </div>
+            <span
+              className={`ml-auto font-mono text-xs ${passCount === total ? 'text-[#3fb950]' : 'text-[#f85149]'}`}
+            >
+              {passCount}/{total} passed
+            </span>
           )}
-        </>
-      )}
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto px-4 py-3 font-mono text-xs leading-relaxed text-[#c9d1d9]">
+          {!result ? (
+            <span className="text-[#8b949e]">실행하면 응답과 채점 결과가 여기에 표시됩니다.</span>
+          ) : (
+            <>
+              <div className="text-[#8b949e]">
+                hidden grade {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}
+              </div>
+              <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-5">
+                {result.hiddenGrade.cases.map((item, index) => (
+                  <span key={item.id} className={item.pass ? 'text-[#3fb950]' : 'text-[#8b949e]'}>
+                    #{index + 1} {item.pass ? 'pass' : 'fail'}
+                  </span>
+                ))}
+              </div>
+              {(result.checks.length > 0 || result.scriptResults.length > 0) && (
+                <div className="mt-3 space-y-1">
+                  {result.checks.map((c, i) => (
+                    <div key={i} className={c.pass ? 'text-[#3fb950]' : 'text-[#f85149]'}>
+                      {c.pass ? '✓' : '✗'} {c.label} · actual: {c.actual}
+                    </div>
+                  ))}
+                  {result.scriptResults.map((r, i) => (
+                    <div
+                      key={`script-${i}`}
+                      className={r.pass ? 'text-[#3fb950]' : 'text-[#f85149]'}
+                    >
+                      {r.pass ? '✓' : '✗'} {r.name}
+                      {r.error ? ` · ${r.error}` : ''}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <pre className="mt-4 whitespace-pre-wrap text-[#c9d1d9]">{result.bodyText}</pre>
+            </>
+          )}
+        </div>
+      </div>
     </section>
   );
 };

--- a/apps/qaground/src/view/challenges/api-tester-exercise.tsx
+++ b/apps/qaground/src/view/challenges/api-tester-exercise.tsx
@@ -8,10 +8,10 @@ import { recordSubmission } from '@/shared/analytics/record-submission';
 import { track } from '@/shared/analytics/track';
 import {
   type ApiAttemptForGrade,
-  type ApiTargetForGrade,
   type HiddenGradeResult,
   gradeApiAttempts,
 } from '@/shared/challenges/api-hidden-grader';
+import type { ApiEndpoint, ApiSchemaField, ApiSchemaType } from '@/shared/challenges/registry';
 
 const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
   ssr: false,
@@ -23,7 +23,7 @@ const MonacoEditor = dynamic(() => import('@monaco-editor/react'), {
 });
 
 type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
-type AssertKind = 'status' | 'json';
+type AssertKind = 'status' | 'json' | 'exists' | 'type' | 'arrayLength';
 interface Assertion {
   id: number;
   kind: AssertKind;
@@ -49,6 +49,7 @@ interface RunResult {
 }
 
 const METHODS: Method[] = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'];
+const SCHEMA_TYPES: ApiSchemaType[] = ['string', 'number', 'boolean', 'array', 'object', 'null'];
 
 /** 점(.) 경로로 JSON 값 탐색. eval 없이 구조적 접근만 한다. (`data.0.id` 등) */
 function getByPath(obj: unknown, path: string): unknown {
@@ -57,6 +58,14 @@ function getByPath(obj: unknown, path: string): unknown {
     if (acc == null || typeof acc !== 'object') return undefined;
     return (acc as Record<string, unknown>)[key];
   }, obj);
+}
+
+function getJsonType(value: unknown): ApiSchemaType | 'undefined' {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  if (typeof value === 'object') return 'object';
+  return typeof value as ApiSchemaType;
 }
 
 /** 포스트맨 pm.expect 의 chai 유사 단언 (필요한 부분만). 실패 시 throw. */
@@ -217,6 +226,111 @@ function redactHeaders(headers: Record<string, string>): Record<string, string> 
     ])
   );
 }
+
+function defaultValueForSchemaType(type: ApiSchemaType): unknown {
+  if (type === 'number') return 0;
+  if (type === 'boolean') return false;
+  if (type === 'array') return [];
+  if (type === 'object') return {};
+  if (type === 'null') return null;
+  return '';
+}
+
+function SchemaFieldList({ title, fields }: { title: string; fields?: ApiSchemaField[] }) {
+  if (!fields?.length) return null;
+
+  return (
+    <div className="mt-3">
+      <span className="text-text-3 text-xs font-medium">{title}</span>
+      <div className="border-line-2 mt-1 overflow-hidden rounded-lg border">
+        <div className="border-line-2 bg-bg-2 text-text-3 hidden grid-cols-[minmax(7rem,1.2fr)_5rem_4rem_minmax(0,1.5fr)] gap-2 border-b px-3 py-2 text-[11px] font-medium sm:grid">
+          <span>필드</span>
+          <span>타입</span>
+          <span>필수</span>
+          <span>설명</span>
+        </div>
+        {fields.map((field) => (
+          <div
+            key={`${field.path}-${field.type}`}
+            className="border-line-2 grid gap-2 border-b px-3 py-2 text-xs last:border-b-0 sm:grid-cols-[minmax(7rem,1.2fr)_5rem_4rem_minmax(0,1.5fr)] sm:items-center"
+          >
+            <code className="text-text-1 min-w-0 font-mono break-all">{field.path}</code>
+            <span className="text-text-2 font-mono">{field.type}</span>
+            <span className={field.required ? 'text-primary' : 'text-text-3'}>
+              {field.required ? '필수' : '선택'}
+            </span>
+            <span className="text-text-3 min-w-0">{field.desc ?? '-'}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ApiDocsPanel({
+  apiBase,
+  endpoints,
+  onSelectEndpoint,
+}: {
+  apiBase: string;
+  endpoints: ApiEndpoint[];
+  onSelectEndpoint: (endpoint: ApiEndpoint) => void;
+}) {
+  return (
+    <div className="mt-5 flex flex-col gap-4">
+      <div>
+        <span className="text-text-2 text-sm font-medium">API 문서</span>
+        <p className="text-text-3 mt-1 text-xs leading-relaxed">
+          엔드포인트, 인증 조건, 요청 스키마, 응답 예시를 확인하고 테스터에 바로 적용합니다.
+        </p>
+      </div>
+
+      {endpoints.map((endpoint) => (
+        <div
+          key={`${endpoint.method} ${endpoint.path}`}
+          className="border-line-2 bg-bg-3 rounded-xl border p-4"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-primary font-mono text-xs font-semibold">
+                  {endpoint.method}
+                </span>
+                <code className="text-text-1 font-mono text-xs break-all">
+                  {apiBase}
+                  {endpoint.path}
+                </code>
+              </div>
+              <p className="text-text-3 mt-1 text-xs">{endpoint.desc}</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => onSelectEndpoint(endpoint)}
+              className="border-line-2 hover:bg-bg-2 rounded-button border px-3 py-1.5 text-xs transition-colors"
+            >
+              요청에 적용
+            </button>
+          </div>
+
+          <div className="mt-3 text-xs">
+            <span className="text-text-3 font-medium">인증</span>
+            <p className="text-text-2 mt-1">{endpoint.auth ? 'Bearer 토큰 필요' : '불필요'}</p>
+          </div>
+
+          <SchemaFieldList title="쿼리 파라미터" fields={endpoint.query} />
+          <SchemaFieldList title="요청 본문" fields={endpoint.body} />
+          <SchemaFieldList title="응답 스키마" fields={endpoint.response} />
+
+          {endpoint.responseExample !== undefined && (
+            <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-48 overflow-auto rounded-lg border p-3 font-mono text-xs">
+              {JSON.stringify(endpoint.responseExample, null, 2)}
+            </pre>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
 let nextId = 2;
 
 /**
@@ -232,7 +346,7 @@ export const ApiTesterExercise = ({
 }: {
   apiBase: string;
   slug: string;
-  endpoints: ApiTargetForGrade[];
+  endpoints: ApiEndpoint[];
 }) => {
   const [method, setMethod] = useState<Method>('GET');
   const [path, setPath] = useState('/products?page=1&limit=5');
@@ -247,12 +361,38 @@ export const ApiTesterExercise = ({
   const [error, setError] = useState('');
   const [result, setResult] = useState<RunResult | null>(null);
   const [attempts, setAttempts] = useState<ApiAttemptForGrade[]>([]);
+  const [activeTab, setActiveTab] = useState<'tester' | 'docs'>('tester');
 
   const updateAssertion = (id: number, patch: Partial<Assertion>) =>
     setAssertions((as) => as.map((a) => (a.id === id ? { ...a, ...patch } : a)));
-  const addAssertion = () =>
-    setAssertions((as) => [...as, { id: nextId++, kind: 'json', path: '', expected: '' }]);
+  const addAssertion = (kind: AssertKind = 'json') =>
+    setAssertions((as) => [
+      ...as,
+      {
+        id: nextId++,
+        kind,
+        path: '',
+        expected: kind === 'type' ? 'string' : kind === 'arrayLength' ? '0' : '',
+      },
+    ]);
   const removeAssertion = (id: number) => setAssertions((as) => as.filter((a) => a.id !== id));
+
+  const applyEndpoint = (endpoint: ApiEndpoint) => {
+    setMethod(endpoint.method);
+    setPath(endpoint.path);
+    if (endpoint.body?.length) {
+      setBody(
+        JSON.stringify(
+          Object.fromEntries(
+            endpoint.body.map((field) => [field.path, defaultValueForSchemaType(field.type)])
+          ),
+          null,
+          2
+        )
+      );
+    }
+    setActiveTab('tester');
+  };
 
   const run = async () => {
     setRunning(true);
@@ -286,8 +426,35 @@ export const ApiTesterExercise = ({
             actual: String(res.status),
           };
         }
+
         const actual = getByPath(json, a.path);
         const actualStr = actual === undefined ? '(없음)' : JSON.stringify(actual);
+        const actualType = getJsonType(actual);
+
+        if (a.kind === 'exists') {
+          return {
+            label: `${a.path || '(경로 없음)'} 필드 존재`,
+            pass: actual !== undefined,
+            actual: actualStr,
+          };
+        }
+
+        if (a.kind === 'type') {
+          return {
+            label: `${a.path || '(경로 없음)'} 타입 == ${a.expected}`,
+            pass: actualType === a.expected.trim(),
+            actual: actualType,
+          };
+        }
+
+        if (a.kind === 'arrayLength') {
+          return {
+            label: `${a.path || '(경로 없음)'} 배열 길이 == ${a.expected}`,
+            pass: Array.isArray(actual) && actual.length === Number(a.expected.trim()),
+            actual: Array.isArray(actual) ? String(actual.length) : actualType,
+          };
+        }
+
         return {
           label: `${a.path || '(경로 없음)'} == ${a.expected}`,
           pass: actual !== undefined && String(actual) === a.expected.trim(),
@@ -347,256 +514,328 @@ export const ApiTesterExercise = ({
 
   return (
     <section className="border-line-2 bg-bg-2 rounded-2xl border p-6">
-      <h2 className="text-base font-semibold">API 테스터 · 자동 채점</h2>
+      <h2 className="text-base font-semibold">API 테스터 자동 채점</h2>
       <p className="text-text-2 mt-2 text-sm leading-relaxed">
         요청을 구성하고, 구조화된 단언이나 포스트맨 스타일{' '}
         <code className="font-mono">pm.test</code> 스크립트로 응답을 검증해 채점합니다.
       </p>
 
-      {/* 요청 */}
-      <div className="mt-5 flex flex-col gap-3">
-        <div className="flex gap-2">
-          <select
-            data-testid="api-method"
-            value={method}
-            onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-              setMethod(e.target.value as Method)
-            }
-            className={`h-button-md w-28 ${fieldClass}`}
-          >
-            {METHODS.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
-          </select>
-          <span className="text-text-3 h-button-md flex items-center font-mono text-xs">
-            {apiBase}
-          </span>
-          <input
-            data-testid="api-path"
-            value={path}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPath(e.target.value)}
-            placeholder="/products?page=1&limit=5"
-            className={`h-button-md flex-1 font-mono ${fieldClass}`}
-          />
-        </div>
-
-        <input
-          data-testid="api-token"
-          value={token}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
-          placeholder="Bearer 토큰 (보호된 요청에만, 예: qaground-demo-token)"
-          className={`h-button-md ${fieldClass}`}
-        />
-
-        <textarea
-          data-testid="api-headers"
-          value={customHeaders}
-          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setCustomHeaders(e.target.value)}
-          rows={2}
-          placeholder={'추가 헤더 (선택)\nx-qaground-signature: test-signature'}
-          className={`py-2 font-mono ${fieldClass}`}
-        />
-
-        {method !== 'GET' && (
-          <textarea
-            data-testid="api-body"
-            value={body}
-            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
-            rows={3}
-            placeholder={'요청 본문(JSON)\n{ "name": "테스트 상품", "price": 1000 }'}
-            className={`py-2 font-mono ${fieldClass}`}
-          />
-        )}
-      </div>
-
-      {/* 단언 */}
-      <div className="mt-5">
-        <span className="text-text-2 text-sm font-medium">검증(단언)</span>
-        <div className="mt-2 flex flex-col gap-2">
-          {assertions.map((a) => (
-            <div key={a.id} className="flex items-center gap-2">
-              <select
-                value={a.kind}
-                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
-                  updateAssertion(a.id, { kind: e.target.value as AssertKind })
-                }
-                className={`h-9 w-28 ${fieldClass}`}
-              >
-                <option value="status">상태 코드</option>
-                <option value="json">JSON 필드</option>
-              </select>
-              {a.kind === 'json' && (
-                <input
-                  value={a.path}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    updateAssertion(a.id, { path: e.target.value })
-                  }
-                  placeholder="경로 (예: total, data.0.name)"
-                  className={`h-9 flex-1 font-mono ${fieldClass}`}
-                />
-              )}
-              <span className="text-text-3 text-sm">==</span>
-              <input
-                value={a.expected}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  updateAssertion(a.id, { expected: e.target.value })
-                }
-                placeholder="기대값"
-                className={`h-9 w-28 font-mono ${fieldClass}`}
-              />
-              <button
-                type="button"
-                onClick={() => removeAssertion(a.id)}
-                className="text-text-3 hover:text-system-red px-1 text-sm transition-colors"
-                aria-label="단언 삭제"
-              >
-                ×
-              </button>
-            </div>
+      {!!endpoints.length && (
+        <div className="border-line-2 bg-bg-3 mt-5 inline-flex rounded-lg border p-1">
+          {(['tester', 'docs'] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={`rounded-md px-3 py-1.5 text-sm transition-colors ${
+                activeTab === tab ? 'bg-primary text-white' : 'text-text-2 hover:text-text-1'
+              }`}
+            >
+              {tab === 'tester' ? '테스터' : 'API 문서'}
+            </button>
           ))}
         </div>
-        <button
-          type="button"
-          onClick={addAssertion}
-          className="text-text-2 hover:text-text-1 mt-2 text-sm transition-colors"
-        >
-          + 단언 추가
-        </button>
-      </div>
-
-      {/* 테스트 스크립트 (Postman 스타일) */}
-      <div className="mt-6">
-        <span className="text-text-2 text-sm font-medium">
-          테스트 스크립트 (Postman 스타일, 선택)
-        </span>
-        <p className="text-text-3 mt-1 text-xs leading-relaxed">
-          <code className="font-mono">pm.response</code>,{' '}
-          <code className="font-mono">pm.expect</code>, <code className="font-mono">pm.test</code>{' '}
-          로 응답을 검증합니다. 비워 두면 단언만 채점합니다.
-        </p>
-        <div className="border-line-2 mt-2 overflow-hidden rounded-xl border">
-          <MonacoEditor
-            height="180px"
-            defaultLanguage="javascript"
-            theme="vs-dark"
-            value={script}
-            onChange={(value) => setScript(value ?? '')}
-            options={{
-              minimap: { enabled: false },
-              fontSize: 13,
-              tabSize: 2,
-              scrollBeyondLastLine: false,
-              automaticLayout: true,
-              lineNumbers: 'off',
-              padding: { top: 10, bottom: 10 },
-            }}
-          />
-        </div>
-      </div>
-
-      <button
-        data-testid="api-run"
-        type="button"
-        onClick={run}
-        disabled={running}
-        className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:opacity-60"
-      >
-        {running ? '실행 중...' : '실행하고 채점'}
-      </button>
-
-      {error && (
-        <p className="text-system-red mt-4 text-sm" role="alert">
-          {error}
-        </p>
       )}
 
-      {result && (
-        <div data-testid="api-result" className="border-line-2 mt-6 border-t pt-6">
-          <div className="flex items-center gap-2">
-            <span className="text-text-2 text-sm">응답 상태</span>
-            <span className="text-text-1 font-mono text-sm font-semibold">{result.status}</span>
-            <span
-              className={`ml-auto text-sm font-semibold ${passCount === total ? 'text-primary' : 'text-system-red'}`}
-            >
-              {passCount}/{total} 통과
-            </span>
-          </div>
+      {activeTab === 'docs' && !!endpoints.length && (
+        <ApiDocsPanel apiBase={apiBase} endpoints={endpoints} onSelectEndpoint={applyEndpoint} />
+      )}
 
-          <div className="border-line-2 bg-bg-3 mt-4 rounded-xl border p-4">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-text-1 text-sm font-semibold">숨김 채점</span>
-              <span
-                className={`font-mono text-sm font-semibold ${
-                  result.hiddenGrade.score === result.hiddenGrade.maxScore
-                    ? 'text-primary'
-                    : 'text-text-1'
-                }`}
+      {activeTab === 'tester' && (
+        <>
+          {/* 요청 */}
+          <div className="mt-5 flex flex-col gap-3">
+            <div className="flex gap-2">
+              <select
+                data-testid="api-method"
+                value={method}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setMethod(e.target.value as Method)
+                }
+                className={`h-button-md w-28 ${fieldClass}`}
               >
-                {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}점
+                {METHODS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+              <span className="text-text-3 h-button-md flex items-center font-mono text-xs">
+                {apiBase}
               </span>
+              <input
+                data-testid="api-path"
+                value={path}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setPath(e.target.value)}
+                placeholder="/products?page=1&limit=5"
+                className={`h-button-md flex-1 font-mono ${fieldClass}`}
+              />
             </div>
-            <p className="text-text-3 mt-1 text-xs">
-              숨김 케이스 {result.hiddenGrade.passed}/{result.hiddenGrade.total} 통과
-            </p>
-            <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
-              {result.hiddenGrade.cases.map((item, index) => (
-                <span
-                  key={item.id}
-                  className={`border-line-2 rounded-lg border px-2 py-1 text-center text-xs font-medium ${
-                    item.pass ? 'text-primary' : 'text-text-3'
-                  }`}
-                >
-                  #{index + 1} {item.pass ? '통과' : '실패'}
-                </span>
+
+            <input
+              data-testid="api-token"
+              value={token}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
+              placeholder="Bearer 토큰 (보호된 요청에만, 예: qaground-demo-token)"
+              className={`h-button-md ${fieldClass}`}
+            />
+            <textarea
+              data-testid="api-headers"
+              value={customHeaders}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setCustomHeaders(e.target.value)
+              }
+              rows={2}
+              placeholder={'추가 헤더 (선택)\nx-qaground-signature: test-signature'}
+              className={`py-2 font-mono ${fieldClass}`}
+            />
+            {method !== 'GET' && (
+              <textarea
+                data-testid="api-body"
+                value={body}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setBody(e.target.value)}
+                rows={3}
+                placeholder={'요청 본문(JSON)\n{ "name": "테스트 상품", "price": 1000 }'}
+                className={`py-2 font-mono ${fieldClass}`}
+              />
+            )}
+          </div>
+
+          {/* 단언 */}
+          <div className="mt-5">
+            <span className="text-text-2 text-sm font-medium">검증(단언)</span>
+            <div className="mt-2 flex flex-col gap-2">
+              {assertions.map((a) => (
+                <div key={a.id} className="flex items-center gap-2">
+                  <select
+                    value={a.kind}
+                    onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                      updateAssertion(a.id, { kind: e.target.value as AssertKind })
+                    }
+                    className={`h-9 w-28 ${fieldClass}`}
+                  >
+                    <option value="status">상태 코드</option>
+                    <option value="json">JSON 값</option>
+                    <option value="exists">필드 존재</option>
+                    <option value="type">타입</option>
+                    <option value="arrayLength">배열 길이</option>
+                  </select>
+                  {a.kind !== 'status' && (
+                    <input
+                      value={a.path}
+                      onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        updateAssertion(a.id, { path: e.target.value })
+                      }
+                      placeholder="경로 (예: total, data.0.name)"
+                      className={`h-9 flex-1 font-mono ${fieldClass}`}
+                    />
+                  )}
+                  {a.kind !== 'exists' && (
+                    <>
+                      <span className="text-text-3 text-sm">==</span>
+                      {a.kind === 'type' ? (
+                        <select
+                          value={a.expected}
+                          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                            updateAssertion(a.id, { expected: e.target.value })
+                          }
+                          className={`h-9 w-28 font-mono ${fieldClass}`}
+                        >
+                          {SCHEMA_TYPES.map((type) => (
+                            <option key={type} value={type}>
+                              {type}
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          value={a.expected}
+                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                            updateAssertion(a.id, { expected: e.target.value })
+                          }
+                          placeholder={a.kind === 'arrayLength' ? '길이' : '기대값'}
+                          className={`h-9 w-28 font-mono ${fieldClass}`}
+                        />
+                      )}
+                    </>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => removeAssertion(a.id)}
+                    className="text-text-3 hover:text-system-red px-1 text-sm transition-colors"
+                    aria-label="단언 삭제"
+                  >
+                    ×
+                  </button>
+                </div>
               ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => addAssertion()}
+              className="text-text-2 hover:text-text-1 mt-2 text-sm transition-colors"
+            >
+              + JSON 값 검증 추가
+            </button>
+            <button
+              type="button"
+              onClick={() => addAssertion('exists')}
+              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
+            >
+              + 필드 존재
+            </button>
+            <button
+              type="button"
+              onClick={() => addAssertion('type')}
+              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
+            >
+              + 타입
+            </button>
+            <button
+              type="button"
+              onClick={() => addAssertion('arrayLength')}
+              className="text-text-2 hover:text-text-1 mt-2 ml-3 text-sm transition-colors"
+            >
+              + 배열 길이
+            </button>
+          </div>
+
+          {/* 테스트 스크립트 (Postman 스타일) */}
+          <div className="mt-6">
+            <span className="text-text-2 text-sm font-medium">
+              테스트 스크립트 (Postman 스타일, 선택)
+            </span>
+            <p className="text-text-3 mt-1 text-xs leading-relaxed">
+              <code className="font-mono">pm.response</code>,{' '}
+              <code className="font-mono">pm.expect</code>,{' '}
+              <code className="font-mono">pm.test</code> 로 응답을 검증합니다. 비워 두면 단언만
+              채점합니다.
+            </p>
+            <div className="border-line-2 mt-2 overflow-hidden rounded-xl border">
+              <MonacoEditor
+                height="180px"
+                defaultLanguage="javascript"
+                theme="vs-dark"
+                value={script}
+                onChange={(value) => setScript(value ?? '')}
+                options={{
+                  minimap: { enabled: false },
+                  fontSize: 13,
+                  tabSize: 2,
+                  scrollBeyondLastLine: false,
+                  automaticLayout: true,
+                  lineNumbers: 'off',
+                  padding: { top: 10, bottom: 10 },
+                }}
+              />
             </div>
           </div>
 
-          {result.checks.length > 0 && (
-            <ul className="mt-3 flex flex-col gap-2">
-              {result.checks.map((c, i) => (
-                <li
-                  key={i}
-                  className="border-line-2 bg-bg-3 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
-                >
-                  <span className={c.pass ? 'text-primary' : 'text-system-red'}>
-                    {c.pass ? '통과' : '실패'}
-                  </span>
-                  <span className="text-text-1 font-mono text-xs">{c.label}</span>
-                  <span className="text-text-3 ml-auto font-mono text-xs">실제: {c.actual}</span>
-                </li>
-              ))}
-            </ul>
+          <button
+            data-testid="api-run"
+            type="button"
+            onClick={run}
+            disabled={running}
+            className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-5 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors disabled:opacity-60"
+          >
+            {running ? '실행 중...' : '실행하고 채점'}
+          </button>
+
+          {error && (
+            <p className="text-system-red mt-4 text-sm" role="alert">
+              {error}
+            </p>
           )}
 
-          {result.scriptResults.length > 0 && (
-            <ul className="mt-3 flex flex-col gap-2">
-              {result.scriptResults.map((r, i) => (
-                <li
-                  key={i}
-                  className="border-line-2 bg-bg-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-sm"
+          {result && (
+            <div data-testid="api-result" className="border-line-2 mt-6 border-t pt-6">
+              <div className="flex items-center gap-2">
+                <span className="text-text-2 text-sm">응답 상태</span>
+                <span className="text-text-1 font-mono text-sm font-semibold">{result.status}</span>
+                <span
+                  className={`ml-auto text-sm font-semibold ${passCount === total ? 'text-primary' : 'text-system-red'}`}
                 >
-                  <span className={r.pass ? 'text-primary' : 'text-system-red'}>
-                    {r.pass ? '통과' : '실패'}
-                  </span>
-                  <span className="flex flex-col gap-0.5">
-                    <span className="text-text-1 text-xs">{r.name}</span>
-                    {r.error && (
-                      <span className="text-system-red font-mono text-xs">{r.error}</span>
-                    )}
-                  </span>
-                  <span className="text-text-3 ml-auto font-mono text-xs">pm.test</span>
-                </li>
-              ))}
-            </ul>
-          )}
+                  {passCount}/{total} 통과
+                </span>
+              </div>
 
-          <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-72 overflow-auto rounded-xl border p-4 font-mono text-xs">
-            {result.bodyText}
-          </pre>
-        </div>
+              <div className="border-line-2 bg-bg-3 mt-4 rounded-xl border p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-text-1 text-sm font-semibold">숨김 채점</span>
+                  <span
+                    className={`font-mono text-sm font-semibold ${
+                      result.hiddenGrade.score === result.hiddenGrade.maxScore
+                        ? 'text-primary'
+                        : 'text-text-1'
+                    }`}
+                  >
+                    {result.hiddenGrade.score}/{result.hiddenGrade.maxScore}점
+                  </span>
+                </div>
+                <p className="text-text-3 mt-1 text-xs">
+                  숨김 케이스 {result.hiddenGrade.passed}/{result.hiddenGrade.total} 통과
+                </p>
+                <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
+                  {result.hiddenGrade.cases.map((item, index) => (
+                    <span
+                      key={item.id}
+                      className={`border-line-2 rounded-lg border px-2 py-1 text-center text-xs font-medium ${
+                        item.pass ? 'text-primary' : 'text-text-3'
+                      }`}
+                    >
+                      #{index + 1} {item.pass ? '통과' : '실패'}
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              {result.checks.length > 0 && (
+                <ul className="mt-3 flex flex-col gap-2">
+                  {result.checks.map((c, i) => (
+                    <li
+                      key={i}
+                      className="border-line-2 bg-bg-3 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm"
+                    >
+                      <span className={c.pass ? 'text-primary' : 'text-system-red'}>
+                        {c.pass ? '통과' : '실패'}
+                      </span>
+                      <span className="text-text-1 font-mono text-xs">{c.label}</span>
+                      <span className="text-text-3 ml-auto font-mono text-xs">
+                        실제: {c.actual}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {result.scriptResults.length > 0 && (
+                <ul className="mt-3 flex flex-col gap-2">
+                  {result.scriptResults.map((r, i) => (
+                    <li
+                      key={i}
+                      className="border-line-2 bg-bg-3 flex items-start gap-2 rounded-lg border px-3 py-2 text-sm"
+                    >
+                      <span className={r.pass ? 'text-primary' : 'text-system-red'}>
+                        {r.pass ? '통과' : '실패'}
+                      </span>
+                      <span className="flex flex-col gap-0.5">
+                        <span className="text-text-1 text-xs">{r.name}</span>
+                        {r.error && (
+                          <span className="text-system-red font-mono text-xs">{r.error}</span>
+                        )}
+                      </span>
+                      <span className="text-text-3 ml-auto font-mono text-xs">pm.test</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <pre className="border-line-2 bg-bg-1 text-text-2 mt-3 max-h-72 overflow-auto rounded-xl border p-4 font-mono text-xs">
+                {result.bodyText}
+              </pre>
+            </div>
+          )}
+        </>
       )}
     </section>
   );

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -33,13 +33,13 @@ function ChallengeMeta({ challenge }: { challenge: Challenge }) {
   return (
     <>
       <div className="mb-3 flex items-center gap-2">
-        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+        <span className="bg-bg-3 text-text-2 px-2.5 py-1 text-xs">
           {TRACK_LABEL[challenge.track]}
         </span>
-        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+        <span className="bg-bg-3 text-text-2 px-2.5 py-1 text-xs">
           {CATEGORY_LABEL[challenge.category]}
         </span>
-        <span className="bg-bg-3 text-text-2 rounded-full px-2.5 py-1 text-xs">
+        <span className="bg-bg-3 text-text-2 px-2.5 py-1 text-xs">
           {DIFFICULTY_LABEL[challenge.difficulty]}
         </span>
         {challenge.tools.map((tool) => (
@@ -75,7 +75,7 @@ function ApiEndpoints({ challenge }: { challenge: Challenge }) {
       <p className="text-text-2 mt-2 text-sm">
         베이스 경로 <code className="text-primary font-mono text-xs">{challenge.apiBase}</code>
       </p>
-      <div className="border-line-2 bg-bg-2 mt-3 overflow-hidden rounded-xl border">
+      <div className="border-line-2 bg-bg-2 mt-3 overflow-hidden border">
         <div className="border-line-2 text-text-3 grid grid-cols-[3.5rem_1fr_2.5rem] gap-3 border-b px-4 py-2.5 text-xs">
           <span>메서드</span>
           <span>경로</span>
@@ -98,7 +98,7 @@ function ApiEndpoints({ challenge }: { challenge: Challenge }) {
         ))}
       </div>
       {challenge.apiNote && (
-        <p className="border-line-2 bg-bg-2 text-text-2 mt-3 rounded-xl border px-4 py-3 text-xs leading-relaxed">
+        <p className="border-line-2 bg-bg-2 text-text-2 mt-3 border px-4 py-3 text-xs leading-relaxed">
           {challenge.apiNote}
         </p>
       )}
@@ -135,14 +135,14 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             ←
           </Link>
           <h1 className="mr-1 text-base font-semibold sm:text-lg">{challenge.title}</h1>
-          <span className="bg-bg-3 text-text-2 rounded-full px-2 py-0.5 text-xs">
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
             {TRACK_LABEL[challenge.track]}
           </span>
-          <span className="bg-bg-3 text-text-2 rounded-full px-2 py-0.5 text-xs">
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
             {CATEGORY_LABEL[challenge.category]}
           </span>
           <span
-            className={`rounded-full px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
+            className={`px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
           >
             {DIFFICULTY_LABEL[challenge.difficulty]}
           </span>
@@ -183,6 +183,57 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
               sandboxSlug={challenge.sandboxSlug!}
               selectors={challenge.selectors!}
               starterSpec={challenge.starterSpec}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // API 트랙: 자동화 코드 작성 화면과 같은 풀높이 2단 레이아웃.
+  if (isApiTester) {
+    return (
+      <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans lg:h-screen lg:overflow-hidden">
+        <PlaygroundHeader containerClassName="max-w-none" />
+        <div className="border-line-2 flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5 border-b px-4 py-2.5 sm:px-6">
+          <Link
+            href="/challenges"
+            aria-label="챌린지 목록"
+            className="text-text-3 hover:text-text-1 text-sm transition-colors"
+          >
+            ←
+          </Link>
+          <h1 className="mr-1 text-base font-semibold sm:text-lg">{challenge.title}</h1>
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
+            {TRACK_LABEL[challenge.track]}
+          </span>
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
+            {CATEGORY_LABEL[challenge.category]}
+          </span>
+          <span
+            className={`px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
+          >
+            {DIFFICULTY_LABEL[challenge.difficulty]}
+          </span>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+          <div className="border-line-2 overflow-y-auto border-b p-5 sm:p-6 lg:w-2/5 lg:max-w-lg lg:border-r lg:border-b-0">
+            <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
+              {challenge.summary}
+            </p>
+            <h2 className="mt-6 text-base font-semibold">요구사항</h2>
+            <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
+              {challenge.requirement.map((r) => (
+                <li key={r}>{r}</li>
+              ))}
+            </ol>
+            <ApiEndpoints challenge={challenge} />
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col">
+            <ApiTesterExercise
+              apiBase={challenge.apiBase!}
+              slug={challenge.slug}
+              endpoints={challenge.endpoints!}
             />
           </div>
         </div>
@@ -240,14 +291,14 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
               ←
             </Link>
             <h1 className="mr-1 text-base font-semibold sm:text-lg">{challenge.title}</h1>
-            <span className="bg-bg-3 text-text-2 rounded-full px-2 py-0.5 text-xs">
+            <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
               {TRACK_LABEL[challenge.track]}
             </span>
-            <span className="bg-bg-3 text-text-2 rounded-full px-2 py-0.5 text-xs">
+            <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
               {CATEGORY_LABEL[challenge.category]}
             </span>
             <span
-              className={`rounded-full px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
+              className={`px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
             >
               {DIFFICULTY_LABEL[challenge.difficulty]}
             </span>
@@ -315,7 +366,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             <Link
               href={`/sandbox/${challenge.sandboxSlug}`}
               target="_blank"
-              className="bg-primary rounded-button h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
+              className="bg-primary h-button-md hover:bg-primary/90 active:bg-primary/80 mt-4 inline-flex items-center justify-center px-5 text-sm font-medium text-white transition-colors"
             >
               연습 대상 열기
             </Link>
@@ -323,7 +374,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
         ) : null}
 
         {!challenge.knownDefects && !challenge.modelTestCases && (
-          <section className="border-line-3 mt-8 rounded-2xl border border-dashed p-6">
+          <section className="border-line-3 mt-8 border border-dashed p-6">
             <h2 className="text-base font-semibold">
               {challenge.track === 'manual' ? '결과 제출' : '자동 채점 제출'}
             </h2>

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -276,61 +276,73 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
     );
   }
 
-  // 매뉴얼 케이스(케이스 작성·버그 찾기): 얇은 메타바 + 좌 문제·요구사항(sticky) / 우 작성 폼
+  // 매뉴얼 케이스(케이스 작성·버그 찾기): 문제 읽기 흐름은 살리고 작성 영역은 풀높이 작업 화면으로 분리.
   if (challenge.modelTestCases || challenge.knownDefects) {
     return (
-      <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans">
-        <PlaygroundHeader containerClassName="max-w-6xl" />
-        <div className="border-line-2 border-b">
-          <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5 sm:px-6">
-            <Link
-              href="/challenges"
-              aria-label="챌린지 목록"
-              className="text-text-3 hover:text-text-1 text-sm transition-colors"
-            >
-              ←
-            </Link>
-            <h1 className="mr-1 text-base font-semibold sm:text-lg">{challenge.title}</h1>
-            <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
-              {TRACK_LABEL[challenge.track]}
-            </span>
-            <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
-              {CATEGORY_LABEL[challenge.category]}
-            </span>
-            <span
-              className={`px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
-            >
-              {DIFFICULTY_LABEL[challenge.difficulty]}
-            </span>
+      <div className="bg-bg-1 text-text-1 flex min-h-screen flex-col font-sans lg:h-screen lg:overflow-hidden">
+        <PlaygroundHeader containerClassName="max-w-none" />
+        <div className="border-line-2 flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5 border-b px-4 py-2.5 sm:px-6">
+          <Link
+            href="/challenges"
+            aria-label="챌린지 목록"
+            className="text-text-3 hover:text-text-1 text-sm transition-colors"
+          >
+            ←
+          </Link>
+          <h1 className="mr-1 text-base font-semibold sm:text-lg">{challenge.title}</h1>
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
+            {TRACK_LABEL[challenge.track]}
+          </span>
+          <span className="bg-bg-3 text-text-2 px-2 py-0.5 text-xs">
+            {CATEGORY_LABEL[challenge.category]}
+          </span>
+          <span
+            className={`px-2 py-0.5 text-xs font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}
+          >
+            {DIFFICULTY_LABEL[challenge.difficulty]}
+          </span>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+          <aside className="border-line-2 overflow-y-auto border-b p-5 sm:p-6 lg:w-2/5 lg:max-w-lg lg:border-r lg:border-b-0">
+            <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
+              {challenge.summary}
+            </p>
+            <div className="mt-6">
+              <RequirementList challenge={challenge} />
+            </div>
+            {challenge.knownDefects && challenge.sandboxSlug && (
+              <div className="border-line-2 bg-bg-2 mt-6 border p-4">
+                <h3 className="text-text-1 text-sm font-semibold">연습 대상</h3>
+                <p className="text-text-3 mt-1 text-xs leading-relaxed">
+                  결함 리포트는 실제 화면을 관찰하며 재현 절차와 실제 결과를 남기는 흐름이
+                  중요합니다.
+                </p>
+                <Link
+                  href={`/sandbox/${challenge.sandboxSlug}`}
+                  target="_blank"
+                  className="border-line-3 text-text-1 hover:bg-bg-3 mt-3 inline-flex h-9 items-center justify-center border px-4 text-sm transition-colors"
+                >
+                  연습 대상 열기 ↗
+                </Link>
+              </div>
+            )}
+          </aside>
+          <div className="min-h-0 flex-1 overflow-y-auto p-5 sm:p-6">
+            {challenge.knownDefects ? (
+              <DefectReportExercise
+                slug={challenge.slug}
+                sandboxSlug={undefined}
+                knownDefects={challenge.knownDefects}
+              />
+            ) : (
+              <TestCaseExercise
+                slug={challenge.slug}
+                modelTestCases={challenge.modelTestCases!}
+                requirements={challenge.requirement}
+              />
+            )}
           </div>
         </div>
-        <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-8 sm:px-6">
-          <div className="grid gap-8 lg:grid-cols-[2fr_3fr] lg:gap-10">
-            <div className="lg:sticky lg:top-24 lg:self-start">
-              <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
-                {challenge.summary}
-              </p>
-              <div className="mt-6">
-                <RequirementList challenge={challenge} />
-              </div>
-            </div>
-            <div>
-              {challenge.knownDefects ? (
-                <DefectReportExercise
-                  slug={challenge.slug}
-                  sandboxSlug={challenge.sandboxSlug}
-                  knownDefects={challenge.knownDefects}
-                />
-              ) : (
-                <TestCaseExercise
-                  slug={challenge.slug}
-                  modelTestCases={challenge.modelTestCases!}
-                  requirements={challenge.requirement}
-                />
-              )}
-            </div>
-          </div>
-        </main>
       </div>
     );
   }

--- a/apps/qaground/src/view/challenges/challenge-detail-view.tsx
+++ b/apps/qaground/src/view/challenges/challenge-detail-view.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 
 import {
   CATEGORY_LABEL,
+  CHALLENGES,
   type Challenge,
   type ChallengeDifficulty,
   DIFFICULTY_LABEL,
@@ -54,6 +55,61 @@ function ChallengeMeta({ challenge }: { challenge: Challenge }) {
   );
 }
 
+const CHALLENGE_TITLE_BY_SLUG = new Map(CHALLENGES.map((item) => [item.slug, item.title]));
+
+function ChallengeLearningMeta({ challenge }: { challenge: Challenge }) {
+  const prerequisites = challenge.prerequisites ?? [];
+  const next = challenge.recommendedNext ?? [];
+  if (!challenge.estimatedMinutes && prerequisites.length === 0 && next.length === 0) return null;
+
+  const linkItems = (slugs: string[]) =>
+    slugs.map((slug) => ({ slug, title: CHALLENGE_TITLE_BY_SLUG.get(slug) ?? slug }));
+
+  return (
+    <div className="border-line-2 bg-bg-2 mt-5 border-l-2 px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        {challenge.estimatedMinutes && (
+          <span className="text-text-2">예상 {challenge.estimatedMinutes}분</span>
+        )}
+        <span className={`px-2 py-0.5 font-medium ${DIFFICULTY_BADGE[challenge.difficulty]}`}>
+          {DIFFICULTY_LABEL[challenge.difficulty]}
+        </span>
+      </div>
+      {prerequisites.length > 0 && (
+        <div className="mt-3">
+          <p className="text-text-3 text-xs font-medium">먼저 풀면 좋은 문제</p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {linkItems(prerequisites).map((item) => (
+              <Link
+                key={item.slug}
+                href={`/challenges/${item.slug}`}
+                className="border-line-3 text-text-2 hover:text-text-1 border px-2 py-1 text-xs transition-colors"
+              >
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+      {next.length > 0 && (
+        <div className="mt-3">
+          <p className="text-text-3 text-xs font-medium">다음 추천</p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {linkItems(next).map((item) => (
+              <Link
+                key={item.slug}
+                href={`/challenges/${item.slug}`}
+                className="border-line-3 text-text-2 hover:text-text-1 border px-2 py-1 text-xs transition-colors"
+              >
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 function RequirementList({ challenge }: { challenge: Challenge }) {
   return (
     <>
@@ -152,6 +208,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
               {challenge.summary}
             </p>
+            <ChallengeLearningMeta challenge={challenge} />
             <h2 className="mt-6 text-base font-semibold">요구사항</h2>
             <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
               {challenge.requirement.map((r) => (
@@ -221,6 +278,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
               {challenge.summary}
             </p>
+            <ChallengeLearningMeta challenge={challenge} />
             <h2 className="mt-6 text-base font-semibold">요구사항</h2>
             <ol className="text-text-2 mt-3 flex list-decimal flex-col gap-2 pl-5 text-sm leading-relaxed">
               {challenge.requirement.map((r) => (
@@ -249,6 +307,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
         <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-12 sm:px-6">
           {backLink}
           <ChallengeMeta challenge={challenge} />
+          <ChallengeLearningMeta challenge={challenge} />
           <div className="mt-8 grid gap-8 lg:grid-cols-[4fr_6fr] lg:gap-10">
             <div className="lg:sticky lg:top-24 lg:self-start">
               <RequirementList challenge={challenge} />
@@ -307,6 +366,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
             <p className="text-text-2 text-sm leading-relaxed whitespace-pre-line">
               {challenge.summary}
             </p>
+            <ChallengeLearningMeta challenge={challenge} />
             <div className="mt-6">
               <RequirementList challenge={challenge} />
             </div>
@@ -353,6 +413,7 @@ export const ChallengeDetailView = ({ challenge }: { challenge: Challenge }) => 
       <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-12 sm:px-6">
         {backLink}
         <ChallengeMeta challenge={challenge} />
+        <ChallengeLearningMeta challenge={challenge} />
         <section className="mt-8">
           <RequirementList challenge={challenge} />
         </section>

--- a/apps/qaground/src/view/challenges/defect-report-exercise.tsx
+++ b/apps/qaground/src/view/challenges/defect-report-exercise.tsx
@@ -88,7 +88,7 @@ export const DefectReportExercise = ({
     'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary w-full border px-3 text-sm transition-colors outline-none';
 
   return (
-    <section className="border-line-2 bg-bg-2 rounded-2xl border p-5 sm:p-6">
+    <section>
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-base font-semibold">결함 리포트 작성</h2>
         <span className="text-text-3 text-xs">

--- a/apps/qaground/src/view/challenges/test-case-exercise.tsx
+++ b/apps/qaground/src/view/challenges/test-case-exercise.tsx
@@ -33,6 +33,7 @@ type Row = {
   precondition: string;
   steps: string[];
   expected: string;
+  covers: number[];
   dependsOn: number[];
 };
 
@@ -103,6 +104,7 @@ export const TestCaseExercise = ({
     precondition: '',
     steps: [''],
     expected: '',
+    covers: index < reqTotal ? [index] : [],
     dependsOn: [],
   });
   const [rows, setRows] = useState<Row[]>(() => [rowForIndex(0)]);
@@ -114,8 +116,8 @@ export const TestCaseExercise = ({
   const named = rows.filter((r) => r.name.trim());
   const written = named.length;
   const coveredSet = new Set<number>();
-  named.forEach((_, i) => {
-    if (i < reqTotal) coveredSet.add(i);
+  named.forEach((r) => {
+    r.covers.forEach((reqIndex) => coveredSet.add(reqIndex));
   });
   const reqCovered = coveredSet.size;
   const canSubmit = written >= 1;
@@ -147,6 +149,13 @@ export const TestCaseExercise = ({
         message: '기대 결과를 관찰 가능한 상태로 더 구체화하세요.',
       });
     }
+    if (r.covers.length === 0 && r.name.trim()) {
+      issues.push({
+        caseNo: index + 1,
+        severity: 'error',
+        message: '검증할 요구사항을 하나 이상 선택하세요.',
+      });
+    }
     if (index > 0 && r.dependsOn.length === 0 && r.name.trim()) {
       issues.push({
         caseNo: index + 1,
@@ -171,7 +180,20 @@ export const TestCaseExercise = ({
     setRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, [key]: v } : r)));
   const addRow = () => setRows((rs) => [...rs, rowForIndex(rs.length)]);
   const removeRow = (i: number) =>
-    setRows((rs) => (rs.length > 1 ? rs.filter((_, idx) => idx !== i) : rs));
+    setRows((rs) =>
+      rs.length > 1
+        ? rs
+            .filter((_, idx) => idx !== i)
+            .map((r) => ({
+              ...r,
+              dependsOn: r.dependsOn
+                .filter((dependencyIndex) => dependencyIndex !== i)
+                .map((dependencyIndex) =>
+                  dependencyIndex > i ? dependencyIndex - 1 : dependencyIndex
+                ),
+            }))
+        : rs
+    );
 
   const updateStep = (ci: number, si: number, v: string) =>
     setRows((rs) =>
@@ -200,6 +222,19 @@ export const TestCaseExercise = ({
           : r
       )
     );
+  const toggleCoverage = (ci: number, reqIndex: number) =>
+    setRows((rs) =>
+      rs.map((r, idx) =>
+        idx === ci
+          ? {
+              ...r,
+              covers: r.covers.includes(reqIndex)
+                ? r.covers.filter((x) => x !== reqIndex)
+                : [...r.covers, reqIndex].sort((a, b) => a - b),
+            }
+          : r
+      )
+    );
 
   // AI 채점 시도. 키 미설정·오류·타임아웃이면 null → 커버리지로 폴백한다.
   const fetchAiGrade = async (): Promise<AiGrade | null> => {
@@ -217,6 +252,7 @@ export const TestCaseExercise = ({
               precondition: r.precondition,
               steps: r.steps.filter((s) => s.trim()),
               expected: r.expected,
+              covers: r.covers.map((reqIndex) => '요구-' + (reqIndex + 1)),
               dependsOn: r.dependsOn.map((dependencyIndex) => 'TC-' + (dependencyIndex + 1)),
             })),
           },
@@ -456,6 +492,30 @@ export const TestCaseExercise = ({
               placeholder="기대 결과 — 예: 적용되지 않고 안내가 표시됨"
               className={`mt-2 resize-none py-2 ${fieldClass}`}
             />
+
+            <div className="mt-2.5">
+              <span className="text-text-3 text-xs">요구사항 커버리지</span>
+              <div className="mt-1.5 flex flex-wrap gap-1.5">
+                {requirements.map((requirement, reqIndex) => {
+                  const on = r.covers.includes(reqIndex);
+                  return (
+                    <button
+                      key={requirement}
+                      type="button"
+                      title={requirement}
+                      onClick={() => toggleCoverage(i, reqIndex)}
+                      className={`border px-2 py-0.5 text-xs transition-colors ${
+                        on
+                          ? 'border-primary bg-primary/15 text-primary'
+                          : 'border-line-3 text-text-3 hover:text-text-1'
+                      }`}
+                    >
+                      요구 {reqIndex + 1}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
 
             {i > 0 && (
               <div className="mt-2.5">

--- a/apps/qaground/src/view/challenges/test-case-exercise.tsx
+++ b/apps/qaground/src/view/challenges/test-case-exercise.tsx
@@ -33,7 +33,7 @@ type Row = {
   precondition: string;
   steps: string[];
   expected: string;
-  reqs: number[];
+  dependsOn: number[];
 };
 
 const PRIORITY_LABEL: Record<Priority, string> = {
@@ -97,7 +97,7 @@ export const TestCaseExercise = ({
     precondition: '',
     steps: [''],
     expected: '',
-    reqs: index < reqTotal ? [index] : [],
+    dependsOn: [],
   });
   const [rows, setRows] = useState<Row[]>(() => [rowForIndex(0)]);
   const [result, setResult] = useState<GradeResult | null>(null);
@@ -108,7 +108,9 @@ export const TestCaseExercise = ({
   const named = rows.filter((r) => r.name.trim());
   const written = named.length;
   const coveredSet = new Set<number>();
-  named.forEach((r) => r.reqs.forEach((i) => coveredSet.add(i)));
+  named.forEach((_, i) => {
+    if (i < reqTotal) coveredSet.add(i);
+  });
   const reqCovered = coveredSet.size;
   const canSubmit = written >= 1;
 
@@ -132,11 +134,16 @@ export const TestCaseExercise = ({
         idx === ci && r.steps.length > 1 ? { ...r, steps: r.steps.filter((_, j) => j !== si) } : r
       )
     );
-  const toggleReq = (ci: number, ri: number) =>
+  const toggleDependency = (ci: number, dependencyIndex: number) =>
     setRows((rs) =>
       rs.map((r, idx) =>
         idx === ci
-          ? { ...r, reqs: r.reqs.includes(ri) ? r.reqs.filter((x) => x !== ri) : [...r.reqs, ri] }
+          ? {
+              ...r,
+              dependsOn: r.dependsOn.includes(dependencyIndex)
+                ? r.dependsOn.filter((x) => x !== dependencyIndex)
+                : [...r.dependsOn, dependencyIndex],
+            }
           : r
       )
     );
@@ -266,7 +273,7 @@ export const TestCaseExercise = ({
     'border-line-3 bg-bg-3 rounded-button text-text-1 placeholder:text-text-3 focus:border-primary w-full border px-3 text-sm transition-colors outline-none';
 
   return (
-    <section className="border-line-2 bg-bg-2 rounded-2xl border p-5 sm:p-6">
+    <section>
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-base font-semibold">테스트 케이스 작성</h2>
         <span className="text-text-3 text-xs">
@@ -367,26 +374,26 @@ export const TestCaseExercise = ({
               className={`mt-2 resize-none py-2 ${fieldClass}`}
             />
 
-            {reqTotal > 0 && (
+            {i > 0 && (
               <div className="mt-2.5">
-                <span className="text-text-3 text-xs">연관 요구사항</span>
+                <span className="text-text-3 text-xs">종속 TC</span>
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  {/* 요구사항 총개수가 곧 작성할 케이스 수 힌트라서, 칩은 작성한 TC 개수만큼만 노출 */}
-                  {requirements.slice(0, rows.length).map((req, ri) => {
-                    const on = r.reqs.includes(ri);
+                  {rows.slice(0, i).map((candidate, dependencyIndex) => {
+                    const on = r.dependsOn.includes(dependencyIndex);
+                    const label = candidate.name.trim() || `TC-${dependencyIndex + 1}`;
                     return (
                       <button
-                        key={ri}
+                        key={dependencyIndex}
                         type="button"
-                        title={req}
-                        onClick={() => toggleReq(i, ri)}
-                        className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+                        title={`${label} 완료 후 실행`}
+                        onClick={() => toggleDependency(i, dependencyIndex)}
+                        className={`border px-2 py-0.5 text-xs transition-colors ${
                           on
                             ? 'border-primary bg-primary/15 text-primary'
                             : 'border-line-3 text-text-3 hover:text-text-1'
                         }`}
                       >
-                        요구 {ri + 1}
+                        TC-{dependencyIndex + 1}에 종속
                       </button>
                     );
                   })}

--- a/apps/qaground/src/view/challenges/test-case-exercise.tsx
+++ b/apps/qaground/src/view/challenges/test-case-exercise.tsx
@@ -49,6 +49,12 @@ const PRIORITY_BADGE: Record<Priority, string> = {
 };
 
 type GradeStatus = 'passed' | 'partial' | 'failed';
+type QualitySeverity = 'warn' | 'error';
+interface QualityIssue {
+  caseNo: number;
+  severity: QualitySeverity;
+  message: string;
+}
 interface GradeResult {
   status: GradeStatus;
   written: number;
@@ -113,6 +119,53 @@ export const TestCaseExercise = ({
   });
   const reqCovered = coveredSet.size;
   const canSubmit = written >= 1;
+  const qualityIssues = rows.flatMap<QualityIssue>((r, index) => {
+    const touched =
+      r.name.trim() ||
+      r.precondition.trim() ||
+      r.steps.some((step) => step.trim()) ||
+      r.expected.trim();
+    if (!touched) return [];
+
+    const issues: QualityIssue[] = [];
+    if (!r.name.trim()) {
+      issues.push({
+        caseNo: index + 1,
+        severity: 'error',
+        message: '케이스 이름이 비어 있습니다.',
+      });
+    }
+    if (!r.steps.some((step) => step.trim())) {
+      issues.push({ caseNo: index + 1, severity: 'error', message: '실행 절차가 없습니다.' });
+    }
+    if (!r.expected.trim()) {
+      issues.push({ caseNo: index + 1, severity: 'error', message: '기대 결과가 비어 있습니다.' });
+    } else if (r.expected.trim().length < 10) {
+      issues.push({
+        caseNo: index + 1,
+        severity: 'warn',
+        message: '기대 결과를 관찰 가능한 상태로 더 구체화하세요.',
+      });
+    }
+    if (index > 0 && r.dependsOn.length === 0 && r.name.trim()) {
+      issues.push({
+        caseNo: index + 1,
+        severity: 'warn',
+        message: '선행 TC가 있다면 종속 관계를 지정하세요.',
+      });
+    }
+    r.dependsOn.forEach((dependencyIndex) => {
+      if (!rows[dependencyIndex]?.name.trim()) {
+        issues.push({
+          caseNo: index + 1,
+          severity: 'warn',
+          message: `종속 대상 TC-${dependencyIndex + 1}의 이름이 비어 있습니다.`,
+        });
+      }
+    });
+    return issues;
+  });
+  const visibleQualityIssues = qualityIssues.slice(0, 5);
 
   const update = (i: number, key: 'name' | 'priority' | 'precondition' | 'expected', v: string) =>
     setRows((rs) => rs.map((r, idx) => (idx === i ? { ...r, [key]: v } : r)));
@@ -164,6 +217,7 @@ export const TestCaseExercise = ({
               precondition: r.precondition,
               steps: r.steps.filter((s) => s.trim()),
               expected: r.expected,
+              dependsOn: r.dependsOn.map((dependencyIndex) => 'TC-' + (dependencyIndex + 1)),
             })),
           },
         }),
@@ -277,13 +331,42 @@ export const TestCaseExercise = ({
       <div className="flex flex-wrap items-baseline justify-between gap-2">
         <h2 className="text-base font-semibold">테스트 케이스 작성</h2>
         <span className="text-text-3 text-xs">
-          작성 {written}개 · 요구사항 연결 {reqCovered}개
+          작성 {written}개 · 커버리지 {reqCovered}/{reqTotal}
         </span>
       </div>
       <p className="text-text-2 mt-2 text-sm leading-relaxed">
-        요구사항을 분석해 케이스를 작성하고, 각 케이스가 검증하는 요구사항을 연결하세요. 모든
-        요구사항에 케이스를 연결하면 통과입니다. 제출하면 채점 결과와 모범 답안이 나타납니다.
+        요구사항을 분석해 케이스를 작성하고, 선행 TC가 필요한 경우 종속 관계를 지정하세요. 모든
+        요구사항을 검증할 수 있을 만큼 케이스를 작성하면 통과입니다.
       </p>
+
+      {(visibleQualityIssues.length > 0 || written > 0) && (
+        <div className="border-line-2 bg-bg-2 mt-4 border-l-2 px-3 py-2.5">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-text-2 text-xs font-semibold">품질 점검</span>
+            <span className="text-text-3 text-xs">
+              {qualityIssues.length === 0
+                ? '주요 누락 없음'
+                : `${qualityIssues.length}개 확인 필요`}
+            </span>
+          </div>
+          {visibleQualityIssues.length > 0 && (
+            <ul className="mt-2 flex flex-col gap-1">
+              {visibleQualityIssues.map((issue, index) => (
+                <li
+                  key={`${issue.caseNo}-${index}`}
+                  className={
+                    issue.severity === 'error'
+                      ? 'text-system-red text-xs'
+                      : 'text-xs text-[#d29922]'
+                  }
+                >
+                  TC-{issue.caseNo}: {issue.message}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       <ol className="mt-5 flex flex-col gap-3">
         {rows.map((r, i) => (


### PR DESCRIPTION
## 변경 내용
- 챌린지 상세에 예상 풀이 시간, 선수 문제, 다음 추천 문제를 표시합니다.
- API 테스트 워크벤치에 최근 요청 기록, 응답 시간, 응답 헤더 확인을 추가합니다.
- 매뉴얼 테스트 케이스 작성 화면에 제목, 절차, 기대 결과, 종속 TC 기준 품질 피드백을 추가합니다.

## 영향
- 사용자가 문제 난이도와 학습 순서를 더 쉽게 파악할 수 있습니다.
- API 챌린지 실행 결과를 디버깅하기 쉬워집니다.
- 매뉴얼 케이스 작성 중 누락된 항목을 제출 전에 확인할 수 있습니다.

## 검증
- pnpm --filter qaground build
- http://localhost:3200/challenges/rest-api-products 응답 확인
- http://localhost:3200/challenges/test-design-password-reset 응답 확인