### PR TITLE
feat(web): 요구사항 페이지 레이아웃 개선

### DIFF
--- a/apps/web/app/projects/[slug]/requirements/create/page.tsx
+++ b/apps/web/app/projects/[slug]/requirements/create/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from 'next';
+
+import { projectIdQueryOptions } from '@/entities/project/api/query';
+import { requirementAnalysesQueryOptions } from '@/entities/requirement-analysis';
+import { cachedGetProjectId } from '@/shared/lib/cache';
+import { RequirementsView } from '@/view';
+import { HydrationBoundary, QueryClient, dehydrate } from '@tanstack/react-query';
+
+export const metadata: Metadata = {
+  title: '요구사항 생성',
+  description: '요구사항 문서를 정리하고 테스트 시나리오로 이어지는 작업을 생성합니다.',
+};
+
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 60 * 1000 } },
+  });
+
+  try {
+    const result = await queryClient.fetchQuery({
+      ...projectIdQueryOptions(slug),
+      queryFn: () => cachedGetProjectId(slug),
+    });
+    const projectId = result?.success ? result.data.id : undefined;
+
+    if (projectId) {
+      await queryClient.prefetchQuery(requirementAnalysesQueryOptions(projectId));
+    }
+  } catch {
+    // prefetch 실패 시 클라이언트에서 재시도
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <RequirementsView openCreateOnMount />
+    </HydrationBoundary>
+  );
+}

--- a/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-form.tsx
+++ b/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-form.tsx
@@ -47,7 +47,7 @@ export const RequirementAnalysisForm = ({
             type="button"
             onClick={() => onLanguageChange(l)}
             className={cn(
-              'typo-caption rounded-full px-2.5 py-0.5 transition-colors',
+              'typo-caption rounded-2 px-2.5 py-0.5 transition-colors',
               language === l
                 ? 'bg-primary/10 text-primary'
                 : 'bg-bg-3 text-text-3 hover:text-text-1'

--- a/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-modal.tsx
+++ b/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-modal.tsx
@@ -153,13 +153,13 @@ export const RequirementAnalysisModal = ({ projectId, onClose }: Props) => {
   };
 
   return (
-    <Dialog.Root defaultOpen>
+    <Dialog.Root defaultOpen onOpenChange={(open) => !open && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay onClick={step !== 'loading' ? onClose : undefined} />
-        <Dialog.Content className="bg-bg-2 border-line-2 rounded-5 flex max-h-[85vh] w-full max-w-[720px] flex-col border p-0">
+        <Dialog.Content className="bg-bg-2 border-line-2 rounded-3 flex max-h-[85vh] w-full max-w-[720px] flex-col border p-0">
           {/* 헤더 */}
           <div className="border-line-2 flex items-center justify-between border-b px-6 py-4">
-            <Dialog.Title className="typo-h2-heading text-text-1">AI 요구사항 분석</Dialog.Title>
+            <Dialog.Title className="typo-h2-heading text-text-1">요구사항 생성</Dialog.Title>
             {step !== 'loading' && (
               <button
                 type="button"
@@ -176,7 +176,7 @@ export const RequirementAnalysisModal = ({ projectId, onClose }: Props) => {
           <div className="flex-1 overflow-y-auto p-6">
             {!hasConfig ? (
               <div className="flex flex-col items-center gap-4 py-10 text-center">
-                <div className="bg-primary/10 flex h-14 w-14 items-center justify-center rounded-full">
+                <div className="bg-primary/10 rounded-3 flex h-14 w-14 items-center justify-center">
                   <Bot className="text-primary h-7 w-7" />
                 </div>
                 <div className="flex flex-col gap-1">

--- a/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-preview.tsx
+++ b/apps/web/src/features/ai-requirement-analysis/ui/requirement-analysis-preview.tsx
@@ -62,7 +62,7 @@ export const RequirementAnalysisPreview = ({
             {analysis.functionalRequirements.map((fr) => (
               <div key={fr.id} className="flex flex-col gap-0.5">
                 <div className="flex items-center gap-2">
-                  <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-0.5">
+                  <span className="typo-caption bg-bg-3 text-text-3 rounded-2 px-2 py-0.5">
                     {fr.id}
                   </span>
                   <span className="typo-body2-heading text-text-1">{fr.title}</span>
@@ -167,9 +167,7 @@ export const RequirementAnalysisPreview = ({
                     <span className="typo-body2-heading text-text-1 flex-1 truncate">
                       {scenario.name}
                     </span>
-                    <span
-                      className={cn('typo-caption shrink-0 rounded-full px-2 py-0.5', type.cls)}
-                    >
+                    <span className={cn('typo-caption rounded-2 shrink-0 px-2 py-0.5', type.cls)}>
                       {type.text}
                     </span>
                   </div>
@@ -183,7 +181,7 @@ export const RequirementAnalysisPreview = ({
                       {scenario.relatedRequirementIds.map((rid) => (
                         <span
                           key={rid}
-                          className="typo-caption bg-bg-3 text-text-4 rounded-full px-2 py-0.5"
+                          className="typo-caption bg-bg-3 text-text-4 rounded-2 px-2 py-0.5"
                         >
                           {rid}
                         </span>

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -13,7 +13,16 @@ import { ActionToolbar } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useDisclosure } from '@testea/lib';
 import { MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
-import { FileSearch, FolderTree, ListChecks, Plus } from 'lucide-react';
+import {
+  CalendarDays,
+  FileSearch,
+  FileText,
+  FolderTree,
+  Languages,
+  ListChecks,
+  Plus,
+  Sparkles,
+} from 'lucide-react';
 
 const LANGUAGE_LABEL: Record<string, string> = {
   ko: '한국어',
@@ -22,6 +31,19 @@ const LANGUAGE_LABEL: Record<string, string> = {
 
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
+
+const statItems = (analyses: RequirementAnalysisListItem[]) => {
+  const functionalCount = analyses.reduce((sum, item) => sum + item.functionalCount, 0);
+  const scenarioCount = analyses.reduce((sum, item) => sum + item.scenarioCount, 0);
+  const savedSuiteCount = analyses.reduce((sum, item) => sum + item.savedSuiteCount, 0);
+
+  return [
+    { label: '분석서', value: analyses.length, icon: FileText },
+    { label: '기능 요구사항', value: functionalCount, icon: ListChecks },
+    { label: '시나리오', value: scenarioCount, icon: FolderTree },
+    { label: '저장된 스위트', value: savedSuiteCount, icon: Sparkles },
+  ];
+};
 
 export const RequirementsView = () => {
   const params = useParams();
@@ -50,27 +72,44 @@ export const RequirementsView = () => {
     enabled: !!projectId,
   });
 
+  const allAnalyses = useMemo<RequirementAnalysisListItem[]>(
+    () => (analysesData?.success ? analysesData.data : []),
+    [analysesData]
+  );
+
   const analyses = useMemo<RequirementAnalysisListItem[]>(() => {
-    if (!analysesData?.success) return [];
-    const items = analysesData.data;
-    if (!searchQuery.trim()) return items;
+    if (!searchQuery.trim()) return allAnalyses;
     const q = searchQuery.toLowerCase();
-    return items.filter(
+    return allAnalyses.filter(
       (a) => a.title.toLowerCase().includes(q) || a.summary.toLowerCase().includes(q)
     );
-  }, [analysesData, searchQuery]);
+  }, [allAnalyses, searchQuery]);
+
+  const stats = useMemo(() => statItems(allAnalyses), [allAnalyses]);
+  const latestAnalysis = allAnalyses[0];
+  const languageCount = useMemo(
+    () =>
+      allAnalyses.reduce<Record<string, number>>((acc, item) => {
+        acc[item.language] = (acc[item.language] ?? 0) + 1;
+        return acc;
+      }, {}),
+    [allAnalyses]
+  );
 
   if (!hydrated || isLoadingProject || isLoadingAnalyses) {
     return (
-      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
+      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1280px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex flex-col gap-2">
           <Skeleton className="h-8 w-64" />
           <Skeleton className="h-5 w-96" />
         </header>
-        <div className="col-span-6 flex flex-col gap-3">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="rounded-3 h-24 w-full" />
-          ))}
+        <div className="col-span-6 grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="rounded-3 h-28 w-full" />
+            ))}
+          </div>
+          <Skeleton className="rounded-3 hidden h-80 w-full lg:block" />
         </div>
       </MainContainer>
     );
@@ -84,12 +123,30 @@ export const RequirementsView = () => {
   }
 
   return (
-    <MainContainer className="mx-auto grid h-screen w-full max-w-[1200px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-4 overflow-hidden px-10 py-8">
-      <header className="col-span-6 flex flex-col gap-1">
-        <h1 className="typo-title-heading">요구사항 생성</h1>
-        <p className="typo-body1-normal text-text-3">
-          요구사항을 입력하면 AI가 요구사항 분석서와 테스트 시나리오를 만들어줍니다.
-        </p>
+    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
+      <header className="col-span-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+        <div className="flex min-w-0 flex-col gap-1.5">
+          <p className="typo-caption text-primary">AI 요구사항 분석</p>
+          <h1 className="typo-title-heading text-text-1">요구사항 생성</h1>
+          <p className="typo-body1-normal text-text-3 max-w-2xl">
+            요구사항을 입력하면 분석서, 기능 요구사항, 테스트 시나리오를 생성하고 후속 작업으로
+            연결합니다.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:w-[30rem]">
+          {stats.map((item) => {
+            const Icon = item.icon;
+            return (
+              <div key={item.label} className="border-line-2 bg-bg-2 rounded-3 border px-3 py-2.5">
+                <div className="text-text-3 flex items-center gap-1.5">
+                  <Icon className="h-3.5 w-3.5" />
+                  <span className="typo-caption truncate">{item.label}</span>
+                </div>
+                <p className="typo-h3-heading text-text-1 mt-1">{item.value}</p>
+              </div>
+            );
+          })}
+        </div>
       </header>
 
       <ActionToolbar.Root ariaLabel="요구사항 분석 컨트롤">
@@ -112,70 +169,169 @@ export const RequirementsView = () => {
         </ActionToolbar.Action>
       </ActionToolbar.Root>
 
-      <section className="col-span-6 flex min-h-0 flex-col">
-        <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
-          {analyses.length === 0 ? (
-            <div className="rounded-3 border-line-2 bg-bg-2/50 flex h-full flex-col items-center justify-center gap-4 border-2 border-dashed py-20 text-center">
-              <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
-                <FileSearch className="h-6 w-6" strokeWidth={1.5} />
-              </div>
-              <div className="flex flex-col gap-1">
-                {searchQuery.trim() ? (
-                  <>
-                    <p className="typo-h3-heading text-text-1">검색 결과가 없습니다.</p>
-                    <p className="typo-body2-normal text-text-3">
-                      다른 키워드로 다시 검색해보세요.
-                    </p>
-                  </>
-                ) : (
-                  <>
-                    <p className="typo-h3-heading text-text-1">
-                      아직 생성한 요구사항 분석이 없습니다.
-                    </p>
-                    <p className="typo-body2-normal text-text-3">
-                      요구사항을 입력해 분석서와 테스트 시나리오를 만들어보세요.
-                    </p>
-                  </>
-                )}
-              </div>
+      <section className="col-span-6 grid min-h-0 gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="flex min-h-0 flex-col">
+          <div className="border-line-2 bg-bg-2 rounded-3 mb-3 flex items-center justify-between border px-4 py-3">
+            <div>
+              <h2 className="typo-body1-heading text-text-1">분석서 목록</h2>
+              <p className="typo-label-normal text-text-3 mt-0.5">
+                {searchQuery.trim()
+                  ? `검색 결과 ${analyses.length}개 / 전체 ${allAnalyses.length}개`
+                  : `전체 ${allAnalyses.length}개 분석서`}
+              </p>
             </div>
-          ) : (
-            analyses.map((a) => (
-              <Link
-                key={a.id}
-                href={`/projects/${slug}/scenarios/${a.id}`}
-                className="rounded-3 border-line-2 bg-bg-2 hover:border-primary/40 flex flex-col gap-2.5 border px-5 py-4 transition-colors"
-              >
-                <div className="flex items-start gap-3">
-                  <div className="min-w-0 flex-1">
-                    <h3 className="typo-body1-heading text-text-1 truncate">{a.title}</h3>
-                    {a.summary && (
-                      <p className="typo-body2-normal text-text-3 mt-1 line-clamp-2 whitespace-pre-line">
-                        {a.summary}
+            <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-1">최신순</span>
+          </div>
+
+          <div className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
+            {analyses.length === 0 ? (
+              <div className="rounded-3 border-line-2 bg-bg-2/50 flex h-full min-h-[320px] flex-col items-center justify-center gap-4 border-2 border-dashed py-20 text-center">
+                <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
+                  <FileSearch className="h-6 w-6" strokeWidth={1.5} />
+                </div>
+                <div className="flex flex-col gap-1">
+                  {searchQuery.trim() ? (
+                    <>
+                      <p className="typo-h3-heading text-text-1">검색 결과가 없습니다.</p>
+                      <p className="typo-body2-normal text-text-3">
+                        다른 키워드로 다시 검색해보세요.
                       </p>
-                    )}
+                    </>
+                  ) : (
+                    <>
+                      <p className="typo-h3-heading text-text-1">
+                        아직 생성한 요구사항 분석이 없습니다.
+                      </p>
+                      <p className="typo-body2-normal text-text-3">
+                        요구사항을 입력해 분석서와 테스트 시나리오를 만들어보세요.
+                      </p>
+                    </>
+                  )}
+                </div>
+              </div>
+            ) : (
+              analyses.map((a) => (
+                <Link
+                  key={a.id}
+                  href={`/projects/${slug}/scenarios/${a.id}`}
+                  className="group rounded-3 border-line-2 bg-bg-2 hover:border-primary/40 hover:bg-bg-3 flex flex-col gap-3 border px-5 py-4 transition-colors"
+                >
+                  <div className="flex items-start gap-4">
+                    <div className="bg-bg-3 text-primary border-line-2 rounded-3 flex h-10 w-10 shrink-0 items-center justify-center border">
+                      <FileText className="h-5 w-5" strokeWidth={1.8} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <h3 className="typo-body1-heading text-text-1 group-hover:text-primary truncate">
+                          {a.title}
+                        </h3>
+                        <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-0.5">
+                          {LANGUAGE_LABEL[a.language] ?? a.language}
+                        </span>
+                      </div>
+                      {a.summary && (
+                        <p className="typo-body2-normal text-text-3 mt-1.5 line-clamp-2 whitespace-pre-line">
+                          {a.summary}
+                        </p>
+                      )}
+                    </div>
+                    <span className="typo-label-normal text-text-4 hidden shrink-0 sm:block">
+                      {formatDate(a.createdAt)}
+                    </span>
                   </div>
-                  <span className="typo-label-normal text-text-4 shrink-0">
-                    {formatDate(a.createdAt)}
-                  </span>
-                </div>
-                <div className="text-text-3 flex flex-wrap items-center gap-4">
-                  <span className="typo-label-normal flex items-center gap-1.5">
-                    <ListChecks className="h-3.5 w-3.5" />
-                    기능 요구사항 {a.functionalCount}
-                  </span>
-                  <span className="typo-label-normal flex items-center gap-1.5">
-                    <FolderTree className="h-3.5 w-3.5" />
-                    시나리오 {a.scenarioCount} · 스위트 {a.savedSuiteCount}개 저장
-                  </span>
-                  <span className="typo-label-normal bg-bg-3 rounded-full px-2 py-0.5">
-                    {LANGUAGE_LABEL[a.language] ?? a.language}
-                  </span>
-                </div>
-              </Link>
-            ))
-          )}
+                  <div className="text-text-3 flex flex-wrap items-center gap-x-4 gap-y-2 pl-14">
+                    <span className="typo-label-normal flex items-center gap-1.5">
+                      <ListChecks className="h-3.5 w-3.5" />
+                      기능 요구사항 {a.functionalCount}
+                    </span>
+                    <span className="typo-label-normal flex items-center gap-1.5">
+                      <FolderTree className="h-3.5 w-3.5" />
+                      시나리오 {a.scenarioCount}
+                    </span>
+                    <span className="typo-label-normal flex items-center gap-1.5">
+                      <Sparkles className="h-3.5 w-3.5" />
+                      스위트 {a.savedSuiteCount}개 저장
+                    </span>
+                    <span className="typo-label-normal text-text-4 flex items-center gap-1.5 sm:hidden">
+                      <CalendarDays className="h-3.5 w-3.5" />
+                      {formatDate(a.createdAt)}
+                    </span>
+                  </div>
+                </Link>
+              ))
+            )}
+          </div>
         </div>
+
+        <aside className="hidden min-h-0 flex-col gap-4 lg:flex">
+          <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
+            <h2 className="typo-body1-heading text-text-1">작업 흐름</h2>
+            <ol className="mt-4 flex flex-col gap-3">
+              {[
+                ['1', '요구사항 입력', '문서나 기능 설명을 분석합니다.'],
+                ['2', '시나리오 검토', '생성된 시나리오를 기능별로 정리합니다.'],
+                ['3', '스위트 저장', '실행 가능한 테스트 묶음으로 전환합니다.'],
+              ].map(([step, title, desc]) => (
+                <li key={step} className="flex gap-3">
+                  <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
+                    {step}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="typo-label-heading text-text-2 block">{title}</span>
+                    <span className="typo-label-normal text-text-4 mt-0.5 block">{desc}</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
+            <div className="flex items-center gap-2">
+              <Languages className="text-text-3 h-4 w-4" />
+              <h2 className="typo-body1-heading text-text-1">언어 구성</h2>
+            </div>
+            <div className="mt-4 flex flex-col gap-2">
+              {Object.keys(languageCount).length === 0 ? (
+                <p className="typo-label-normal text-text-4">아직 분석서가 없습니다.</p>
+              ) : (
+                Object.entries(languageCount).map(([language, count]) => (
+                  <div key={language} className="flex items-center justify-between gap-3">
+                    <span className="typo-label-normal text-text-3">
+                      {LANGUAGE_LABEL[language] ?? language}
+                    </span>
+                    <span className="typo-label-heading text-text-1">{count}</span>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          <div className="border-primary/20 bg-primary/5 rounded-3 border p-4">
+            <h2 className="typo-body1-heading text-text-1">다음 추천 작업</h2>
+            <p className="typo-body2-normal text-text-3 mt-2">
+              {latestAnalysis
+                ? `${latestAnalysis.title} 분석서의 시나리오를 확인하고 테스트 스위트로 저장하세요.`
+                : '첫 요구사항 분석서를 생성해 테스트 설계 흐름을 시작하세요.'}
+            </p>
+            {latestAnalysis ? (
+              <Link
+                href={`/projects/${slug}/scenarios/${latestAnalysis.id}`}
+                className="typo-label-heading text-primary mt-3 inline-flex"
+              >
+                최신 분석서 열기
+              </Link>
+            ) : (
+              <button
+                type="button"
+                onClick={onOpen}
+                disabled={!projectId}
+                className="typo-label-heading text-primary mt-3 inline-flex disabled:opacity-50"
+              >
+                새 분석 시작
+              </button>
+            )}
+          </div>
+        </aside>
       </section>
 
       {isOpen && projectId && <RequirementAnalysisModal projectId={projectId} onClose={onClose} />}

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 
 import { projectIdQueryOptions } from '@/entities/project';
 import type { RequirementAnalysisListItem } from '@/entities/requirement-analysis';
@@ -20,6 +20,7 @@ import {
   Languages,
   ListChecks,
   Plus,
+  Search,
   Sparkles,
 } from 'lucide-react';
 
@@ -31,11 +32,23 @@ const LANGUAGE_LABEL: Record<string, string> = {
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
 
-export const RequirementsView = () => {
+type RequirementsViewProps = {
+  openCreateOnMount?: boolean;
+};
+
+export const RequirementsView = ({ openCreateOnMount = false }: RequirementsViewProps) => {
   const params = useParams();
+  const router = useRouter();
   const slug = params.slug as string;
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen, onClose } = useDisclosure(openCreateOnMount);
   const [searchQuery, setSearchQuery] = useState('');
+  const createHref = `/projects/${slug}/requirements/create`;
+  const listHref = `/projects/${slug}/requirements`;
+  const openCreate = () => router.push(createHref);
+  const closeCreate = () => {
+    onClose();
+    if (openCreateOnMount) router.replace(listHref);
+  };
 
   // 클라이언트 hydration 완료 전까지 서버와 동일 출력(스켈레톤) 보장 → SSR↔CSR 미스매치 방지
   const [hydrated, setHydrated] = useState(false);
@@ -117,7 +130,13 @@ export const RequirementsView = () => {
             요구사항 문서를 정리하고 기능 단위 시나리오로 이어지는 작업 목록을 관리합니다.
           </p>
         </div>
-        <DSButton size="small" type="button" variant="solid" onClick={onOpen} disabled={!projectId}>
+        <DSButton
+          size="small"
+          type="button"
+          variant="solid"
+          onClick={openCreate}
+          disabled={!projectId}
+        >
           <Plus className="h-4 w-4" />
           <span className="leading-none">새 요구사항 정리</span>
         </DSButton>
@@ -178,7 +197,7 @@ export const RequirementsView = () => {
                       </p>
                       <button
                         type="button"
-                        onClick={onOpen}
+                        onClick={openCreate}
                         disabled={!projectId}
                         className="bg-primary hover:bg-primary/90 typo-label-heading rounded-2 mt-5 inline-flex h-9 w-fit items-center justify-center gap-2 px-4 text-white transition-colors disabled:opacity-50"
                       >
@@ -328,7 +347,7 @@ export const RequirementsView = () => {
             ) : (
               <button
                 type="button"
-                onClick={onOpen}
+                onClick={openCreate}
                 disabled={!projectId}
                 className="typo-label-heading text-primary mt-3 inline-flex disabled:opacity-50"
               >
@@ -339,7 +358,9 @@ export const RequirementsView = () => {
         </aside>
       </section>
 
-      {isOpen && projectId && <RequirementAnalysisModal projectId={projectId} onClose={onClose} />}
+      {isOpen && projectId && (
+        <RequirementAnalysisModal projectId={projectId} onClose={closeCreate} />
+      )}
     </MainContainer>
   );
 };

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -9,10 +9,9 @@ import { projectIdQueryOptions } from '@/entities/project';
 import type { RequirementAnalysisListItem } from '@/entities/requirement-analysis';
 import { requirementAnalysesQueryOptions } from '@/entities/requirement-analysis';
 import { RequirementAnalysisModal } from '@/features/ai-requirement-analysis';
-import { ActionToolbar } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useDisclosure } from '@testea/lib';
-import { MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
+import { DSButton, MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
 import {
   CalendarDays,
   FileSearch,
@@ -109,49 +108,49 @@ export const RequirementsView = () => {
   }
 
   return (
-    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
-      <header className="col-span-6 flex min-w-0 flex-col gap-1.5">
-        <p className="typo-caption text-primary">요구사항 정리</p>
-        <h1 className="typo-title-heading text-text-1">요구사항 생성</h1>
-        <p className="typo-body1-normal text-text-3 max-w-2xl">
-          요구사항 문서를 정리하고 기능 단위 시나리오로 이어지는 작업 목록을 관리합니다.
-        </p>
-      </header>
-
-      <ActionToolbar.Root ariaLabel="요구사항 정리 컨트롤">
-        <ActionToolbar.Group>
-          <ActionToolbar.Search
-            placeholder="제목·요약으로 검색"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </ActionToolbar.Group>
-        <ActionToolbar.Action
-          size="small"
-          type="button"
-          variant="solid"
-          onClick={onOpen}
-          disabled={!projectId}
-        >
+    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
+      <header className="col-span-6 flex min-w-0 flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="typo-caption text-primary">요구사항 정리</p>
+          <h1 className="typo-title-heading text-text-1 mt-1">요구사항 생성</h1>
+          <p className="typo-body1-normal text-text-3 mt-1.5 max-w-2xl">
+            요구사항 문서를 정리하고 기능 단위 시나리오로 이어지는 작업 목록을 관리합니다.
+          </p>
+        </div>
+        <DSButton size="small" type="button" variant="solid" onClick={onOpen} disabled={!projectId}>
           <Plus className="h-4 w-4" />
           <span className="leading-none">새 요구사항 정리</span>
-        </ActionToolbar.Action>
-      </ActionToolbar.Root>
+        </DSButton>
+      </header>
 
       <section className="col-span-6 grid min-h-0 gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
         <div className="border-line-2 bg-bg-2 rounded-3 flex min-h-0 flex-col overflow-hidden border">
-          <div className="border-line-2 flex items-center justify-between gap-4 border-b px-5 py-4">
-            <div className="min-w-0">
-              <h2 className="typo-body1-heading text-text-1">요구사항 정리</h2>
-              <p className="typo-label-normal text-text-3 mt-0.5">
-                {searchQuery.trim()
-                  ? `검색 결과 ${analyses.length}개 / 전체 ${allAnalyses.length}개`
-                  : `전체 ${allAnalyses.length}개 분석`}
-              </p>
+          <div className="border-line-2 flex flex-col gap-3 border-b px-5 py-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 className="typo-body1-heading text-text-1">요구사항 정리</h2>
+                <p className="typo-label-normal text-text-3 mt-0.5">
+                  {searchQuery.trim()
+                    ? `검색 결과 ${analyses.length}개 / 전체 ${allAnalyses.length}개`
+                    : `전체 ${allAnalyses.length}개 분석`}
+                </p>
+              </div>
+              <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+                최신순
+              </span>
             </div>
-            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
-              최신순
-            </span>
+            <div className="relative w-full max-w-2xl lg:max-w-3xl">
+              <Search
+                className="text-text-4 pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
+                aria-hidden="true"
+              />
+              <input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="제목·요약으로 검색"
+                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary h-9 w-full rounded-full border px-9 transition-colors outline-none"
+              />
+            </div>
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -135,7 +135,7 @@ export const RequirementsView = () => {
                     : `전체 ${allAnalyses.length}개 분석`}
                 </p>
               </div>
-              <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+              <span className="typo-caption bg-bg-3 text-text-3 rounded-2 shrink-0 px-2 py-1">
                 최신순
               </span>
             </div>
@@ -148,7 +148,7 @@ export const RequirementsView = () => {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="제목·요약으로 검색"
-                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary h-9 w-full rounded-full border px-9 transition-colors outline-none"
+                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary rounded-2 h-9 w-full border px-9 transition-colors outline-none"
               />
             </div>
           </div>
@@ -229,7 +229,7 @@ export const RequirementsView = () => {
                           <h3 className="typo-body1-heading text-text-1 group-hover:text-primary truncate">
                             {a.title}
                           </h3>
-                          <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-0.5">
+                          <span className="typo-caption bg-bg-3 text-text-3 rounded-2 shrink-0 px-2 py-0.5">
                             {LANGUAGE_LABEL[a.language] ?? a.language}
                           </span>
                         </div>
@@ -278,7 +278,7 @@ export const RequirementsView = () => {
                 ['3', '검증', '시나리오와 스위트로 옮길 기준을 남깁니다.'],
               ].map(([step, title, desc]) => (
                 <li key={step} className="flex gap-3">
-                  <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
+                  <span className="bg-bg-3 text-text-2 rounded-2 flex h-6 w-6 shrink-0 items-center justify-center text-xs">
                     {step}
                   </span>
                   <span className="min-w-0">

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -143,11 +143,11 @@ export const RequirementsView = () => {
         <div className="flex min-h-0 flex-col">
           <div className="border-line-2 bg-bg-2 rounded-3 mb-3 flex items-center justify-between border px-4 py-3">
             <div>
-              <h2 className="typo-body1-heading text-text-1">분석서 목록</h2>
+              <h2 className="typo-body1-heading text-text-1">요구사항 분석</h2>
               <p className="typo-label-normal text-text-3 mt-0.5">
                 {searchQuery.trim()
                   ? `검색 결과 ${analyses.length}개 / 전체 ${allAnalyses.length}개`
-                  : `전체 ${allAnalyses.length}개 분석서`}
+                  : `전체 ${allAnalyses.length}개 분석`}
               </p>
             </div>
             <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-1">최신순</span>
@@ -155,28 +155,53 @@ export const RequirementsView = () => {
 
           <div className="min-h-0 flex-1 overflow-y-auto pr-1">
             {analyses.length === 0 ? (
-              <div className="rounded-3 border-line-2 bg-bg-2/50 flex h-full min-h-[320px] flex-col items-center justify-center gap-4 border-2 border-dashed py-20 text-center">
-                <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
-                  <FileSearch className="h-6 w-6" strokeWidth={1.5} />
-                </div>
-                <div className="flex flex-col gap-1">
+              <div className="border-line-2 bg-bg-2 rounded-3 grid h-full min-h-[360px] overflow-hidden border lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <div className="flex min-w-0 flex-col justify-center px-8 py-10">
+                  <div className="bg-bg-3 text-primary border-line-2 rounded-3 flex h-11 w-11 items-center justify-center border">
+                    <FileSearch className="h-5 w-5" strokeWidth={1.7} />
+                  </div>
                   {searchQuery.trim() ? (
                     <>
-                      <p className="typo-h3-heading text-text-1">검색 결과가 없습니다.</p>
-                      <p className="typo-body2-normal text-text-3">
-                        다른 키워드로 다시 검색해보세요.
+                      <h3 className="typo-h2-heading text-text-1 mt-5">검색 결과가 없습니다.</h3>
+                      <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
+                        제목이나 요약에 포함된 다른 키워드로 다시 검색해보세요.
                       </p>
                     </>
                   ) : (
                     <>
-                      <p className="typo-h3-heading text-text-1">
-                        아직 생성한 요구사항 분석이 없습니다.
+                      <h3 className="typo-h2-heading text-text-1 mt-5">
+                        첫 요구사항 분석을 시작하세요.
+                      </h3>
+                      <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
+                        기능 설명, 정책 문서, 회의록을 입력하면 분석 결과와 테스트 시나리오로
+                        이어지는 작업 단위를 만듭니다.
                       </p>
-                      <p className="typo-body2-normal text-text-3">
-                        요구사항을 입력해 분석서와 테스트 시나리오를 만들어보세요.
-                      </p>
+                      <button
+                        type="button"
+                        onClick={onOpen}
+                        disabled={!projectId}
+                        className="bg-primary hover:bg-primary/90 typo-label-heading rounded-2 mt-5 inline-flex h-9 w-fit items-center justify-center gap-2 px-4 text-white transition-colors disabled:opacity-50"
+                      >
+                        <Plus className="h-4 w-4" />새 요구사항 분석
+                      </button>
                     </>
                   )}
+                </div>
+                <div className="border-line-2 bg-bg-1/60 flex flex-col justify-center gap-4 border-t px-6 py-8 lg:border-t-0 lg:border-l">
+                  <div>
+                    <p className="typo-label-heading text-text-2">권장 입력</p>
+                    <ul className="typo-label-normal text-text-4 mt-2 flex flex-col gap-1.5">
+                      <li>사용자 역할과 주요 행동</li>
+                      <li>정상 흐름과 예외 조건</li>
+                      <li>화면, API, 데이터 제약</li>
+                    </ul>
+                  </div>
+                  <div className="border-line-2 border-t pt-4">
+                    <p className="typo-label-heading text-text-2">생성 후 이동</p>
+                    <p className="typo-label-normal text-text-4 mt-1">
+                      분석 결과를 확인한 뒤 시나리오 관리에서 케이스와 스위트로 확장합니다.
+                    </p>
+                  </div>
                 </div>
               </div>
             ) : (

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -111,15 +111,14 @@ export const RequirementsView = () => {
   return (
     <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
       <header className="col-span-6 flex min-w-0 flex-col gap-1.5">
-        <p className="typo-caption text-primary">AI 요구사항 분석</p>
+        <p className="typo-caption text-primary">요구사항 정리</p>
         <h1 className="typo-title-heading text-text-1">요구사항 생성</h1>
         <p className="typo-body1-normal text-text-3 max-w-2xl">
-          요구사항을 입력하면 분석서, 기능 요구사항, 테스트 시나리오를 생성하고 후속 작업으로
-          연결합니다.
+          요구사항 문서를 정리하고 기능 단위 시나리오로 이어지는 작업 목록을 관리합니다.
         </p>
       </header>
 
-      <ActionToolbar.Root ariaLabel="요구사항 분석 컨트롤">
+      <ActionToolbar.Root ariaLabel="요구사항 정리 컨트롤">
         <ActionToolbar.Group>
           <ActionToolbar.Search
             placeholder="제목·요약으로 검색"
@@ -135,7 +134,7 @@ export const RequirementsView = () => {
           disabled={!projectId}
         >
           <Plus className="h-4 w-4" />
-          <span className="leading-none">새 요구사항 분석</span>
+          <span className="leading-none">새 요구사항 정리</span>
         </ActionToolbar.Action>
       </ActionToolbar.Root>
 
@@ -143,7 +142,7 @@ export const RequirementsView = () => {
         <div className="border-line-2 bg-bg-2 rounded-3 flex min-h-0 flex-col overflow-hidden border">
           <div className="border-line-2 flex items-center justify-between gap-4 border-b px-5 py-4">
             <div className="min-w-0">
-              <h2 className="typo-body1-heading text-text-1">요구사항 분석</h2>
+              <h2 className="typo-body1-heading text-text-1">요구사항 정리</h2>
               <p className="typo-label-normal text-text-3 mt-0.5">
                 {searchQuery.trim()
                   ? `검색 결과 ${analyses.length}개 / 전체 ${allAnalyses.length}개`
@@ -172,11 +171,11 @@ export const RequirementsView = () => {
                   ) : (
                     <>
                       <h3 className="typo-h2-heading text-text-1 mt-5">
-                        첫 요구사항 분석을 시작하세요.
+                        아직 정리된 요구사항이 없습니다.
                       </h3>
                       <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
-                        기능 설명, 정책 문서, 회의록을 입력하면 분석 결과와 테스트 시나리오로
-                        이어지는 작업 단위를 만듭니다.
+                        기능 설명이나 정책 문서를 등록하면 시나리오 설계에 필요한 기준을 남길 수
+                        있습니다.
                       </p>
                       <button
                         type="button"
@@ -184,14 +183,14 @@ export const RequirementsView = () => {
                         disabled={!projectId}
                         className="bg-primary hover:bg-primary/90 typo-label-heading rounded-2 mt-5 inline-flex h-9 w-fit items-center justify-center gap-2 px-4 text-white transition-colors disabled:opacity-50"
                       >
-                        <Plus className="h-4 w-4" />새 요구사항 분석
+                        <Plus className="h-4 w-4" />새 요구사항 정리
                       </button>
                     </>
                   )}
                 </div>
                 <div className="border-line-2 bg-bg-1/60 flex flex-col justify-center gap-4 border-t px-6 py-8 lg:border-t-0 lg:border-l">
                   <div>
-                    <p className="typo-label-heading text-text-2">권장 입력</p>
+                    <p className="typo-label-heading text-text-2">입력하면 좋은 내용</p>
                     <ul className="typo-label-normal text-text-4 mt-2 flex flex-col gap-1.5">
                       <li>사용자 역할과 주요 행동</li>
                       <li>정상 흐름과 예외 조건</li>
@@ -199,9 +198,9 @@ export const RequirementsView = () => {
                     </ul>
                   </div>
                   <div className="border-line-2 border-t pt-4">
-                    <p className="typo-label-heading text-text-2">생성 후 이동</p>
+                    <p className="typo-label-heading text-text-2">연결되는 작업</p>
                     <p className="typo-label-normal text-text-4 mt-1">
-                      분석 결과를 확인한 뒤 시나리오 관리에서 케이스와 스위트로 확장합니다.
+                      정리한 요구사항은 시나리오 관리와 테스트 스위트 작성의 기준으로 사용됩니다.
                     </p>
                   </div>
                 </div>
@@ -209,7 +208,7 @@ export const RequirementsView = () => {
             ) : (
               <div className="min-h-full">
                 <div className="border-line-2 text-text-4 grid grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] gap-4 border-b px-5 py-2.5 text-xs max-lg:hidden">
-                  <span>분석 결과</span>
+                  <span>항목</span>
                   <span>요구사항</span>
                   <span>시나리오</span>
                   <span>생성일</span>
@@ -272,12 +271,12 @@ export const RequirementsView = () => {
 
         <aside className="hidden min-h-0 flex-col gap-4 lg:flex">
           <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
-            <h2 className="typo-body1-heading text-text-1">작업 흐름</h2>
+            <h2 className="typo-body1-heading text-text-1">검토 기준</h2>
             <ol className="mt-4 flex flex-col gap-3">
               {[
-                ['1', '요구사항 입력', '문서나 기능 설명을 분석합니다.'],
-                ['2', '시나리오 검토', '생성된 시나리오를 기능별로 정리합니다.'],
-                ['3', '스위트 저장', '실행 가능한 테스트 묶음으로 전환합니다.'],
+                ['1', '범위', '기능에 포함되는 동작과 제외할 동작을 나눕니다.'],
+                ['2', '예외', '실패 조건과 빈 값, 권한 차이를 확인합니다.'],
+                ['3', '검증', '시나리오와 스위트로 옮길 기준을 남깁니다.'],
               ].map(([step, title, desc]) => (
                 <li key={step} className="flex gap-3">
                   <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
@@ -295,11 +294,11 @@ export const RequirementsView = () => {
           <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
             <div className="flex items-center gap-2">
               <Languages className="text-text-3 h-4 w-4" />
-              <h2 className="typo-body1-heading text-text-1">언어 구성</h2>
+              <h2 className="typo-body1-heading text-text-1">문서 언어</h2>
             </div>
             <div className="mt-4 flex flex-col gap-2">
               {Object.keys(languageCount).length === 0 ? (
-                <p className="typo-label-normal text-text-4">아직 분석서가 없습니다.</p>
+                <p className="typo-label-normal text-text-4">아직 정리된 문서가 없습니다.</p>
               ) : (
                 Object.entries(languageCount).map(([language, count]) => (
                   <div key={language} className="flex items-center justify-between gap-3">
@@ -314,18 +313,18 @@ export const RequirementsView = () => {
           </div>
 
           <div className="border-primary/20 bg-primary/5 rounded-3 border p-4">
-            <h2 className="typo-body1-heading text-text-1">다음 추천 작업</h2>
+            <h2 className="typo-body1-heading text-text-1">최근 작업</h2>
             <p className="typo-body2-normal text-text-3 mt-2">
               {latestAnalysis
-                ? `${latestAnalysis.title} 분석서의 시나리오를 확인하고 테스트 스위트로 저장하세요.`
-                : '첫 요구사항 분석서를 생성해 테스트 설계 흐름을 시작하세요.'}
+                ? `${latestAnalysis.title} 항목에서 이어진 시나리오를 확인하세요.`
+                : '요구사항을 먼저 정리하면 시나리오 작성으로 이어갈 수 있습니다.'}
             </p>
             {latestAnalysis ? (
               <Link
                 href={`/projects/${slug}/scenarios/${latestAnalysis.id}`}
                 className="typo-label-heading text-primary mt-3 inline-flex"
               >
-                최신 분석서 열기
+                최근 항목 열기
               </Link>
             ) : (
               <button
@@ -334,7 +333,7 @@ export const RequirementsView = () => {
                 disabled={!projectId}
                 className="typo-label-heading text-primary mt-3 inline-flex disabled:opacity-50"
               >
-                새 분석 시작
+                새 요구사항 정리
               </button>
             )}
           </div>

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -32,19 +32,6 @@ const LANGUAGE_LABEL: Record<string, string> = {
 const formatDate = (iso: string) =>
   new Date(iso).toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
 
-const statItems = (analyses: RequirementAnalysisListItem[]) => {
-  const functionalCount = analyses.reduce((sum, item) => sum + item.functionalCount, 0);
-  const scenarioCount = analyses.reduce((sum, item) => sum + item.scenarioCount, 0);
-  const savedSuiteCount = analyses.reduce((sum, item) => sum + item.savedSuiteCount, 0);
-
-  return [
-    { label: '분석서', value: analyses.length, icon: FileText },
-    { label: '기능 요구사항', value: functionalCount, icon: ListChecks },
-    { label: '시나리오', value: scenarioCount, icon: FolderTree },
-    { label: '저장된 스위트', value: savedSuiteCount, icon: Sparkles },
-  ];
-};
-
 export const RequirementsView = () => {
   const params = useParams();
   const slug = params.slug as string;
@@ -85,7 +72,6 @@ export const RequirementsView = () => {
     );
   }, [allAnalyses, searchQuery]);
 
-  const stats = useMemo(() => statItems(allAnalyses), [allAnalyses]);
   const latestAnalysis = allAnalyses[0];
   const languageCount = useMemo(
     () =>
@@ -124,29 +110,13 @@ export const RequirementsView = () => {
 
   return (
     <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
-      <header className="col-span-6 grid gap-5 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-        <div className="flex min-w-0 flex-col gap-1.5">
-          <p className="typo-caption text-primary">AI 요구사항 분석</p>
-          <h1 className="typo-title-heading text-text-1">요구사항 생성</h1>
-          <p className="typo-body1-normal text-text-3 max-w-2xl">
-            요구사항을 입력하면 분석서, 기능 요구사항, 테스트 시나리오를 생성하고 후속 작업으로
-            연결합니다.
-          </p>
-        </div>
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:w-[30rem]">
-          {stats.map((item) => {
-            const Icon = item.icon;
-            return (
-              <div key={item.label} className="border-line-2 bg-bg-2 rounded-3 border px-3 py-2.5">
-                <div className="text-text-3 flex items-center gap-1.5">
-                  <Icon className="h-3.5 w-3.5" />
-                  <span className="typo-caption truncate">{item.label}</span>
-                </div>
-                <p className="typo-h3-heading text-text-1 mt-1">{item.value}</p>
-              </div>
-            );
-          })}
-        </div>
+      <header className="col-span-6 flex min-w-0 flex-col gap-1.5">
+        <p className="typo-caption text-primary">AI 요구사항 분석</p>
+        <h1 className="typo-title-heading text-text-1">요구사항 생성</h1>
+        <p className="typo-body1-normal text-text-3 max-w-2xl">
+          요구사항을 입력하면 분석서, 기능 요구사항, 테스트 시나리오를 생성하고 후속 작업으로
+          연결합니다.
+        </p>
       </header>
 
       <ActionToolbar.Root ariaLabel="요구사항 분석 컨트롤">

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -140,9 +140,9 @@ export const RequirementsView = () => {
       </ActionToolbar.Root>
 
       <section className="col-span-6 grid min-h-0 gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
-        <div className="flex min-h-0 flex-col">
-          <div className="border-line-2 bg-bg-2 rounded-3 mb-3 flex items-center justify-between border px-4 py-3">
-            <div>
+        <div className="border-line-2 bg-bg-2 rounded-3 flex min-h-0 flex-col overflow-hidden border">
+          <div className="border-line-2 flex items-center justify-between gap-4 border-b px-5 py-4">
+            <div className="min-w-0">
               <h2 className="typo-body1-heading text-text-1">요구사항 분석</h2>
               <p className="typo-label-normal text-text-3 mt-0.5">
                 {searchQuery.trim()
@@ -150,12 +150,14 @@ export const RequirementsView = () => {
                   : `전체 ${allAnalyses.length}개 분석`}
               </p>
             </div>
-            <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-1">최신순</span>
+            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+              최신순
+            </span>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+          <div className="min-h-0 flex-1 overflow-y-auto">
             {analyses.length === 0 ? (
-              <div className="border-line-2 bg-bg-2 rounded-3 grid h-full min-h-[360px] overflow-hidden border lg:grid-cols-[minmax(0,1fr)_18rem]">
+              <div className="grid h-full min-h-[360px] overflow-hidden lg:grid-cols-[minmax(0,1fr)_18rem]">
                 <div className="flex min-w-0 flex-col justify-center px-8 py-10">
                   <div className="bg-bg-3 text-primary border-line-2 rounded-3 flex h-11 w-11 items-center justify-center border">
                     <FileSearch className="h-5 w-5" strokeWidth={1.7} />
@@ -205,7 +207,7 @@ export const RequirementsView = () => {
                 </div>
               </div>
             ) : (
-              <div className="border-line-2 bg-bg-2 rounded-3 overflow-hidden border">
+              <div className="min-h-full">
                 <div className="border-line-2 text-text-4 grid grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] gap-4 border-b px-5 py-2.5 text-xs max-lg:hidden">
                   <span>분석 결과</span>
                   <span>요구사항</span>

--- a/apps/web/src/view/project/requirements/requirements-view.tsx
+++ b/apps/web/src/view/project/requirements/requirements-view.tsx
@@ -153,7 +153,7 @@ export const RequirementsView = () => {
             <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-1">최신순</span>
           </div>
 
-          <div className="flex flex-1 flex-col gap-3 overflow-y-auto pr-1">
+          <div className="min-h-0 flex-1 overflow-y-auto pr-1">
             {analyses.length === 0 ? (
               <div className="rounded-3 border-line-2 bg-bg-2/50 flex h-full min-h-[320px] flex-col items-center justify-center gap-4 border-2 border-dashed py-20 text-center">
                 <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
@@ -180,55 +180,65 @@ export const RequirementsView = () => {
                 </div>
               </div>
             ) : (
-              analyses.map((a) => (
-                <Link
-                  key={a.id}
-                  href={`/projects/${slug}/scenarios/${a.id}`}
-                  className="group rounded-3 border-line-2 bg-bg-2 hover:border-primary/40 hover:bg-bg-3 flex flex-col gap-3 border px-5 py-4 transition-colors"
-                >
-                  <div className="flex items-start gap-4">
-                    <div className="bg-bg-3 text-primary border-line-2 rounded-3 flex h-10 w-10 shrink-0 items-center justify-center border">
-                      <FileText className="h-5 w-5" strokeWidth={1.8} />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <h3 className="typo-body1-heading text-text-1 group-hover:text-primary truncate">
-                          {a.title}
-                        </h3>
-                        <span className="typo-caption bg-bg-3 text-text-3 rounded-full px-2 py-0.5">
-                          {LANGUAGE_LABEL[a.language] ?? a.language}
-                        </span>
+              <div className="border-line-2 bg-bg-2 rounded-3 overflow-hidden border">
+                <div className="border-line-2 text-text-4 grid grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] gap-4 border-b px-5 py-2.5 text-xs max-lg:hidden">
+                  <span>분석 결과</span>
+                  <span>요구사항</span>
+                  <span>시나리오</span>
+                  <span>생성일</span>
+                </div>
+                <div className="divide-line-2 divide-y">
+                  {analyses.map((a) => (
+                    <Link
+                      key={a.id}
+                      href={`/projects/${slug}/scenarios/${a.id}`}
+                      className="group hover:bg-bg-3 grid gap-3 px-5 py-4 transition-colors lg:grid-cols-[minmax(0,1fr)_8rem_8rem_8rem] lg:items-center lg:gap-4"
+                    >
+                      <div className="min-w-0">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <FileText
+                            className="text-primary h-4 w-4 shrink-0"
+                            strokeWidth={1.8}
+                            aria-hidden="true"
+                          />
+                          <h3 className="typo-body1-heading text-text-1 group-hover:text-primary truncate">
+                            {a.title}
+                          </h3>
+                          <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-0.5">
+                            {LANGUAGE_LABEL[a.language] ?? a.language}
+                          </span>
+                        </div>
+                        {a.summary && (
+                          <p className="typo-body2-normal text-text-3 mt-1.5 line-clamp-2 whitespace-pre-line lg:line-clamp-1">
+                            {a.summary}
+                          </p>
+                        )}
+                        <div className="text-text-4 mt-2 flex flex-wrap gap-x-3 gap-y-1 lg:hidden">
+                          <span className="typo-label-normal">
+                            기능 요구사항 {a.functionalCount}
+                          </span>
+                          <span className="typo-label-normal">시나리오 {a.scenarioCount}</span>
+                          <span className="typo-label-normal">
+                            스위트 {a.savedSuiteCount}개 저장
+                          </span>
+                          <span className="typo-label-normal">{formatDate(a.createdAt)}</span>
+                        </div>
                       </div>
-                      {a.summary && (
-                        <p className="typo-body2-normal text-text-3 mt-1.5 line-clamp-2 whitespace-pre-line">
-                          {a.summary}
-                        </p>
-                      )}
-                    </div>
-                    <span className="typo-label-normal text-text-4 hidden shrink-0 sm:block">
-                      {formatDate(a.createdAt)}
-                    </span>
-                  </div>
-                  <div className="text-text-3 flex flex-wrap items-center gap-x-4 gap-y-2 pl-14">
-                    <span className="typo-label-normal flex items-center gap-1.5">
-                      <ListChecks className="h-3.5 w-3.5" />
-                      기능 요구사항 {a.functionalCount}
-                    </span>
-                    <span className="typo-label-normal flex items-center gap-1.5">
-                      <FolderTree className="h-3.5 w-3.5" />
-                      시나리오 {a.scenarioCount}
-                    </span>
-                    <span className="typo-label-normal flex items-center gap-1.5">
-                      <Sparkles className="h-3.5 w-3.5" />
-                      스위트 {a.savedSuiteCount}개 저장
-                    </span>
-                    <span className="typo-label-normal text-text-4 flex items-center gap-1.5 sm:hidden">
-                      <CalendarDays className="h-3.5 w-3.5" />
-                      {formatDate(a.createdAt)}
-                    </span>
-                  </div>
-                </Link>
-              ))
+                      <span className="typo-label-normal text-text-3 hidden lg:flex lg:items-center lg:gap-1.5">
+                        <ListChecks className="h-3.5 w-3.5" aria-hidden="true" />
+                        {a.functionalCount}
+                      </span>
+                      <span className="typo-label-normal text-text-3 hidden lg:flex lg:items-center lg:gap-1.5">
+                        <FolderTree className="h-3.5 w-3.5" aria-hidden="true" />
+                        {a.scenarioCount}
+                      </span>
+                      <span className="typo-label-normal text-text-4 hidden lg:block">
+                        {formatDate(a.createdAt)}
+                      </span>
+                    </Link>
+                  ))}
+                </div>
+              </div>
             )}
           </div>
         </div>

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -16,11 +16,14 @@ import { ActionToolbar } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useDisclosure } from '@testea/lib';
 import { MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
-import { FolderTree, ListChecks, Plus, Sparkles } from 'lucide-react';
+import { CalendarDays, FileText, FolderTree, ListChecks, Plus, Sparkles } from 'lucide-react';
 
 import { NewFeatureModal } from './_components/new-feature-modal';
 
 const STATUS_ORDER = ['CONFIRMED', 'REVIEW', 'DRAFT'] as const;
+
+const formatDate = (iso: string | null) =>
+  iso ? new Date(iso).toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' }) : '수동';
 
 export const ScenarioFeaturesView = () => {
   const params = useParams();
@@ -52,28 +55,47 @@ export const ScenarioFeaturesView = () => {
     enabled: !!projectId,
   });
 
+  const allFeatures = useMemo<ScenarioFeatureListItem[]>(
+    () => (featuresData?.success ? featuresData.data : []),
+    [featuresData]
+  );
+
   const features = useMemo<ScenarioFeatureListItem[]>(() => {
-    if (!featuresData?.success) return [];
-    const items = featuresData.data;
     const q = searchQuery.trim().toLowerCase();
-    if (!q) return items;
-    return items.filter((f) => f.title.toLowerCase().includes(q));
-  }, [featuresData, searchQuery]);
+    if (!q) return allFeatures;
+    return allFeatures.filter(
+      (f) => f.title.toLowerCase().includes(q) || f.summary.toLowerCase().includes(q)
+    );
+  }, [allFeatures, searchQuery]);
+
+  const statusTotals = useMemo(
+    () =>
+      STATUS_ORDER.map((status) => ({
+        status,
+        count: allFeatures.reduce((sum, feature) => sum + feature.statusCounts[status], 0),
+      })),
+    [allFeatures]
+  );
+  const totalScenarioCount = allFeatures.reduce((sum, feature) => sum + feature.scenarioCount, 0);
+  const latestFeature = allFeatures.find((feature) => !feature.isManual) ?? allFeatures[0];
 
   const hrefFor = (f: ScenarioFeatureListItem) =>
     `/projects/${slug}/scenarios/${f.isManual ? 'manual' : f.id}`;
 
   if (!hydrated || isLoadingProject || isLoadingFeatures) {
     return (
-      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1200px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
+      <MainContainer className="mx-auto grid min-h-screen w-full max-w-[1280px] flex-1 grid-cols-6 content-start gap-x-5 gap-y-8 px-10 py-8">
         <header className="col-span-6 flex flex-col gap-2">
           <Skeleton className="h-8 w-64" />
           <Skeleton className="h-5 w-96" />
         </header>
-        <div className="col-span-6 flex flex-col gap-3">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="rounded-3 h-24 w-full" />
-          ))}
+        <div className="col-span-6 grid gap-4 lg:grid-cols-[minmax(0,1fr)_20rem]">
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="rounded-3 h-24 w-full" />
+            ))}
+          </div>
+          <Skeleton className="rounded-3 hidden h-72 w-full lg:block" />
         </div>
       </MainContainer>
     );
@@ -87,18 +109,20 @@ export const ScenarioFeaturesView = () => {
   }
 
   return (
-    <MainContainer className="mx-auto grid h-screen w-full max-w-[1200px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-4 overflow-hidden px-10 py-8">
-      <header className="col-span-6 flex flex-col gap-1">
-        <h1 className="typo-title-heading">시나리오 관리</h1>
-        <p className="typo-body1-normal text-text-3">
-          기능(요구사항)별로 테스트 시나리오를 작성·관리합니다. 기능을 선택해 시나리오를 추가하세요.
+    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
+      <header className="col-span-6 flex flex-col gap-1.5">
+        <p className="typo-caption text-primary">테스트 설계</p>
+        <h1 className="typo-title-heading text-text-1">시나리오 관리</h1>
+        <p className="typo-body1-normal text-text-3 max-w-2xl">
+          기능 단위로 테스트 시나리오를 검토하고 상태를 정리합니다. 기능을 선택하면 상세 시나리오
+          목록으로 이동합니다.
         </p>
       </header>
 
       <ActionToolbar.Root ariaLabel="기능 목록 컨트롤">
         <ActionToolbar.Group>
           <ActionToolbar.Search
-            placeholder="기능 이름으로 검색"
+            placeholder="기능 이름·요약으로 검색"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
@@ -127,69 +151,220 @@ export const ScenarioFeaturesView = () => {
         </div>
       </ActionToolbar.Root>
 
-      <section className="col-span-6 flex min-h-0 flex-col">
-        <div className="flex flex-1 flex-col gap-3 overflow-y-auto">
-          {features.length === 0 ? (
-            <div className="rounded-3 border-line-2 bg-bg-2/50 flex h-full flex-col items-center justify-center gap-4 border-2 border-dashed py-20 text-center">
-              <div className="bg-bg-3 text-text-3 flex h-12 w-12 items-center justify-center rounded-full">
-                <FolderTree className="h-6 w-6" strokeWidth={1.5} />
-              </div>
-              <div className="flex flex-col gap-1">
-                {searchQuery.trim() ? (
-                  <>
-                    <p className="typo-h3-heading text-text-1">검색 결과가 없습니다.</p>
-                    <p className="typo-body2-normal text-text-3">다른 키워드로 검색해보세요.</p>
-                  </>
-                ) : (
-                  <>
-                    <p className="typo-h3-heading text-text-1">아직 기능이 없습니다.</p>
-                    <p className="typo-body2-normal text-text-3">
-                      새 기능을 만들거나 AI 요구사항 분석으로 시작해보세요.
-                    </p>
-                  </>
-                )}
-              </div>
+      <section className="col-span-6 grid min-h-0 gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="border-line-2 bg-bg-2 rounded-3 flex min-h-0 flex-col overflow-hidden border">
+          <div className="border-line-2 flex items-center justify-between gap-4 border-b px-5 py-4">
+            <div className="min-w-0">
+              <h2 className="typo-body1-heading text-text-1">기능별 시나리오</h2>
+              <p className="typo-label-normal text-text-3 mt-0.5">
+                {searchQuery.trim()
+                  ? `검색 결과 ${features.length}개 / 전체 ${allFeatures.length}개`
+                  : `전체 ${allFeatures.length}개 기능 · 시나리오 ${totalScenarioCount}개`}
+              </p>
             </div>
-          ) : (
-            features.map((f) => (
-              <Link
-                key={f.id ?? 'manual'}
-                href={hrefFor(f)}
-                className="rounded-3 border-line-2 bg-bg-2 hover:border-primary/40 flex flex-col gap-2.5 border px-5 py-4 transition-colors"
-              >
-                <div className="flex items-start gap-3">
-                  <div className="min-w-0 flex-1">
-                    <h3 className="typo-body1-heading text-text-1 truncate">{f.title}</h3>
-                    {f.summary && (
-                      <p className="typo-body2-normal text-text-3 mt-1 line-clamp-2 whitespace-pre-line">
-                        {f.summary}
-                      </p>
-                    )}
+            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+              상태별 관리
+            </span>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {features.length === 0 ? (
+              <div className="grid h-full min-h-[360px] overflow-hidden lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <div className="flex min-w-0 flex-col justify-center px-8 py-10">
+                  <div className="bg-bg-3 text-primary border-line-2 rounded-3 flex h-11 w-11 items-center justify-center border">
+                    <FolderTree className="h-5 w-5" strokeWidth={1.7} />
                   </div>
-                  {f.isManual && (
-                    <span className="typo-caption text-text-4 bg-bg-3 shrink-0 rounded-full px-2 py-0.5">
-                      수동
-                    </span>
+                  {searchQuery.trim() ? (
+                    <>
+                      <h3 className="typo-h2-heading text-text-1 mt-5">검색 결과가 없습니다.</h3>
+                      <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
+                        기능 이름이나 요약에 포함된 다른 키워드로 다시 검색해보세요.
+                      </p>
+                    </>
+                  ) : (
+                    <>
+                      <h3 className="typo-h2-heading text-text-1 mt-5">
+                        첫 기능을 만들고 시나리오를 정리하세요.
+                      </h3>
+                      <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
+                        직접 기능을 만들거나 AI 요구사항 분석에서 기능과 시나리오를 생성할 수
+                        있습니다.
+                      </p>
+                      <div className="mt-5 flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          onClick={onNewOpen}
+                          disabled={!projectId}
+                          className="bg-primary hover:bg-primary/90 typo-label-heading rounded-2 inline-flex h-9 items-center justify-center gap-2 px-4 text-white transition-colors disabled:opacity-50"
+                        >
+                          <Plus className="h-4 w-4" />새 기능
+                        </button>
+                        <button
+                          type="button"
+                          onClick={onAiOpen}
+                          disabled={!projectId}
+                          className="border-line-2 bg-bg-3 hover:bg-bg-1 typo-label-heading text-text-2 rounded-2 inline-flex h-9 items-center justify-center gap-2 border px-4 transition-colors disabled:opacity-50"
+                        >
+                          <Sparkles className="h-4 w-4" />
+                          AI 분석
+                        </button>
+                      </div>
+                    </>
                   )}
                 </div>
-                <div className="text-text-3 flex flex-wrap items-center gap-3">
-                  <span className="typo-label-normal flex items-center gap-1.5">
-                    <ListChecks className="h-3.5 w-3.5" />
-                    시나리오 {f.scenarioCount}개
-                  </span>
-                  {STATUS_ORDER.filter((s) => f.statusCounts[s] > 0).map((s) => (
-                    <span
-                      key={s}
-                      className={`typo-caption rounded-full px-2 py-0.5 ${SCENARIO_STATUS_META[s].cls}`}
+                <div className="border-line-2 bg-bg-1/60 flex flex-col justify-center gap-4 border-t px-6 py-8 lg:border-t-0 lg:border-l">
+                  <div>
+                    <p className="typo-label-heading text-text-2">관리 기준</p>
+                    <ul className="typo-label-normal text-text-4 mt-2 flex flex-col gap-1.5">
+                      <li>기능별 시나리오 묶음</li>
+                      <li>초안·검토·확정 상태</li>
+                      <li>스위트 저장 전 검토 흐름</li>
+                    </ul>
+                  </div>
+                  <div className="border-line-2 border-t pt-4">
+                    <p className="typo-label-heading text-text-2">다음 단계</p>
+                    <p className="typo-label-normal text-text-4 mt-1">
+                      기능을 선택해 시나리오를 보강한 뒤 테스트 스위트로 저장합니다.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="min-h-full">
+                <div className="border-line-2 text-text-4 grid grid-cols-[minmax(0,1fr)_7rem_12rem_6rem] gap-4 border-b px-5 py-2.5 text-xs max-lg:hidden">
+                  <span>기능</span>
+                  <span>시나리오</span>
+                  <span>상태</span>
+                  <span>생성</span>
+                </div>
+                <div className="divide-line-2 divide-y">
+                  {features.map((f) => (
+                    <Link
+                      key={f.id ?? 'manual'}
+                      href={hrefFor(f)}
+                      className="group hover:bg-bg-3 grid gap-3 px-5 py-4 transition-colors lg:grid-cols-[minmax(0,1fr)_7rem_12rem_6rem] lg:items-center lg:gap-4"
                     >
-                      {SCENARIO_STATUS_META[s].label} {f.statusCounts[s]}
-                    </span>
+                      <div className="min-w-0">
+                        <div className="flex min-w-0 items-center gap-2">
+                          <FileText
+                            className="text-primary h-4 w-4 shrink-0"
+                            strokeWidth={1.8}
+                            aria-hidden="true"
+                          />
+                          <h3 className="typo-body1-heading text-text-1 group-hover:text-primary truncate">
+                            {f.title}
+                          </h3>
+                          {f.isManual && (
+                            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-0.5">
+                              수동
+                            </span>
+                          )}
+                        </div>
+                        {f.summary && (
+                          <p className="typo-body2-normal text-text-3 mt-1.5 line-clamp-2 whitespace-pre-line lg:line-clamp-1">
+                            {f.summary}
+                          </p>
+                        )}
+                        <div className="text-text-4 mt-2 flex flex-wrap gap-x-3 gap-y-1 lg:hidden">
+                          <span className="typo-label-normal">시나리오 {f.scenarioCount}개</span>
+                          {STATUS_ORDER.filter((s) => f.statusCounts[s] > 0).map((s) => (
+                            <span key={s} className="typo-label-normal">
+                              {SCENARIO_STATUS_META[s].label} {f.statusCounts[s]}
+                            </span>
+                          ))}
+                          <span className="typo-label-normal">{formatDate(f.createdAt)}</span>
+                        </div>
+                      </div>
+                      <span className="typo-label-normal text-text-3 hidden lg:flex lg:items-center lg:gap-1.5">
+                        <ListChecks className="h-3.5 w-3.5" aria-hidden="true" />
+                        {f.scenarioCount}
+                      </span>
+                      <div className="hidden flex-wrap gap-1.5 lg:flex">
+                        {STATUS_ORDER.filter((s) => f.statusCounts[s] > 0).map((s) => (
+                          <span
+                            key={s}
+                            className={`typo-caption rounded-full px-2 py-0.5 ${SCENARIO_STATUS_META[s].cls}`}
+                          >
+                            {SCENARIO_STATUS_META[s].label} {f.statusCounts[s]}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="typo-label-normal text-text-4 hidden lg:flex lg:items-center lg:gap-1.5">
+                        <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+                        {formatDate(f.createdAt)}
+                      </span>
+                    </Link>
                   ))}
                 </div>
-              </Link>
-            ))
-          )}
+              </div>
+            )}
+          </div>
         </div>
+
+        <aside className="hidden min-h-0 flex-col gap-4 lg:flex">
+          <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
+            <h2 className="typo-body1-heading text-text-1">상태 요약</h2>
+            <div className="mt-4 flex flex-col gap-2">
+              {statusTotals.map(({ status, count }) => (
+                <div key={status} className="flex items-center justify-between gap-3">
+                  <span
+                    className={`typo-caption rounded-full px-2 py-0.5 ${SCENARIO_STATUS_META[status].cls}`}
+                  >
+                    {SCENARIO_STATUS_META[status].label}
+                  </span>
+                  <span className="typo-label-heading text-text-1">{count}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
+            <h2 className="typo-body1-heading text-text-1">작업 흐름</h2>
+            <ol className="mt-4 flex flex-col gap-3">
+              {[
+                ['1', '기능 선택', '요구사항 단위로 시나리오를 묶습니다.'],
+                ['2', '상태 정리', '초안·검토·확정 상태를 관리합니다.'],
+                ['3', '스위트 저장', '검증할 시나리오를 실행 묶음으로 전환합니다.'],
+              ].map(([step, title, desc]) => (
+                <li key={step} className="flex gap-3">
+                  <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
+                    {step}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="typo-label-heading text-text-2 block">{title}</span>
+                    <span className="typo-label-normal text-text-4 mt-0.5 block">{desc}</span>
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          <div className="border-primary/20 bg-primary/5 rounded-3 border p-4">
+            <h2 className="typo-body1-heading text-text-1">다음 추천 작업</h2>
+            <p className="typo-body2-normal text-text-3 mt-2">
+              {latestFeature
+                ? `${latestFeature.title} 기능의 시나리오를 검토하고 확정 상태로 정리하세요.`
+                : '첫 기능을 만들고 테스트 시나리오를 추가하세요.'}
+            </p>
+            {latestFeature ? (
+              <Link
+                href={hrefFor(latestFeature)}
+                className="typo-label-heading text-primary mt-3 inline-flex"
+              >
+                기능 열기
+              </Link>
+            ) : (
+              <button
+                type="button"
+                onClick={onNewOpen}
+                disabled={!projectId}
+                className="typo-label-heading text-primary mt-3 inline-flex disabled:opacity-50"
+              >
+                새 기능 만들기
+              </button>
+            )}
+          </div>
+        </aside>
       </section>
 
       {isNewOpen && projectId && (

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -161,7 +161,7 @@ export const ScenarioFeaturesView = () => {
                     : `전체 ${allFeatures.length}개 기능 · 시나리오 ${totalScenarioCount}개`}
                 </p>
               </div>
-              <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+              <span className="typo-caption bg-bg-3 text-text-3 rounded-2 shrink-0 px-2 py-1">
                 상태별 관리
               </span>
             </div>
@@ -174,7 +174,7 @@ export const ScenarioFeaturesView = () => {
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
                 placeholder="기능 이름·요약으로 검색"
-                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary h-9 w-full rounded-full border px-9 transition-colors outline-none"
+                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary rounded-2 h-9 w-full border px-9 transition-colors outline-none"
               />
             </div>
           </div>
@@ -267,7 +267,7 @@ export const ScenarioFeaturesView = () => {
                             {f.title}
                           </h3>
                           {f.isManual && (
-                            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-0.5">
+                            <span className="typo-caption bg-bg-3 text-text-3 rounded-2 shrink-0 px-2 py-0.5">
                               수동
                             </span>
                           )}
@@ -295,7 +295,7 @@ export const ScenarioFeaturesView = () => {
                         {STATUS_ORDER.filter((s) => f.statusCounts[s] > 0).map((s) => (
                           <span
                             key={s}
-                            className={`typo-caption rounded-full px-2 py-0.5 ${SCENARIO_STATUS_META[s].cls}`}
+                            className={`typo-caption rounded-2 px-2 py-0.5 ${SCENARIO_STATUS_META[s].cls}`}
                           >
                             {SCENARIO_STATUS_META[s].label} {f.statusCounts[s]}
                           </span>
@@ -320,7 +320,7 @@ export const ScenarioFeaturesView = () => {
               {statusTotals.map(({ status, count }) => (
                 <div key={status} className="flex items-center justify-between gap-3">
                   <span
-                    className={`typo-caption rounded-full px-2 py-0.5 ${SCENARIO_STATUS_META[status].cls}`}
+                    className={`typo-caption rounded-2 px-2 py-0.5 ${SCENARIO_STATUS_META[status].cls}`}
                   >
                     {SCENARIO_STATUS_META[status].label}
                   </span>
@@ -339,7 +339,7 @@ export const ScenarioFeaturesView = () => {
                 ['3', '실행', '스위트에 넣을 시나리오만 남깁니다.'],
               ].map(([step, title, desc]) => (
                 <li key={step} className="flex gap-3">
-                  <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
+                  <span className="bg-bg-3 text-text-2 rounded-2 flex h-6 w-6 shrink-0 items-center justify-center text-xs">
                     {step}
                   </span>
                   <span className="min-w-0">

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -12,11 +12,18 @@ import {
 } from '@/entities/test-scenario';
 import { RequirementAnalysisModal } from '@/features/ai-requirement-analysis';
 import { SCENARIO_STATUS_META } from '@/features/scenario-management';
-import { ActionToolbar } from '@/widgets';
 import { useQuery } from '@tanstack/react-query';
 import { useDisclosure } from '@testea/lib';
-import { MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
-import { CalendarDays, FileText, FolderTree, ListChecks, Plus, Sparkles } from 'lucide-react';
+import { DSButton, MainContainer, ProjectErrorFallback, Skeleton } from '@testea/ui';
+import {
+  CalendarDays,
+  FileText,
+  FolderTree,
+  ListChecks,
+  Plus,
+  Search,
+  Sparkles,
+} from 'lucide-react';
 
 import { NewFeatureModal } from './_components/new-feature-modal';
 
@@ -109,25 +116,17 @@ export const ScenarioFeaturesView = () => {
   }
 
   return (
-    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
-      <header className="col-span-6 flex flex-col gap-1.5">
-        <p className="typo-caption text-primary">시나리오</p>
-        <h1 className="typo-title-heading text-text-1">시나리오 관리</h1>
-        <p className="typo-body1-normal text-text-3 max-w-2xl">
-          기능별 시나리오와 상태를 확인하고 테스트 스위트로 넘길 항목을 정리합니다.
-        </p>
-      </header>
-
-      <ActionToolbar.Root ariaLabel="기능 목록 컨트롤">
-        <ActionToolbar.Group>
-          <ActionToolbar.Search
-            placeholder="기능 이름·요약으로 검색"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-          />
-        </ActionToolbar.Group>
+    <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
+      <header className="col-span-6 flex min-w-0 flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="typo-caption text-primary">시나리오</p>
+          <h1 className="typo-title-heading text-text-1 mt-1">시나리오 관리</h1>
+          <p className="typo-body1-normal text-text-3 mt-1.5 max-w-2xl">
+            기능별 시나리오와 상태를 확인하고 테스트 스위트로 넘길 항목을 정리합니다.
+          </p>
+        </div>
         <div className="flex shrink-0 items-center gap-2">
-          <ActionToolbar.Action
+          <DSButton
             size="small"
             type="button"
             variant="ghost"
@@ -136,8 +135,8 @@ export const ScenarioFeaturesView = () => {
           >
             <Sparkles className="h-4 w-4" />
             <span className="leading-none">요구사항 정리</span>
-          </ActionToolbar.Action>
-          <ActionToolbar.Action
+          </DSButton>
+          <DSButton
             size="small"
             type="button"
             variant="solid"
@@ -146,24 +145,38 @@ export const ScenarioFeaturesView = () => {
           >
             <Plus className="h-4 w-4" />
             <span className="leading-none">새 기능</span>
-          </ActionToolbar.Action>
+          </DSButton>
         </div>
-      </ActionToolbar.Root>
+      </header>
 
       <section className="col-span-6 grid min-h-0 gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
         <div className="border-line-2 bg-bg-2 rounded-3 flex min-h-0 flex-col overflow-hidden border">
-          <div className="border-line-2 flex items-center justify-between gap-4 border-b px-5 py-4">
-            <div className="min-w-0">
-              <h2 className="typo-body1-heading text-text-1">기능별 시나리오</h2>
-              <p className="typo-label-normal text-text-3 mt-0.5">
-                {searchQuery.trim()
-                  ? `검색 결과 ${features.length}개 / 전체 ${allFeatures.length}개`
-                  : `전체 ${allFeatures.length}개 기능 · 시나리오 ${totalScenarioCount}개`}
-              </p>
+          <div className="border-line-2 flex flex-col gap-3 border-b px-5 py-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h2 className="typo-body1-heading text-text-1">기능별 시나리오</h2>
+                <p className="typo-label-normal text-text-3 mt-0.5">
+                  {searchQuery.trim()
+                    ? `검색 결과 ${features.length}개 / 전체 ${allFeatures.length}개`
+                    : `전체 ${allFeatures.length}개 기능 · 시나리오 ${totalScenarioCount}개`}
+                </p>
+              </div>
+              <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
+                상태별 관리
+              </span>
             </div>
-            <span className="typo-caption bg-bg-3 text-text-3 shrink-0 rounded-full px-2 py-1">
-              상태별 관리
-            </span>
+            <div className="relative w-full max-w-2xl lg:max-w-3xl">
+              <Search
+                className="text-text-4 pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
+                aria-hidden="true"
+              />
+              <input
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="기능 이름·요약으로 검색"
+                className="border-line-2 bg-bg-1 typo-body2-normal text-text-1 placeholder:text-text-4 focus:border-primary h-9 w-full rounded-full border px-9 transition-colors outline-none"
+              />
+            </div>
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/web/src/view/project/scenarios/scenarios-view.tsx
+++ b/apps/web/src/view/project/scenarios/scenarios-view.tsx
@@ -111,11 +111,10 @@ export const ScenarioFeaturesView = () => {
   return (
     <MainContainer className="mx-auto grid h-screen w-full max-w-[1280px] flex-1 grid-cols-6 grid-rows-[auto_auto_1fr] gap-x-5 gap-y-5 overflow-hidden px-10 py-8">
       <header className="col-span-6 flex flex-col gap-1.5">
-        <p className="typo-caption text-primary">테스트 설계</p>
+        <p className="typo-caption text-primary">시나리오</p>
         <h1 className="typo-title-heading text-text-1">시나리오 관리</h1>
         <p className="typo-body1-normal text-text-3 max-w-2xl">
-          기능 단위로 테스트 시나리오를 검토하고 상태를 정리합니다. 기능을 선택하면 상세 시나리오
-          목록으로 이동합니다.
+          기능별 시나리오와 상태를 확인하고 테스트 스위트로 넘길 항목을 정리합니다.
         </p>
       </header>
 
@@ -136,7 +135,7 @@ export const ScenarioFeaturesView = () => {
             disabled={!projectId}
           >
             <Sparkles className="h-4 w-4" />
-            <span className="leading-none">AI 요구사항 분석</span>
+            <span className="leading-none">요구사항 정리</span>
           </ActionToolbar.Action>
           <ActionToolbar.Action
             size="small"
@@ -184,10 +183,10 @@ export const ScenarioFeaturesView = () => {
                   ) : (
                     <>
                       <h3 className="typo-h2-heading text-text-1 mt-5">
-                        첫 기능을 만들고 시나리오를 정리하세요.
+                        아직 등록된 기능이 없습니다.
                       </h3>
                       <p className="typo-body2-normal text-text-3 mt-2 max-w-xl">
-                        직접 기능을 만들거나 AI 요구사항 분석에서 기능과 시나리오를 생성할 수
+                        기능을 직접 추가하거나 정리된 요구사항에서 시나리오를 이어서 만들 수
                         있습니다.
                       </p>
                       <div className="mt-5 flex flex-wrap gap-2">
@@ -206,7 +205,7 @@ export const ScenarioFeaturesView = () => {
                           className="border-line-2 bg-bg-3 hover:bg-bg-1 typo-label-heading text-text-2 rounded-2 inline-flex h-9 items-center justify-center gap-2 border px-4 transition-colors disabled:opacity-50"
                         >
                           <Sparkles className="h-4 w-4" />
-                          AI 분석
+                          요구사항 정리
                         </button>
                       </div>
                     </>
@@ -214,17 +213,17 @@ export const ScenarioFeaturesView = () => {
                 </div>
                 <div className="border-line-2 bg-bg-1/60 flex flex-col justify-center gap-4 border-t px-6 py-8 lg:border-t-0 lg:border-l">
                   <div>
-                    <p className="typo-label-heading text-text-2">관리 기준</p>
+                    <p className="typo-label-heading text-text-2">검토할 항목</p>
                     <ul className="typo-label-normal text-text-4 mt-2 flex flex-col gap-1.5">
                       <li>기능별 시나리오 묶음</li>
                       <li>초안·검토·확정 상태</li>
-                      <li>스위트 저장 전 검토 흐름</li>
+                      <li>스위트로 묶을 대상</li>
                     </ul>
                   </div>
                   <div className="border-line-2 border-t pt-4">
-                    <p className="typo-label-heading text-text-2">다음 단계</p>
+                    <p className="typo-label-heading text-text-2">연결되는 작업</p>
                     <p className="typo-label-normal text-text-4 mt-1">
-                      기능을 선택해 시나리오를 보강한 뒤 테스트 스위트로 저장합니다.
+                      검토가 끝난 시나리오는 테스트 스위트에서 바로 사용할 수 있습니다.
                     </p>
                   </div>
                 </div>
@@ -303,7 +302,7 @@ export const ScenarioFeaturesView = () => {
 
         <aside className="hidden min-h-0 flex-col gap-4 lg:flex">
           <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
-            <h2 className="typo-body1-heading text-text-1">상태 요약</h2>
+            <h2 className="typo-body1-heading text-text-1">상태별 개수</h2>
             <div className="mt-4 flex flex-col gap-2">
               {statusTotals.map(({ status, count }) => (
                 <div key={status} className="flex items-center justify-between gap-3">
@@ -319,12 +318,12 @@ export const ScenarioFeaturesView = () => {
           </div>
 
           <div className="border-line-2 bg-bg-2 rounded-3 border p-4">
-            <h2 className="typo-body1-heading text-text-1">작업 흐름</h2>
+            <h2 className="typo-body1-heading text-text-1">검토 기준</h2>
             <ol className="mt-4 flex flex-col gap-3">
               {[
-                ['1', '기능 선택', '요구사항 단위로 시나리오를 묶습니다.'],
-                ['2', '상태 정리', '초안·검토·확정 상태를 관리합니다.'],
-                ['3', '스위트 저장', '검증할 시나리오를 실행 묶음으로 전환합니다.'],
+                ['1', '범위', '기능 안에서 검증할 행동을 확인합니다.'],
+                ['2', '상태', '초안과 검토 완료 항목을 구분합니다.'],
+                ['3', '실행', '스위트에 넣을 시나리오만 남깁니다.'],
               ].map(([step, title, desc]) => (
                 <li key={step} className="flex gap-3">
                   <span className="bg-bg-3 text-text-2 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs">
@@ -340,11 +339,11 @@ export const ScenarioFeaturesView = () => {
           </div>
 
           <div className="border-primary/20 bg-primary/5 rounded-3 border p-4">
-            <h2 className="typo-body1-heading text-text-1">다음 추천 작업</h2>
+            <h2 className="typo-body1-heading text-text-1">최근 작업</h2>
             <p className="typo-body2-normal text-text-3 mt-2">
               {latestFeature
-                ? `${latestFeature.title} 기능의 시나리오를 검토하고 확정 상태로 정리하세요.`
-                : '첫 기능을 만들고 테스트 시나리오를 추가하세요.'}
+                ? `${latestFeature.title} 기능에서 정리 중인 시나리오를 확인하세요.`
+                : '기능을 먼저 등록하면 시나리오를 추가할 수 있습니다.'}
             </p>
             {latestFeature ? (
               <Link


### PR DESCRIPTION
## 변경 내용
- 요구사항 생성 페이지 상단에 분석서, 기능 요구사항, 시나리오, 저장된 스위트 요약을 추가했습니다.
- 분석서 목록을 더 읽기 쉬운 행형 카드로 재구성하고 날짜, 언어, 생성 결과 메타를 분리했습니다.
- 우측에 작업 흐름, 언어 구성, 다음 추천 작업 패널을 추가했습니다.
- 빈 상태와 로딩 스켈레톤을 새 레이아웃에 맞게 조정했습니다.

## 검증
- pnpm --filter web build
- http://localhost:3000/projects/sample-project/requirements 200 응답 확인

## 참고
- agent-browser와 Playwright CLI가 현재 세션 PATH에서 사용할 수 없어 스크린샷 검증은 진행하지 못했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the requirements list view with a richer, icon-based layout and improved responsive presentation.
  * Added a right-side overview panel on larger screens with workflow steps, language breakdown, and next-step actions.

* **Bug Fixes**
  * Improved loading behavior to reduce hydration mismatch issues during page render.
  * Refined empty and no-results states so they show more relevant messaging and a clearer start action.

* **UI Improvements**
  * Reorganized the list into a cleaner count/sort header and scrollable results area.
  * Enhanced mobile and desktop card layouts for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->